### PR TITLE
Remove crowdloans from FL

### DIFF
--- a/packages/extension-polkagate/src/fullscreen/accountDetails/components/CommonTasks.tsx
+++ b/packages/extension-polkagate/src/fullscreen/accountDetails/components/CommonTasks.tsx
@@ -3,7 +3,7 @@
 
 /* eslint-disable react/jsx-max-props-per-line */
 
-import { faCoins, faHistory, faPaperPlane, faPiggyBank, faVoteYea } from '@fortawesome/free-solid-svg-icons';
+import { faCoins, faHistory, faPaperPlane, faVoteYea } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { ArrowForwardIosRounded as ArrowForwardIosRoundedIcon, Boy as BoyIcon, QrCode2 as QrCodeIcon } from '@mui/icons-material';
 import { Divider, Grid, Typography, useTheme } from '@mui/material';
@@ -13,7 +13,7 @@ import React, { useCallback, useMemo } from 'react';
 import { PoolStakingIcon } from '../../../components';
 import { useTranslation } from '../../../hooks';
 import { FetchedBalance } from '../../../hooks/useAssetsBalances';
-import { CROWDLOANS_CHAINS, GOVERNANCE_CHAINS, STAKING_CHAINS } from '../../../util/constants';
+import { GOVERNANCE_CHAINS, STAKING_CHAINS } from '../../../util/constants';
 import { popupNumbers } from '..';
 
 interface Props {
@@ -93,13 +93,12 @@ export const TaskButton = ({ disabled, icon, mr = '25px', noBorderButton = false
   );
 };
 
-export default function CommonTasks({ address, assetId, balance, genesisHash, setDisplayPopup }: Props): React.ReactElement {
+export default function CommonTasks ({ address, assetId, balance, genesisHash, setDisplayPopup }: Props): React.ReactElement {
   const { t } = useTranslation();
   const theme = useTheme();
 
   const governanceDisabled = useMemo(() => !GOVERNANCE_CHAINS.includes(genesisHash ?? ''), [genesisHash]);
   const stakingDisabled = useMemo(() => !STAKING_CHAINS.includes(genesisHash ?? ''), [genesisHash]);
-  const crowdloanDisabled = useMemo(() => !CROWDLOANS_CHAINS.includes(genesisHash ?? ''), [genesisHash]);
   const isDarkTheme = useMemo(() => theme.palette.mode === 'dark', [theme.palette.mode]);
   const stakingIconColor = useMemo(() => stakingDisabled ? theme.palette.action.disabledBackground : theme.palette.text.primary, [stakingDisabled, theme.palette.action.disabledBackground, theme.palette.text.primary]);
 
@@ -133,10 +132,6 @@ export default function CommonTasks({ address, assetId, balance, genesisHash, se
   const goToPoolStaking = useCallback(() => {
     address && !stakingDisabled && openOrFocusTab(`/poolfs/${address}/`);
   }, [address, stakingDisabled]);
-
-  const goToCrowdLoans = useCallback(() => {
-    address && genesisHash && !crowdloanDisabled && openOrFocusTab(`/crowdloans/${address}/`);
-  }, [address, crowdloanDisabled, genesisHash]);
 
   const goToHistory = useCallback(() => {
     address && genesisHash && setDisplayPopup(popupNumbers.HISTORY);
@@ -227,20 +222,6 @@ export default function CommonTasks({ address, assetId, balance, genesisHash, se
           secondaryIconType='page'
           show={hasSoloStake || hasPoolStake}
           text={t('Stake in Pool')}
-        />
-        <TaskButton
-          disabled={crowdloanDisabled}
-          icon={
-            <FontAwesomeIcon
-              color={crowdloanDisabled ? theme.palette.action.disabledBackground : theme.palette.text.primary}
-              flip='horizontal'
-              fontSize='28px'
-              icon={faPiggyBank}
-            />
-          }
-          onClick={goToCrowdLoans}
-          secondaryIconType='page'
-          text={t('Crowdloans')}
         />
         <TaskButton
           disabled={!genesisHash}

--- a/packages/extension-polkagate/src/partials/QuickActionFullScreen.tsx
+++ b/packages/extension-polkagate/src/partials/QuickActionFullScreen.tsx
@@ -18,7 +18,7 @@ import { PoolStakingIcon } from '../components';
 import { useAccount, useApi, useTranslation } from '../hooks';
 import { windowOpen } from '../messaging';
 import HistoryModal from '../popup/history/modal/HistoryModal';
-import { CROWDLOANS_CHAINS, GOVERNANCE_CHAINS, STAKING_CHAINS } from '../util/constants';
+import { GOVERNANCE_CHAINS, STAKING_CHAINS } from '../util/constants';
 
 interface Props {
   address: AccountId | string;
@@ -71,16 +71,9 @@ export default function QuickActionFullScreen ({ address, assetId, containerRef,
     });
   }, [account?.genesisHash, address, api, history]);
 
-  const goToCrowdLoans = useCallback(() => {
-    address && CROWDLOANS_CHAINS.includes(account?.genesisHash ?? '') &&
-      history.push({
-        pathname: `/crowdloans/${String(address)}`
-      });
-  }, [account?.genesisHash, address, history]);
-
   const goToGovernance = useCallback(() => {
     supportGov && windowOpen(`/governance/${address}/referenda`).catch(console.error);
-  }, [account?.genesisHash, address]);
+  }, [address, supportGov]);
 
   const goToHistory = useCallback(() => {
     setShowHistory(true);
@@ -159,15 +152,6 @@ export default function QuickActionFullScreen ({ address, assetId, containerRef,
         }
         onClick={goToSoloStaking}
         title={t('Solo Staking')}
-      />
-      <QuickActionButton
-        disabled={!CROWDLOANS_CHAINS.includes(account?.genesisHash ?? '')}
-        divider
-        icon={
-          <vaadin-icon icon='vaadin:piggy-bank-coin' style={{ height: '30px', color: `${CROWDLOANS_CHAINS.includes(account?.genesisHash) ? theme.palette.text.primary : theme.palette.action.disabledBackground}` }} />
-        }
-        onClick={goToCrowdLoans}
-        title={t('Crowdloans')}
       />
       <QuickActionButton
         disabled={!account?.genesisHash || !supportGov}

--- a/packages/extension-polkagate/src/partials/QuickActionFullScreen.tsx
+++ b/packages/extension-polkagate/src/partials/QuickActionFullScreen.tsx
@@ -10,13 +10,12 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { ArrowForwardIos as ArrowForwardIosIcon, Boy as BoyIcon } from '@mui/icons-material';
 import { Box, ClickAwayListener, Divider, Grid, IconButton, Slide, Typography, useTheme } from '@mui/material';
 import React, { useCallback, useMemo, useState } from 'react';
-import { useHistory } from 'react-router-dom';
 
 import { AccountId } from '@polkadot/types/interfaces/runtime';
 
 import { PoolStakingIcon } from '../components';
-import { useAccount, useApi, useTranslation } from '../hooks';
-import { windowOpen } from '../messaging';
+import { openOrFocusTab } from '../fullscreen/accountDetails/components/CommonTasks';
+import { useAccount, useTranslation } from '../hooks';
 import HistoryModal from '../popup/history/modal/HistoryModal';
 import { GOVERNANCE_CHAINS, STAKING_CHAINS } from '../util/constants';
 
@@ -42,9 +41,7 @@ const ACTION_ICON_SIZE = '27px';
 export default function QuickActionFullScreen ({ address, assetId, containerRef, quickActionOpen, setQuickActionOpen }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const theme = useTheme();
-  const history = useHistory();
   const account = useAccount(address);
-  const api = useApi(address);
 
   const [showHistory, setShowHistory] = useState<boolean>();
 
@@ -54,25 +51,19 @@ export default function QuickActionFullScreen ({ address, assetId, containerRef,
   const handleClose = useCallback(() => quickActionOpen === address && setQuickActionOpen(undefined), [address, quickActionOpen, setQuickActionOpen]);
 
   const goToSend = useCallback(() => {
-    address && account?.genesisHash && windowOpen(`/send/${String(address)}/${assetId || ''}`).catch(console.error);
+    address && account?.genesisHash && openOrFocusTab(`/send/${String(address)}/${assetId || ''}`);
   }, [account?.genesisHash, address, assetId]);
 
   const goToPoolStaking = useCallback(() => {
-    address && STAKING_CHAINS.includes(account?.genesisHash ?? '') && history.push({
-      pathname: `/pool/${String(address)}/`,
-      state: { api }
-    });
-  }, [account?.genesisHash, address, api, history]);
+    address && openOrFocusTab(`/poolfs/${String(address)}/`);
+  }, [address]);
 
   const goToSoloStaking = useCallback(() => {
-    address && STAKING_CHAINS.includes(account?.genesisHash ?? '') && history.push({
-      pathname: `/solo/${String(address)}/`,
-      state: { api }
-    });
-  }, [account?.genesisHash, address, api, history]);
+    address && openOrFocusTab(`/solofs/${String(address)}/`);
+  }, [address]);
 
   const goToGovernance = useCallback(() => {
-    supportGov && windowOpen(`/governance/${address}/referenda`).catch(console.error);
+    supportGov && address && openOrFocusTab(`/governance/${address}/referenda`);
   }, [address, supportGov]);
 
   const goToHistory = useCallback(() => {


### PR DESCRIPTION
## Works Done

1. Remove Crowdloan button from `QuickActionFullScreen`.
2. Remove Crowdloan button from _Most Common Tasks_ on `AccountDetails`.


Close #1124 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the common tasks component to focus on governance chains, removing crowdloan-related functionalities.
	- Refined quick actions in the full-screen interface, removing crowdloan options and enhancing governance-related functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->