### PR TITLE
Add ordering place holder

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,10 @@
   },
   "dependencies": {
     "@acala-network/api": "^6.0.4",
+    "@dnd-kit/core": "^6.1.0",
+    "@dnd-kit/modifiers": "^7.0.0",
+    "@dnd-kit/sortable": "^8.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@emotion/react": "^11.9.0",
     "@emotion/styled": "^11.8.1",
     "@mui/icons-material": "latest",

--- a/packages/extension-polkagate/src/popup/homeFullScreen/index.tsx
+++ b/packages/extension-polkagate/src/popup/homeFullScreen/index.tsx
@@ -3,16 +3,26 @@
 
 /* eslint-disable react/jsx-max-props-per-line */
 
+import { closestCorners, DndContext, DragEndEvent } from '@dnd-kit/core';
+import { arrayMove, SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import { Grid, useTheme } from '@mui/material';
-import React, { useContext, useMemo, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useLayoutEffect, useMemo, useState } from 'react';
+
+import { AccountWithChildren } from '@polkadot/extension-base/background/types';
 
 import { AccountContext } from '../../components';
 import { useFullscreen } from '../../hooks';
 import { FullScreenHeader } from '../governance/FullScreenHeader';
 import HeaderComponents from './components/HeaderComponents';
 import AccountItem from './partials/AccountItem';
+import DraggableAccountsList from './partials/DraggableAccountList';
 import HomeMenu from './partials/HomeMenu';
 import TotalBalancePieChart from './partials/TotalBalancePieChart';
+
+export interface AccountsOrder {
+  id: number,
+  account: AccountWithChildren
+}
 
 export default function HomePageFullScreen(): React.ReactElement {
   useFullscreen();
@@ -20,26 +30,33 @@ export default function HomePageFullScreen(): React.ReactElement {
   const { hierarchy } = useContext(AccountContext);
 
   const [hideNumbers, setHideNumbers] = useState<boolean>();
-  const [quickActionOpen, setQuickActionOpen] = useState<string | boolean>();
+  const [accountsOrder, setAccountsOrder] = useState<AccountsOrder[]>();
 
   const indexBgColor = useMemo(() => theme.palette.mode === 'light' ? '#DFDFDF' : theme.palette.background.paper, [theme.palette]);
   const contentBgColor = useMemo(() => theme.palette.mode === 'light' ? '#F1F1F1' : theme.palette.background.default, [theme.palette]);
 
-  const sortedAccount = useMemo(() =>
-    hierarchy.sort((a, b) => {
-      const x = a.name.toLowerCase();
-      const y = b.name.toLowerCase();
+  const init = useMemo(() => {
+    return hierarchy.map((_account, index) => ({
+      account: _account,
+      id: index + 1
+    }));
+  }, [hierarchy]);
 
-      if (x < y) {
-        return -1;
-      }
+  // const sortedAccount = useMemo(() =>
+  //   hierarchy.sort((a, b) => {
+  //     const x = a.name.toLowerCase();
+  //     const y = b.name.toLowerCase();
 
-      if (x > y) {
-        return 1;
-      }
+  //     if (x < y) {
+  //       return -1;
+  //     }
 
-      return 0;
-    }), [hierarchy]);
+  //     if (x > y) {
+  //       return 1;
+  //     }
+
+  //     return 0;
+  //   }), [hierarchy]);
 
   return (
     <Grid bgcolor={indexBgColor} container item justifyContent='center'>
@@ -55,15 +72,10 @@ export default function HomePageFullScreen(): React.ReactElement {
       />
       <Grid container item justifyContent='space-around' sx={{ bgcolor: contentBgColor, height: 'calc(100vh - 70px)', maxWidth: '1282px', overflow: 'scroll', py: '40px' }}>
         <Grid container direction='column' item rowGap='20px' width='fit-content'>
-          {sortedAccount.map((account, index) => (
-            <AccountItem
-              account={account}
-              hideNumbers={hideNumbers}
-              key={index}
-              quickActionOpen={quickActionOpen}
-              setQuickActionOpen={setQuickActionOpen}
-            />
-          ))}
+          <DraggableAccountsList
+            hideNumbers={hideNumbers}
+            initialAccountList={init}
+          />
         </Grid>
         <Grid container direction='column' item rowGap='20px' width='fit-content'>
           <Grid container item width='fit-content'>

--- a/packages/extension-polkagate/src/popup/homeFullScreen/partials/AccountInformation.tsx
+++ b/packages/extension-polkagate/src/popup/homeFullScreen/partials/AccountInformation.tsx
@@ -23,11 +23,11 @@ import { ACALA_GENESIS_HASH, ASSET_HUBS, IDENTITY_CHAINS, KUSAMA_GENESIS_HASH, P
 import { AccountAssets, BalancesInfo, Proxy } from '../../../util/types';
 import { amountToHuman } from '../../../util/utils';
 import AOC from '../../accountDetailsFullScreen/components/AOC';
-import FullScreenAccountMenu from './FullScreenAccountMenu';
-import ForgetAccountModal from '../../forgetAccount/ForgetAccountModal';
-import RenameModal from '../../rename/RenameModal';
 import ExportAccountModal from '../../export/ExportAccountModal';
+import ForgetAccountModal from '../../forgetAccount/ForgetAccountModal';
 import DeriveAccountModal from '../../newAccount/deriveAccount/modal/DeriveAccountModal';
+import RenameModal from '../../rename/RenameModal';
+import FullScreenAccountMenu from './FullScreenAccountMenu';
 
 interface AddressDetailsProps {
   accountAssets: AccountAssets[] | null | undefined;

--- a/packages/extension-polkagate/src/popup/homeFullScreen/partials/AccountItem.tsx
+++ b/packages/extension-polkagate/src/popup/homeFullScreen/partials/AccountItem.tsx
@@ -5,11 +5,13 @@
 
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { Backdrop, Grid, useTheme } from '@mui/material';
-import React, { useMemo, useState } from 'react';
 import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
+import { Backdrop, Grid, useTheme } from '@mui/material';
+import React, { useContext, useMemo, useState } from 'react';
+
 import { AccountWithChildren } from '@polkadot/extension-base/background/types';
 
+import { AccountContext } from '../../../components';
 import { useAccountAssets, useApi, useChain, useFormatted, useTranslation } from '../../../hooks';
 import QuickActionFullScreen from '../../../partials/QuickActionFullScreen';
 import { label } from '../../home/AccountsTree';
@@ -18,14 +20,12 @@ import AccountInformation from '../partials/AccountInformation';
 interface Props {
   account: AccountWithChildren;
   hideNumbers: boolean | undefined;
-  isChild?: boolean;
-  parentName?: string | undefined;
   quickActionOpen: string | boolean | undefined;
   setQuickActionOpen: React.Dispatch<React.SetStateAction<string | boolean | undefined>>;
   id?: number;
 }
 
-function AccountItem({ account, hideNumbers, id, isChild, parentName, quickActionOpen, setQuickActionOpen }: Props): React.ReactElement {
+function AccountItem({ account, hideNumbers, id, quickActionOpen, setQuickActionOpen }: Props): React.ReactElement {
   const api = useApi(account.address);
   const { t } = useTranslation();
   const theme = useTheme();
@@ -33,7 +33,10 @@ function AccountItem({ account, hideNumbers, id, isChild, parentName, quickActio
   const formatted = useFormatted(account.address);
   const accountAssets = useAccountAssets(account.address);
   const containerRef = React.useRef<HTMLDivElement>(null);
+  const { accounts } = useContext(AccountContext);
   const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id: id ?? 0 });
+
+  const hasParent = useMemo(() => accounts.find(({ address }) => address === account.parentAddress), [account.address, accounts]);
 
   const [assetId, setAssetId] = useState<number | undefined>();
 
@@ -41,9 +44,11 @@ function AccountItem({ account, hideNumbers, id, isChild, parentName, quickActio
     <div ref={id ? setNodeRef : null} style={{ transform: CSS.Transform.toString(transform), transition }}>
       <Grid container {...attributes} item ref={containerRef} sx={{ borderRadius: '5px', boxShadow: '2px 3px 4px 0px rgba(0, 0, 0, 0.1)', overflow: 'hidden', position: 'relative' }} width='760px'>
         <DragIndicatorIcon {...listeners} sx={{ ':active': { cursor: 'grabbing' }, color: '#D1D1D1', cursor: 'grab', fontSize: '25px', position: 'absolute', right: '5px', top: '5px' }} />
-        <Grid item sx={{ bgcolor: theme.palette.nay.main, color: 'white', fontSize: '10px', ml: 5, position: 'absolute', px: 1, width: 'fit-content' }}>
-          {label(account, parentName, t)}
-        </Grid>
+        {hasParent &&
+          <Grid item sx={{ bgcolor: theme.palette.nay.main, color: 'white', fontSize: '10px', ml: 5, position: 'absolute', px: 1, width: 'fit-content' }}>
+            {label(account, hasParent.name ?? '', t)}
+          </Grid>
+        }
         <AccountInformation
           accountAssets={accountAssets}
           address={account.address}
@@ -54,7 +59,7 @@ function AccountItem({ account, hideNumbers, id, isChild, parentName, quickActio
           chainName={chain?.name}
           formatted={formatted}
           hideNumbers={hideNumbers}
-          isChild={isChild}
+          isChild={!!hasParent}
           setAssetId={setAssetId}
         />
         <Backdrop
@@ -63,17 +68,6 @@ function AccountItem({ account, hideNumbers, id, isChild, parentName, quickActio
         />
         <QuickActionFullScreen address={account.address} containerRef={containerRef} quickActionOpen={quickActionOpen} setQuickActionOpen={setQuickActionOpen} />
       </Grid>
-      {account?.children?.map((child, index) => (
-        <AccountItem
-          account={child}
-          hideNumbers={hideNumbers}
-          isChild
-          key={index}
-          parentName={account.name}
-          quickActionOpen={quickActionOpen}
-          setQuickActionOpen={setQuickActionOpen}
-        />
-      ))}
     </div>
   );
 }

--- a/packages/extension-polkagate/src/popup/homeFullScreen/partials/AccountItem.tsx
+++ b/packages/extension-polkagate/src/popup/homeFullScreen/partials/AccountItem.tsx
@@ -3,15 +3,17 @@
 
 /* eslint-disable react/jsx-max-props-per-line */
 
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 import { Backdrop, Grid, useTheme } from '@mui/material';
 import React, { useMemo, useState } from 'react';
-
+import DragIndicatorIcon from '@mui/icons-material/DragIndicator';
 import { AccountWithChildren } from '@polkadot/extension-base/background/types';
 
 import { useAccountAssets, useApi, useChain, useFormatted, useTranslation } from '../../../hooks';
 import QuickActionFullScreen from '../../../partials/QuickActionFullScreen';
-import AccountInformation from '../partials/AccountInformation';
 import { label } from '../../home/AccountsTree';
+import AccountInformation from '../partials/AccountInformation';
 
 interface Props {
   account: AccountWithChildren;
@@ -20,9 +22,10 @@ interface Props {
   parentName?: string | undefined;
   quickActionOpen: string | boolean | undefined;
   setQuickActionOpen: React.Dispatch<React.SetStateAction<string | boolean | undefined>>;
+  id?: number;
 }
 
-function AccountItem({ account, hideNumbers, isChild, parentName, quickActionOpen, setQuickActionOpen }: Props): React.ReactElement {
+function AccountItem({ account, hideNumbers, id, isChild, parentName, quickActionOpen, setQuickActionOpen }: Props): React.ReactElement {
   const api = useApi(account.address);
   const { t } = useTranslation();
   const theme = useTheme();
@@ -30,12 +33,14 @@ function AccountItem({ account, hideNumbers, isChild, parentName, quickActionOpe
   const formatted = useFormatted(account.address);
   const accountAssets = useAccountAssets(account.address);
   const containerRef = React.useRef<HTMLDivElement>(null);
+  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id: id ?? 0 });
 
   const [assetId, setAssetId] = useState<number | undefined>();
 
   return (
-    <>
-      <Grid container item ref={containerRef} sx={{ borderRadius: '5px', boxShadow: '2px 3px 4px 0px rgba(0, 0, 0, 0.1)', overflow: 'hidden', position: 'relative' }} width='760px'>
+    <div ref={id ? setNodeRef : null} style={{ transform: CSS.Transform.toString(transform), transition }}>
+      <Grid container {...attributes} item ref={containerRef} sx={{ borderRadius: '5px', boxShadow: '2px 3px 4px 0px rgba(0, 0, 0, 0.1)', overflow: 'hidden', position: 'relative' }} width='760px'>
+        <DragIndicatorIcon {...listeners} sx={{ ':active': { cursor: 'grabbing' }, color: '#D1D1D1', cursor: 'grab', fontSize: '25px', position: 'absolute', right: '5px', top: '5px' }} />
         <Grid item sx={{ bgcolor: theme.palette.nay.main, color: 'white', fontSize: '10px', ml: 5, position: 'absolute', px: 1, width: 'fit-content' }}>
           {label(account, parentName, t)}
         </Grid>
@@ -69,7 +74,7 @@ function AccountItem({ account, hideNumbers, isChild, parentName, quickActionOpe
           setQuickActionOpen={setQuickActionOpen}
         />
       ))}
-    </>
+    </div>
   );
 }
 

--- a/packages/extension-polkagate/src/popup/homeFullScreen/partials/DraggableAccountList.tsx
+++ b/packages/extension-polkagate/src/popup/homeFullScreen/partials/DraggableAccountList.tsx
@@ -1,0 +1,54 @@
+// Copyright 2019-2024 @polkadot/extension-ui authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+/* eslint-disable react/jsx-max-props-per-line */
+
+import { closestCenter, DndContext, DragEndEvent } from '@dnd-kit/core';
+import { restrictToParentElement } from '@dnd-kit/modifiers';
+import { arrayMove, SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
+import React, { useCallback, useState } from 'react';
+
+import { AccountsOrder } from '..';
+import AccountItem from './AccountItem';
+
+interface Props {
+  initialAccountList: AccountsOrder[];
+  hideNumbers: boolean | undefined;
+}
+
+export default function DraggableAccountList ({ hideNumbers, initialAccountList }: Props) {
+  const [accountsOrder, setAccountsOrder] = useState<AccountsOrder[]>(initialAccountList);
+  const [quickActionOpen, setQuickActionOpen] = useState<string | boolean>();
+
+  const getItemPos = useCallback((_id) => accountsOrder?.findIndex(({ id }) => _id === id), [accountsOrder]);
+
+  const handleDrag = useCallback((event: DragEndEvent) => {
+    const { active, over } = event;
+
+    if (active.id === over?.id) {
+      return;
+    }
+
+    const orgPos = getItemPos(active.id);
+    const newPos = getItemPos(over?.id);
+
+    setAccountsOrder(arrayMove(accountsOrder, orgPos, newPos));
+  }, [accountsOrder, getItemPos]);
+
+  return (
+    <DndContext collisionDetection={closestCenter} modifiers={[restrictToParentElement]} onDragEnd={handleDrag}>
+      <SortableContext items={accountsOrder} strategy={verticalListSortingStrategy}>
+        {accountsOrder.map(({ account, id }) => (
+          <AccountItem
+            account={account}
+            hideNumbers={hideNumbers}
+            id={id}
+            key={id}
+            quickActionOpen={quickActionOpen}
+            setQuickActionOpen={setQuickActionOpen}
+          />
+        ))}
+      </SortableContext>
+    </DndContext>
+  );
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2190,6 +2190,68 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@dnd-kit/accessibility@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "@dnd-kit/accessibility@npm:3.1.0"
+  dependencies:
+    tslib: ^2.0.0
+  peerDependencies:
+    react: ">=16.8.0"
+  checksum: fcb88c961e2f4c226ab575bc4a13712419884bb0f60761befcaa23bcb6c9939dc2cac6633416f2a07baee9a8830350c6df444039332408cdaaf27cad17c6b64b
+  languageName: node
+  linkType: hard
+
+"@dnd-kit/core@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "@dnd-kit/core@npm:6.1.0"
+  dependencies:
+    "@dnd-kit/accessibility": ^3.1.0
+    "@dnd-kit/utilities": ^3.2.2
+    tslib: ^2.0.0
+  peerDependencies:
+    react: ">=16.8.0"
+    react-dom: ">=16.8.0"
+  checksum: 3b8f46d2f4d2723abad4721c7bc4d1df2c4f6f26ce54673243666212cfa6f34f33e3255b53144a847da469dc736c966c19e4c45330f967ce8c01f8f878ec7f5b
+  languageName: node
+  linkType: hard
+
+"@dnd-kit/modifiers@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "@dnd-kit/modifiers@npm:7.0.0"
+  dependencies:
+    "@dnd-kit/utilities": ^3.2.2
+    tslib: ^2.0.0
+  peerDependencies:
+    "@dnd-kit/core": ^6.1.0
+    react: ">=16.8.0"
+  checksum: 176f76a552a2692a205f7fe647c836aa7ded7f0fdc3370407f3633c153139fe838cb85e59cbc3b156377cc8fe3fb7b72af15b97ed3de15cec904eae35f0c36e6
+  languageName: node
+  linkType: hard
+
+"@dnd-kit/sortable@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "@dnd-kit/sortable@npm:8.0.0"
+  dependencies:
+    "@dnd-kit/utilities": ^3.2.2
+    tslib: ^2.0.0
+  peerDependencies:
+    "@dnd-kit/core": ^6.1.0
+    react: ">=16.8.0"
+  checksum: 26589fd23c18d930a949489b232a7345c0bee4abb6be91d3673232bc79085f13cb5d82087c2068edbc51cbdd3d47c2fe386bada92dc7f2d0dcde13d6be379daa
+  languageName: node
+  linkType: hard
+
+"@dnd-kit/utilities@npm:^3.2.2":
+  version: 3.2.2
+  resolution: "@dnd-kit/utilities@npm:3.2.2"
+  dependencies:
+    tslib: ^2.0.0
+  peerDependencies:
+    react: ">=16.8.0"
+  checksum: 8a5015c2faa52760ab82a64287b2ac6a3d798867a1bca5ccbc1178560dbd9a1f9f1a21faea80f590ba1a4277c3eb7e7c4d3b4a39f1f32171bf6bc8174b370547
+  languageName: node
+  linkType: hard
+
 "@docknetwork/node-types@npm:0.16.0":
   version: 0.16.0
   resolution: "@docknetwork/node-types@npm:0.16.0"
@@ -19576,6 +19638,10 @@ resolve@^2.0.0-next.3:
   dependencies:
     "@acala-network/api": ^6.0.4
     "@babel/core": ^7.18.2
+    "@dnd-kit/core": ^6.1.0
+    "@dnd-kit/modifiers": ^7.0.0
+    "@dnd-kit/sortable": ^8.0.0
+    "@dnd-kit/utilities": ^3.2.2
     "@emotion/react": ^11.9.0
     "@emotion/styled": ^11.8.1
     "@mui/icons-material": latest
@@ -21288,6 +21354,13 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
+"tslib@npm:^2.0.0, tslib@npm:^2.6.2":
+  version: 2.6.2
+  resolution: "tslib@npm:2.6.2"
+  checksum: 329ea56123005922f39642318e3d1f0f8265d1e7fcb92c633e0809521da75eeaca28d2cf96d7248229deb40e5c19adf408259f4b9640afd20d13aecc1430f3ad
+  languageName: node
+  linkType: hard
+
 "tslib@npm:^2.0.3, tslib@npm:^2.1.0, tslib@npm:^2.2.0":
   version: 2.3.1
   resolution: "tslib@npm:2.3.1"
@@ -21299,13 +21372,6 @@ resolve@^2.0.0-next.3:
   version: 2.5.3
   resolution: "tslib@npm:2.5.3"
   checksum: 88902b309afaf83259131c1e13da1dceb0ad1682a213143a1346a649143924d78cf3760c448b84d796938fd76127183894f8d85cbb3bf9c4fddbfcc140c0003c
-  languageName: node
-  linkType: hard
-
-"tslib@npm:^2.6.2":
-  version: 2.6.2
-  resolution: "tslib@npm:2.6.2"
-  checksum: 329ea56123005922f39642318e3d1f0f8265d1e7fcb92c633e0809521da75eeaca28d2cf96d7248229deb40e5c19adf408259f4b9640afd20d13aecc1430f3ad
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Works Done

1. Displaying derived accounts changed.
2. Accounts order changes with key `addressOrder` in chrome local storage.
3. You can change the order of the account using a handle.

Close: #941