### PR TITLE
Update Leave Pool

### DIFF
--- a/packages/extension-polkagate/src/fullscreen/stake/pool/commonTasks/SetState.tsx
+++ b/packages/extension-polkagate/src/fullscreen/stake/pool/commonTasks/SetState.tsx
@@ -159,10 +159,7 @@ export default function SetState ({ address, api, chain, formatted, onClose, poo
             </Grid>
           </>}
         {step === STEPS.WAIT_SCREEN &&
-          <WaitScreen
-            defaultText={t('Checking your staking status...')}
-            showCube
-          />
+          <WaitScreen />
         }
         {txInfo && step === STEPS.CONFIRM && (
           <Confirmation

--- a/packages/extension-polkagate/src/fullscreen/stake/pool/commonTasks/editPool/index.tsx
+++ b/packages/extension-polkagate/src/fullscreen/stake/pool/commonTasks/editPool/index.tsx
@@ -102,10 +102,7 @@ export default function ManageEditPool ({ address, api, chain, onClose, pool, se
             />
           }
           {step === STEPS.WAIT_SCREEN &&
-            <WaitScreen
-              defaultText={t('Checking your staking status...')}
-              showCube
-            />
+            <WaitScreen />
           }
           {step === STEPS.CONFIRM && txInfo &&
             <Confirmation

--- a/packages/extension-polkagate/src/fullscreen/stake/pool/commonTasks/leavePool/index.tsx
+++ b/packages/extension-polkagate/src/fullscreen/stake/pool/commonTasks/leavePool/index.tsx
@@ -175,10 +175,7 @@ export default function LeavePool({ address, onClose, pool, setRefresh }: Props)
           </>
         }
         {step === STEPS.WAIT_SCREEN &&
-          <WaitScreen
-            defaultText={t('Checking your staking status...')}
-            showCube
-          />
+          <WaitScreen />
         }
         {txInfo && step === STEPS.CONFIRM && (
           <Confirmation

--- a/packages/extension-polkagate/src/fullscreen/stake/pool/commonTasks/removeAll/index.tsx
+++ b/packages/extension-polkagate/src/fullscreen/stake/pool/commonTasks/removeAll/index.tsx
@@ -308,10 +308,7 @@ export default function RemoveAll ({ address, api, chain, onClose, pool, setRefr
             step={step}
           />}
         {step === STEPS.WAIT_SCREEN &&
-          <WaitScreen
-            defaultText={t('Checking your staking status...')}
-            showCube
-          />
+          <WaitScreen />
         }
         {txInfo && step === STEPS.CONFIRM &&
           <Confirmation

--- a/packages/extension-polkagate/src/fullscreen/stake/pool/partials/Confirmation.tsx
+++ b/packages/extension-polkagate/src/fullscreen/stake/pool/partials/Confirmation.tsx
@@ -80,7 +80,7 @@ export default function Confirmation({ children, handleClose, modalHeight, txInf
           _mt='30px'
           _onClick={handleClose}
           _width={100}
-          text={t<string>('Close')}
+          text={t<string>('Done')}
         />
       </Grid>
     </Motion>

--- a/packages/extension-polkagate/src/fullscreen/stake/pool/partials/PoolCommonTasks.tsx
+++ b/packages/extension-polkagate/src/fullscreen/stake/pool/partials/PoolCommonTasks.tsx
@@ -116,7 +116,7 @@ export default function PoolCommonTasks({ address }: Props): React.ReactElement 
             disabled={!justMember || !staked || staked.isZero()}
             icon={
               <FontAwesomeIcon
-                color={poolState === 'Destroying' || !poolRoot ? theme.palette.action.disabledBackground : theme.palette.text.primary}
+                color={!justMember || !staked || staked.isZero() ? theme.palette.action.disabledBackground : theme.palette.text.primary}
                 fontSize='22px'
                 icon={faRightFromBracket}
               />


### PR DESCRIPTION
## Fixed Issues

1. leave pool menu icon is grey while it is enabled
2. in wait screen it has shown a waiting progress animation which we do not use for wait screen while submitting transactions
3. we show "Done" in confirm page, but here I see "close

Close: #1138 