### PR TITLE
History modal now displays transaction histories on more networks 

### DIFF
--- a/packages/extension-polkagate/src/popup/history/index.tsx
+++ b/packages/extension-polkagate/src/popup/history/index.tsx
@@ -50,8 +50,8 @@ export default function TransactionHistory(): React.ReactElement<''> {
   const chainName = useChainName(address);
   const decimal = useDecimal(formatted);
   const token = useToken(formatted);
+
   const [tabIndex, setTabIndex] = useState<number>(state?.tabIndex ?? 1);
-  const [isRefreshing, setRefresh] = useState<boolean>(false);
   const [fetchedHistoriesFromSubscan, setFetchedHistoriesFromSubscan] = React.useState<TransactionDetail[] | []>([]);
   const [tabHistory, setTabHistory] = useState<TransactionDetail[] | null>([]);
   const [localHistories, setLocalHistories] = useState<TransactionDetail[]>([]);
@@ -66,15 +66,19 @@ export default function TransactionHistory(): React.ReactElement<''> {
 
   receivingTransfers.current = transfersTx;
 
-  const grouped = useMemo((): Record<string, TransactionDetail[]> | undefined => {
+  const grouped = useMemo((): Record<string, TransactionDetail[]> | null | undefined => {
     if (!tabHistory) {
       return undefined;
+    }
+
+    if (tabHistory.length === 0) {
+      return null;
     }
 
     const temp = {};
     const options = { day: 'numeric', month: 'short', year: 'numeric' };
 
-    tabHistory?.forEach((h) => {
+    tabHistory.forEach((h) => {
       const day = new Date(h.date).toLocaleDateString(undefined, options);
 
       if (!temp[day]) {
@@ -104,6 +108,7 @@ export default function TransactionHistory(): React.ReactElement<''> {
         from: { address: tx.from, name: tx.from_account_display?.display },
         success: tx.success,
         to: { address: tx.to, name: tx.to_account_display?.display },
+        token: tx.asset_symbol,
         txHash: tx.hash
       });
     });
@@ -128,8 +133,11 @@ export default function TransactionHistory(): React.ReactElement<''> {
   }, [formatted, transfersTx]);
 
   useEffect(() => {
-    const filteredLocalHistories = localHistories?.filter((h1) => !fetchedHistoriesFromSubscan.find((h2) => h1.txHash === h2.txHash));
+    if (!localHistories && !fetchedHistoriesFromSubscan) {
+      return;
+    }
 
+    const filteredLocalHistories = localHistories?.filter((h1) => !fetchedHistoriesFromSubscan?.find((h2) => h1.txHash === h2.txHash));
     let history = filteredLocalHistories.concat(fetchedHistoriesFromSubscan);
 
     history = history.sort((a, b) => b.date - a.date);
@@ -146,18 +154,13 @@ export default function TransactionHistory(): React.ReactElement<''> {
     }
 
     setTabHistory(history);
-    setRefresh(false);
   }, [tabIndex, fetchedHistoriesFromSubscan, localHistories]);
-
-  const onRefresh = useCallback(() => {
-    setRefresh(true);
-  }, []);
 
   useEffect(() => {
     formatted && getHistoryFromStorage(String(formatted)).then((h) => {
       setLocalHistories(h || []);
     }).catch(console.error);
-  }, [formatted, chainName, isRefreshing]);
+  }, [formatted, chainName]);
 
   const getTransfers = useCallback(async (outerState: RecordTabStatus): Promise<void> => {
     const { pageNum, transactions } = outerState;
@@ -167,7 +170,7 @@ export default function TransactionHistory(): React.ReactElement<''> {
       pageNum
     });
 
-    const res = await getTxTransfers(chainName, String(formatted), pageNum, SINGLE_PAGE_SIZE);
+    const res = await getTxTransfers(chainName ?? '', String(formatted), pageNum, SINGLE_PAGE_SIZE);
 
     const { count, transfers } = res.data || {};
     const nextPageNum = pageNum + 1;
@@ -223,7 +226,6 @@ export default function TransactionHistory(): React.ReactElement<''> {
   return (
     <>
       <HeaderBrand
-        isRefreshing={isRefreshing}
         onBackClick={_onBack}
         // onRefresh={grouped && onRefresh}
         showBackArrow
@@ -262,10 +264,10 @@ export default function TransactionHistory(): React.ReactElement<''> {
             }}
             value={2}
           />
-          {STAKING_CHAINS.includes(chain?.genesisHash) &&
+          {STAKING_CHAINS.includes(chain?.genesisHash ?? '') &&
             <Tab disabled icon={<Divider orientation='vertical' sx={{ backgroundColor: 'text.primary', height: '19px', mx: '5px', my: 'auto' }} />} label='' sx={{ minWidth: '1px', p: '0', width: '1px' }} value={5} />
           }
-          {STAKING_CHAINS.includes(chain?.genesisHash) &&
+          {STAKING_CHAINS.includes(chain?.genesisHash ?? '') &&
             <Tab
               label={t<string>('Staking')}
               sx={{
@@ -285,46 +287,44 @@ export default function TransactionHistory(): React.ReactElement<''> {
         </Tabs>
       </Box>
       <Grid container item sx={{ gap: '5px', height: '70%', maxHeight: window.innerHeight - 145, overflowY: 'auto', px: '15px' }} xs={12}>
-        {Object.keys(grouped).length !== 0
-          ? <>
-            {Object.entries(grouped)?.map((group) => {
-              const [date, info] = group;
+        {grouped && Object.keys(grouped).length > 0 &&
+          Object.entries(grouped)?.map((group) => {
+            const [date, info] = group;
 
-              return info.map((h, index) => (
-                <HistoryItem
-                  anotherDay={index === 0}
-                  chainName={chainName}
-                  date={date}
-                  decimal={decimal}
-                  formatted={formatted}
-                  info={h}
-                  key={index}
-                  path={pathname}
-                  token={token}
-                />
-              ));
-            })}
-            {tabHistory === null &&
-              <Grid item mt='50px' textAlign='center'>
-                {t('Nothing to show')}
-              </Grid>
-            }
-            <Grid container justifyContent='center'>
-              {
-                // staking transaction history is saved locally
-                tabIndex !== TAB_MAP.STAKING &&
-                ((transfersTx?.hasMore)
-                  ? 'loading...'
-                  : !!tabHistory?.length &&
-                  <Box fontSize={11}>
-                    {t('No more transactions to load')}
-                  </Box>
-                )
-              }
-            </Grid>
-          </>
-          : <Progress pt='150px' size={50} title={t('Loading history')} />
+            return info.map((h, index) => (
+              <HistoryItem
+                anotherDay={index === 0}
+                chainName={chainName}
+                date={date}
+                decimal={decimal}
+                formatted={formatted ?? ''}
+                info={h}
+                key={index}
+                path={undefined}
+                token={h.token ?? token}
+              />
+            ));
+          })}
+        {grouped === null && transfersTx.isFetching === false &&
+          <Grid item mt='50px' mx='auto' textAlign='center'>
+            {t('Nothing to show')}
+          </Grid>
         }
+        {(grouped === undefined || (transfersTx.isFetching && tabHistory?.length === 0)) && <Progress pt='150px' size={50} title={t('Loading history')} />}
+        {grouped &&
+          <Grid container justifyContent='center'>
+            {
+              // staking transaction history is saved locally
+              tabIndex !== TAB_MAP.STAKING &&
+              ((transfersTx?.hasMore)
+                ? 'loading...'
+                : !!tabHistory?.length &&
+                <Box fontSize={11}>
+                  {t('No more transactions to load')}
+                </Box>
+              )
+            }
+          </Grid>}
         <div id='observerObj' />
       </Grid>
     </>

--- a/packages/extension-polkagate/src/popup/history/modal/HistoryModal.tsx
+++ b/packages/extension-polkagate/src/popup/history/modal/HistoryModal.tsx
@@ -8,12 +8,12 @@ import { Box, Divider, Grid, Tab, Tabs, Typography, useTheme } from '@mui/materi
 import React, { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react';
 
 import { Progress } from '../../../components';
+import { DraggableModal } from '../../../fullscreen/governance/components/DraggableModal';
 import { useChain, useChainName, useDecimal, useFormatted, useToken, useTranslation } from '../../../hooks';
 import { getTxTransfers } from '../../../util/api/getTransfers';
 import { STAKING_ACTIONS, STAKING_CHAINS } from '../../../util/constants';
 import { TransactionDetail, Transfers } from '../../../util/types';
 import { getHistoryFromStorage } from '../../../util/utils';
-import { DraggableModal } from '../../../fullscreen/governance/components/DraggableModal';
 import HistoryDetailModal from './HistoryDetailModal';
 import HistoryItemModal from './HistoryItemModal';
 
@@ -55,10 +55,9 @@ export default function HistoryModal ({ address, setDisplayPopup }: Props): Reac
   const theme = useTheme();
 
   const [tabIndex, setTabIndex] = useState<number>(1);
-  const [isRefreshing, setRefresh] = useState<boolean>(false);
-  const [fetchedHistoriesFromSubscan, setFetchedHistoriesFromSubscan] = React.useState<TransactionDetail[] | []>([]);
-  const [tabHistory, setTabHistory] = useState<TransactionDetail[] | null>([]);
-  const [localHistories, setLocalHistories] = useState<TransactionDetail[]>([]);
+  const [fetchedHistoriesFromSubscan, setFetchedHistoriesFromSubscan] = React.useState<TransactionDetail[] | null | undefined>();
+  const [tabHistory, setTabHistory] = useState<TransactionDetail[] | null | undefined>();
+  const [localHistories, setLocalHistories] = useState<TransactionDetail[] | undefined>();
   const [detailInfo, setDetailInfo] = useState<TransactionDetail>();
   const [showDetail, setShowDetail] = useState<boolean>(false);
 
@@ -72,15 +71,19 @@ export default function HistoryModal ({ address, setDisplayPopup }: Props): Reac
 
   receivingTransfers.current = transfersTx;
 
-  const grouped = useMemo((): Record<string, TransactionDetail[]> | undefined => {
+  const grouped = useMemo((): Record<string, TransactionDetail[]> | null | undefined => {
     if (!tabHistory) {
       return undefined;
+    }
+
+    if (tabHistory.length === 0) {
+      return null;
     }
 
     const temp = {};
     const options = { day: 'numeric', month: 'short', year: 'numeric' };
 
-    tabHistory?.forEach((h) => {
+    tabHistory.forEach((h) => {
       const day = new Date(h.date).toLocaleDateString(undefined, options);
 
       if (!temp[day]) {
@@ -134,36 +137,35 @@ export default function HistoryModal ({ address, setDisplayPopup }: Props): Reac
   }, [formatted, transfersTx]);
 
   useEffect(() => {
-    const filteredLocalHistories = localHistories?.filter((h1) => !fetchedHistoriesFromSubscan.find((h2) => h1.txHash === h2.txHash));
+    if (!localHistories && !fetchedHistoriesFromSubscan) {
+      return;
+    }
 
-    let history = filteredLocalHistories.concat(fetchedHistoriesFromSubscan);
+    const filteredLocalHistories = localHistories?.filter((h1) => !fetchedHistoriesFromSubscan?.find((h2) => h1.txHash === h2.txHash));
 
-    history = history.sort((a, b) => b.date - a.date);
+    let history = filteredLocalHistories?.concat(fetchedHistoriesFromSubscan ?? []);
+
+    history = history?.sort((a, b) => b.date - a.date);
 
     switch (tabIndex) {
       case (TAB_MAP.TRANSFERS):
-        history = history.filter((h) => ['send', 'receive'].includes(h.action.toLowerCase()));
+        history = history?.filter((h) => ['send', 'receive'].includes(h.action.toLowerCase()));
         break;
       case (TAB_MAP.STAKING):
-        history = history.filter((h) => STAKING_ACTIONS.includes(h.action));
+        history = history?.filter((h) => STAKING_ACTIONS.includes(h.action));
         break;
       default:
         break;
     }
 
     setTabHistory(history);
-    setRefresh(false);
   }, [tabIndex, fetchedHistoriesFromSubscan, localHistories]);
-
-  const onRefresh = useCallback(() => {
-    setRefresh(true);
-  }, []);
 
   useEffect(() => {
     formatted && getHistoryFromStorage(String(formatted)).then((h) => {
       setLocalHistories(h || []);
     }).catch(console.error);
-  }, [formatted, chainName, isRefreshing]);
+  }, [formatted, chainName]);
 
   const getTransfers = useCallback(async (outerState: RecordTabStatus): Promise<void> => {
     const { pageNum, transactions } = outerState;
@@ -173,7 +175,7 @@ export default function HistoryModal ({ address, setDisplayPopup }: Props): Reac
       pageNum
     });
 
-    const res = await getTxTransfers(chainName, String(formatted), pageNum, SINGLE_PAGE_SIZE);
+    const res = await getTxTransfers(chainName ?? '', String(formatted), pageNum, SINGLE_PAGE_SIZE);
 
     const { count, transfers } = res.data || {};
     const nextPageNum = pageNum + 1;
@@ -239,7 +241,6 @@ export default function HistoryModal ({ address, setDisplayPopup }: Props): Reac
         </Grid>
         {!showDetail &&
           <>
-
             <Box sx={{ borderBottom: 1, borderColor: 'secondary.light' }}>
               <Tabs centered onChange={handleTabChange} sx={{ 'span.MuiTabs-indicator': { bgcolor: 'secondary.light', height: '4px' } }} value={tabIndex}>
                 <Tab
@@ -257,7 +258,12 @@ export default function HistoryModal ({ address, setDisplayPopup }: Props): Reac
                   }}
                   value={1}
                 />
-                <Tab disabled icon={<Divider orientation='vertical' sx={{ backgroundColor: 'text.primary', height: '19px', mx: '5px', my: 'auto' }} />} label='' sx={{ minWidth: '1px', p: '0', width: '1px' }} value={4} />
+                <Tab
+                  disabled
+                  icon={<Divider orientation='vertical' sx={{ backgroundColor: 'text.primary', height: '19px', mx: '5px', my: 'auto' }} />}
+                  sx={{ minWidth: '1px', p: '0', width: '1px' }}
+                  value={4}
+                />
                 <Tab
                   label={t<string>('Transfers')}
                   sx={{
@@ -273,10 +279,15 @@ export default function HistoryModal ({ address, setDisplayPopup }: Props): Reac
                   }}
                   value={2}
                 />
-                {STAKING_CHAINS.includes(chain?.genesisHash) &&
-                  <Tab disabled icon={<Divider orientation='vertical' sx={{ backgroundColor: 'text.primary', height: '19px', mx: '5px', my: 'auto' }} />} label='' sx={{ minWidth: '1px', p: '0', width: '1px' }} value={5} />
+                {STAKING_CHAINS.includes(chain?.genesisHash ?? '') &&
+                  <Tab
+                    disabled
+                    icon={<Divider orientation='vertical' sx={{ backgroundColor: 'text.primary', height: '19px', mx: '5px', my: 'auto' }} />}
+                    sx={{ minWidth: '1px', p: '0', width: '1px' }}
+                    value={5}
+                  />
                 }
-                {STAKING_CHAINS.includes(chain?.genesisHash) &&
+                {STAKING_CHAINS.includes(chain?.genesisHash ?? '') &&
                   <Tab
                     label={t<string>('Staking')}
                     sx={{
@@ -296,48 +307,45 @@ export default function HistoryModal ({ address, setDisplayPopup }: Props): Reac
               </Tabs>
             </Box>
             <Grid container item sx={{ gap: '5px', height: '70%', maxHeight: 650 - 145, overflowY: 'auto', px: '15px' }} xs={12}>
-              {Object.keys(grouped).length !== 0
-                ? <>
-                  {Object.entries(grouped)?.map((group) => {
-                    const [date, info] = group;
+              {grouped && Object.keys(grouped).length > 0 &&
+                Object.entries(grouped)?.map((group) => {
+                  const [date, info] = group;
 
-                    return info.map((h, index) => (
-                      <HistoryItemModal
-                        anotherDay={index === 0}
-                        chainName={chainName}
-                        date={date}
-                        decimal={decimal}
-                        formatted={formatted}
-                        info={h}
-                        key={index}
-                        path={undefined}
-                        setDetailInfo={setDetailInfo}
-                        setShowDetail={setShowDetail}
-                        token={token}
-                      />
-                    ));
-                  })}
-                  {tabHistory === null &&
-                    <Grid item mt='50px' textAlign='center'>
-                      {t('Nothing to show')}
-                    </Grid>
-                  }
-                  <Grid container justifyContent='center'>
-                    {
-                      // staking transaction history is saved locally
-                      tabIndex !== TAB_MAP.STAKING &&
-                      ((transfersTx?.hasMore)
-                        ? 'loading...'
-                        : !!tabHistory?.length &&
-                        <Box fontSize={11}>
-                          {t('No more transactions to load')}
-                        </Box>
-                      )
-                    }
-                  </Grid>
-                </>
-                : <Progress pt='150px' size={50} title={t('Loading history')} />
+                  return info.map((h, index) => (
+                    <HistoryItemModal
+                      anotherDay={index === 0}
+                      date={date}
+                      decimal={decimal}
+                      formatted={formatted ?? ''}
+                      info={h}
+                      key={index}
+                      path={undefined}
+                      setDetailInfo={setDetailInfo}
+                      setShowDetail={setShowDetail}
+                      token={token}
+                    />
+                  ));
+                })}
+              {grouped === null &&
+                <Grid item mt='50px' mx='auto' textAlign='center'>
+                  {t('Nothing to show')}
+                </Grid>
               }
+              {grouped === undefined && <Progress pt='150px' size={50} title={t('Loading history')} />}
+              {grouped &&
+                <Grid container justifyContent='center'>
+                  {
+                    // staking transaction history is saved locally
+                    tabIndex !== TAB_MAP.STAKING &&
+                    ((transfersTx?.hasMore)
+                      ? 'loading...'
+                      : !!tabHistory?.length &&
+                      <Box fontSize={11}>
+                        {t('No more transactions to load')}
+                      </Box>
+                    )
+                  }
+                </Grid>}
               <div id='observerObj' />
             </Grid>
           </>

--- a/packages/extension-polkagate/src/popup/history/modal/HistoryModal.tsx
+++ b/packages/extension-polkagate/src/popup/history/modal/HistoryModal.tsx
@@ -113,6 +113,7 @@ export default function HistoryModal ({ address, setDisplayPopup }: Props): Reac
         from: { address: tx.from, name: tx.from_account_display?.display },
         success: tx.success,
         to: { address: tx.to, name: tx.to_account_display?.display },
+        token: tx.asset_symbol,
         txHash: tx.hash
       });
     });
@@ -322,16 +323,16 @@ export default function HistoryModal ({ address, setDisplayPopup }: Props): Reac
                       path={undefined}
                       setDetailInfo={setDetailInfo}
                       setShowDetail={setShowDetail}
-                      token={token}
+                      token={h.token ?? token}
                     />
                   ));
                 })}
-              {grouped === null &&
+              {grouped === null && transfersTx.isFetching === false &&
                 <Grid item mt='50px' mx='auto' textAlign='center'>
                   {t('Nothing to show')}
                 </Grid>
               }
-              {grouped === undefined && <Progress pt='150px' size={50} title={t('Loading history')} />}
+              {(grouped === undefined || (transfersTx.isFetching && tabHistory?.length === 0)) && <Progress pt='150px' size={50} title={t('Loading history')} />}
               {grouped &&
                 <Grid container justifyContent='center'>
                   {

--- a/packages/extension-polkagate/src/util/api/getTransfers.ts
+++ b/packages/extension-polkagate/src/util/api/getTransfers.ts
@@ -1,6 +1,8 @@
 // Copyright 2019-2024 @polkadot/extension-polkagate authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+/* eslint-disable sort-keys */
+
 import request from 'umi-request';
 
 import { TransferRequest } from '../types';
@@ -13,25 +15,25 @@ const nullObject = {
     count: 0,
     transfers: null
   }
-};
+} as unknown as TransferRequest;
 
 export function getTxTransfers (chainName: string, address: string, pageNum: number, pageSize: number): Promise<TransferRequest> {
   if (!chainName) {
-    return nullObject;
+    return Promise.resolve(nullObject);
   }
 
-  let network = chainName;
+  let network = chainName.toLowerCase();
 
-  if (chainName.toLowerCase() === 'pendulum') {
-    return nullObject;
+  if (network === 'pendulum') {
+    return Promise.resolve(nullObject);
   }
 
-  if (chainName === 'WestendAssetHub') {
+  if (network === 'westendassethub') {
     network = 'westmint';
   }
 
-  if (chainName.toLowerCase().includes('assethub')) {
-    network = `assethub-${chainName.toLowerCase().replace(/assethub/, '')}`;
+  if (network.includes('assethub')) {
+    network = `assethub-${network.replace(/assethub/, '')}`;
   }
 
   return postReq(`https://${network}.api.subscan.io/api/v2/scan/transfers`, {
@@ -43,6 +45,6 @@ export function getTxTransfers (chainName: string, address: string, pageNum: num
   });
 }
 
-function postReq (api: string, data: Record<string, any> = {}, option?: Record<string, any>): Promise<TransferRequest> {
+function postReq (api: string, data: Record<string, unknown> = {}, option?: Record<string, unknown>): Promise<TransferRequest> {
   return request.post(api, { data, ...option });
 }

--- a/packages/extension-polkagate/src/util/api/getTransfers.ts
+++ b/packages/extension-polkagate/src/util/api/getTransfers.ts
@@ -5,8 +5,36 @@ import request from 'umi-request';
 
 import { TransferRequest } from '../types';
 
+const nullObject = {
+  code: 0,
+  message: 'Success',
+  generated_at: Date.now(),
+  data: {
+    count: 0,
+    transfers: null
+  }
+};
+
 export function getTxTransfers (chainName: string, address: string, pageNum: number, pageSize: number): Promise<TransferRequest> {
-  return postReq(`https://${chainName}.api.subscan.io/api/v2/scan/transfers`, {
+  if (!chainName) {
+    return nullObject;
+  }
+
+  let network = chainName;
+
+  if (chainName.toLowerCase() === 'pendulum') {
+    return nullObject;
+  }
+
+  if (chainName === 'WestendAssetHub') {
+    network = 'westmint';
+  }
+
+  if (chainName.toLowerCase().includes('assethub')) {
+    network = `assethub-${chainName.toLowerCase().replace(/assethub/, '')}`;
+  }
+
+  return postReq(`https://${network}.api.subscan.io/api/v2/scan/transfers`, {
     address,
     // from_block: 8658091,
     // to_block: 8684569,

--- a/packages/extension-polkagate/src/util/types.ts
+++ b/packages/extension-polkagate/src/util/types.ts
@@ -150,6 +150,7 @@ export interface TransactionDetail extends TxResult {
   amount?: string;
   date: number;
   to?: NameAddress;
+  token?: string;
   throughProxy?: NameAddress;
 }
 


### PR DESCRIPTION
History modal now displays transaction histories on networks like asset hubs and so.

Close: #1077 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
    - Improved handling of transaction history in the extension to better manage cases where data may be `null` or `undefined`.
    - Enhanced the transaction fetching logic to support different blockchain networks more reliably.
- **Refactor**
    - Updated `getTxTransfers` function to handle different `chainName` values and set appropriate `network` value before API call.
- **New Features**
    - Added a `token` field to the `TransactionDetail` interface in `types.ts`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->