### PR TITLE
add pending rewards regarding eraStakersPaged

### DIFF
--- a/packages/extension-polkagate/src/fullscreen/stake/solo/pending/index.tsx
+++ b/packages/extension-polkagate/src/fullscreen/stake/solo/pending/index.tsx
@@ -13,13 +13,14 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { DraggableModal } from '@polkadot/extension-polkagate/src/fullscreen/governance/components/DraggableModal';
 import WaitScreen from '@polkadot/extension-polkagate/src/fullscreen/governance/partials/WaitScreen';
+import { EraUnclaimedPayouts } from '@polkadot/extension-polkagate/src/hooks/usePendingRewards2';
 import blockToDate from '@polkadot/extension-polkagate/src/popup/crowdloans/partials/blockToDate';
 import { LabelBalance, ValidatorEra } from '@polkadot/extension-polkagate/src/popup/staking/solo/rewards/PendingRewards';
-import { amountToHuman } from '@polkadot/extension-polkagate/src/util/utils';
+import { amountToHuman, toBN } from '@polkadot/extension-polkagate/src/util/utils';
 import { BN, BN_ONE, BN_ZERO } from '@polkadot/util';
 
 import { Checkbox2, Identity, ShowBalance, TwoButtons } from '../../../../components';
-import { useCurrentBlockNumber, useInfo, usePendingRewards, useTranslation } from '../../../../hooks';
+import { useCurrentBlockNumber, useInfo, usePendingRewards2, useTranslation } from '../../../../hooks';
 import { Inputs } from '../../Entry';
 import Confirmation from '../../partials/Confirmation';
 import Review from '../../partials/Review';
@@ -41,16 +42,23 @@ export const STEPS = {
   PROXY: 100
 };
 
+export interface ExpandedRewards {
+  eraIndex: number;
+  validator: string;
+  page: number;
+  value: BN;
+}
+
 export default function Pending({ address, setRefresh, setShow, show }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const theme = useTheme();
 
   const { api, chain, decimal, token } = useInfo(address);
-  const rewards = usePendingRewards(address);
   const currentBlock = useCurrentBlockNumber(address);
+  const rewards = usePendingRewards2(address);
 
-  const [selectedToPayout, setSelectedToPayout] = useState<ValidatorEra[]>([]);
-  const [erasHistoric, setErasHistoric] = useState<number>();
+  const [expandedRewards, setExpandedRewards] = useState<ExpandedRewards[] | undefined>(undefined);
+  const [selectedToPayout, setSelectedToPayout] = useState<ExpandedRewards[]>([]);
   const [progress, setProgress] = useState<DeriveSessionProgress>();
   const [forcing, setForcing] = useState<Forcing>();
   const [historyDepth, setHistoryDepth] = useState<BN>();
@@ -63,7 +71,6 @@ export default function Pending({ address, setRefresh, setShow, show }: Props): 
       return;
     }
 
-    api.derive.staking.erasHistoric().then((res) => setErasHistoric(res.length)).catch(console.error);
     api.derive.session.progress().then(setProgress).catch(console.error);
     api.query.staking.forceEra().then(setForcing).catch(console.error);
 
@@ -72,27 +79,54 @@ export default function Pending({ address, setRefresh, setShow, show }: Props): 
       : setHistoryDepth(api.consts.staking.historyDepth);
   }, [api]);
 
+  useEffect(() => {
+    if (!rewards) {
+      return;
+    }
+
+    const rewardsArray: [string, string, number, BN][] = Object.entries(rewards || {}).reduce<[string, string, number, BN][]>(
+      (acc, [era, eraRewards]) => {
+        const eraRewardsArray = Object.entries(eraRewards || {}).reduce<[string, string, number, BN][]>(
+          (eraAcc, [validator, [page, amount]]) => {
+            eraAcc.push([era, validator, page, amount]);
+
+            return eraAcc;
+          },
+          []
+        );
+
+        return acc.concat(eraRewardsArray);
+      },
+      []
+    );
+
+    setExpandedRewards(rewardsArray);
+  }, [rewards]);
+
   const totalPending = useMemo(() => {
     if (!rewards) {
       return BN_ZERO;
     }
 
-    return rewards.reduce((sum, { validators }) => {
-      Object.values(validators).forEach(({ value }) => {
-        sum = sum.add(value);
-      });
+    const validatorRewards = Object.values(rewards || {});
+    const pageRewards = validatorRewards.map((item) => Object.values(item || {})).flat();
+
+    const total = pageRewards.reduce((sum: BN, [_, value]: [number, BN]) => {
+      sum = sum.add(value);
 
       return sum;
     }, BN_ZERO);
+
+    return total;
   }, [rewards]);
 
   const totalSelectedPending = useMemo(() => {
-    if (!selectedToPayout) {
+    if (!selectedToPayout?.length) {
       return BN_ZERO;
     }
 
-    return selectedToPayout.reduce((sum, sel) => {
-      sum = sum.add(sel[2]);
+    return selectedToPayout.reduce((sum: BN, value: ExpandedRewards) => {
+      sum = sum.add(value[3] as BN);
 
       return sum;
     }, BN_ZERO);
@@ -103,7 +137,7 @@ export default function Pending({ address, setRefresh, setShow, show }: Props): 
       return;
     }
 
-    const payoutStakers = api.tx.staking.payoutStakers;
+    const payoutStakers = api.tx.staking.payoutStakersByPage;
     const batch = api.tx.utility.batchAll;
 
     const call = selectedToPayout.length === 1
@@ -112,8 +146,8 @@ export default function Pending({ address, setRefresh, setShow, show }: Props): 
 
     const params =
       selectedToPayout.length === 1
-        ? [selectedToPayout[0][0], selectedToPayout[0][1]]
-        : [selectedToPayout.map((p) => payoutStakers(p[0], p[1]))];
+        ? [selectedToPayout[0][1], Number(selectedToPayout[0][0]), selectedToPayout[0][2]]
+        : [selectedToPayout.map((p) => payoutStakers(p[1], Number(p[0]), p[2]))];
 
     const amount = amountToHuman(totalSelectedPending, decimal);
 
@@ -130,8 +164,8 @@ export default function Pending({ address, setRefresh, setShow, show }: Props): 
     });
   }, [api, decimal, selectedToPayout, totalSelectedPending]);
 
-  const isIncluded = useCallback((v: ValidatorEra): boolean => {
-    const _isIncluded = !!selectedToPayout.find((s) => s.every((value, index) => value === v[index]));
+  const isIncluded = useCallback((info: ExpandedRewards): boolean => {
+    const _isIncluded = !!selectedToPayout.find((s) => s === info);
 
     return _isIncluded;
   }, [selectedToPayout]);
@@ -159,25 +193,18 @@ export default function Pending({ address, setRefresh, setShow, show }: Props): 
   }, [currentBlock, forcing, historyDepth, progress]);
 
   const onSelectAll = useCallback((_, checked: boolean) => {
-    if (checked) {
-      const _selected: ValidatorEra[] = [];
-
-      rewards?.forEach((r) => {
-        Object.keys(r.validators).forEach((v) => {
-          _selected.push([v, r.era.toNumber(), r.validators[v].value]);
-        });
-      });
-      setSelectedToPayout(_selected);
+    if (checked && expandedRewards?.length) {
+      setSelectedToPayout([...expandedRewards]);
     } else {
       setSelectedToPayout([]);
     }
-  }, [rewards]);
+  }, [expandedRewards]);
 
-  const onSelect = useCallback((validatorEra: ValidatorEra, checked: boolean) => {
+  const onSelect = useCallback((info: ExpandedRewards, checked: boolean) => {
     if (checked) {
-      setSelectedToPayout((prev) => prev.concat([validatorEra]));
+      setSelectedToPayout((prev) => prev.concat([info]));
     } else {
-      const index = selectedToPayout.findIndex((s) => s.every((value, index) => value === validatorEra[index]));
+      const index = selectedToPayout.findIndex((s: ExpandedRewards) => s === info);
 
       setSelectedToPayout((prev) => {
         const newArray = [...prev];
@@ -220,9 +247,9 @@ export default function Pending({ address, setRefresh, setShow, show }: Props): 
                 {t('Validators usually pay rewards regularly. If not received within the set period, rewards expire. You can manually initiate the payout if desired.')}
               </Typography>
               <Grid alignContent='flex-start' alignItems='center' container item sx={{ border: `1px solid ${theme.palette.primary.main}`, borderBottom: 0, borderTopLeftRadius: '5px', borderTopRightRadius: '5px', p: '5px', width: '100%' }}>
-                <Grid item textAlign='left' sx={{ fontSize: '13px' }} xs={4.75}>
+                <Grid item sx={{ fontSize: '13px' }} textAlign='left' xs={4.75}>
                   <Checkbox2
-                    checked={!!rewards?.length && selectedToPayout?.length === rewards?.length}
+                    checked={!!expandedRewards?.length && selectedToPayout?.length === expandedRewards?.length}
                     iconStyle={{ transform: 'scale(0.9)' }}
                     onChange={onSelectAll}
                     style={{ paddingRight: '5px' }}
@@ -237,37 +264,39 @@ export default function Pending({ address, setRefresh, setShow, show }: Props): 
                 </Grid>
               </Grid>
               <Grid alignContent='flex-start' container height={TABLE_HEIGHT} sx={{ border: 1, borderBottomLeftRadius: '5px', borderBottomRightRadius: '5px', borderColor: 'primary.main', overflow: 'scroll', width: '100%' }}>
-                {!rewards
+                {!expandedRewards
                   ? <Grid container justifyContent='center'>
                     {Array.from({ length: TABLE_HEIGHT / SKELETON_HEIGHT }).map((_, index) => (
                       <Skeleton animation='wave' height={SKELETON_HEIGHT} key={index} sx={{ display: 'inline-block', transform: 'none', width: '96%', my: '5px' }} />
                     ))}
                   </Grid>
-                  : !rewards.length
+                  : !expandedRewards.length
                     ? <Grid container justifyContent='center' sx={{ mt: '70px' }}>
                       <Typography>
                         {t('No pending rewards found!')}
                       </Typography>
                     </Grid>
-                    : <> {rewards?.map((info, index) => (
-                      <Grid container item key={index}>
-                        {
-                          Object.keys(info.validators).map((v, index) => (
-                            <Grid alignContent='flex-start' alignItems='center' container item key={index} sx={{ borderColor: 'primary.main', borderTop: 1, px: '5px' }}>
+                    : <> {expandedRewards?.map((info, index) => {
+                      const [eraIndex, validator, page, value] = info;
+
+                      return (
+                        <Grid container item key={index}>
+                          {
+                            <Grid alignContent='flex-start' alignItems='center' container item sx={{ borderColor: 'primary.main', borderTop: 1, px: '5px' }}>
                               <Grid container item sx={{ fontSize: '13px' }} xs={4}>
                                 <Grid item>
                                   <Checkbox2
-                                    checked={isIncluded([v, info.era.toNumber(), info.validators[v].value])}
+                                    checked={isIncluded(info)}
                                     iconStyle={{ transform: 'scale(0.8)' }}
                                     // eslint-disable-next-line react/jsx-no-bind
-                                    onChange={(_event, checked) => onSelect([v, info.era.toNumber(), info.validators[v].value], checked)}
+                                    onChange={(_event, checked) => onSelect(info, checked)}
                                     style={{ paddingRight: '10px' }}
                                   />
                                 </Grid>
                                 <Grid item>
                                   <ShowBalance
                                     api={api}
-                                    balance={info.validators[v].value}
+                                    balance={value}
                                     withCurrency={false}
                                   />
                                 </Grid>
@@ -276,7 +305,7 @@ export default function Pending({ address, setRefresh, setShow, show }: Props): 
                                 <Identity
                                   api={api}
                                   chain={chain}
-                                  formatted={v}
+                                  formatted={validator}
                                   identiconSize={20}
                                   showSocial={false}
                                   style={{
@@ -289,13 +318,13 @@ export default function Pending({ address, setRefresh, setShow, show }: Props): 
                                 />
                               </Grid>
                               <Grid item sx={{ fontSize: '13px', textAlign: 'right' }} xs={2}>
-                                {eraToDate(info.era.toNumber())}
+                                {eraToDate(Number(eraIndex))}
                               </Grid>
                             </Grid>
-                          ))
-                        }
-                      </Grid>
-                    ))}
+                          }
+                        </Grid>
+                      );
+                    })}
                     </>
                 }
               </Grid>
@@ -323,11 +352,10 @@ export default function Pending({ address, setRefresh, setShow, show }: Props): 
                     </>
                 }
               </Grid>
-
             </Grid>
             <Grid container item sx={{ '> div': { m: 0, width: '100%' }, justifyContent: 'flex-end', mt: '5px' }}>
               <TwoButtons
-                disabled={!inputs}
+                disabled={!inputs || !selectedToPayout.length}
                 mt='1px'
                 onPrimaryClick={onNext}
                 onSecondaryClick={onCancel}

--- a/packages/extension-polkagate/src/fullscreen/stake/solo/pending/index.tsx
+++ b/packages/extension-polkagate/src/fullscreen/stake/solo/pending/index.tsx
@@ -215,7 +215,7 @@ export default function Pending({ address, setRefresh, setShow, show }: Props): 
     }
   }, [selectedToPayout]);
 
-  const TABLE_HEIGHT = window.innerHeight - 600;
+  const TABLE_HEIGHT = 375;
   const SKELETON_HEIGHT = 25;
 
   const onNext = useCallback(() => {

--- a/packages/extension-polkagate/src/fullscreen/stake/solo/pending/index.tsx
+++ b/packages/extension-polkagate/src/fullscreen/stake/solo/pending/index.tsx
@@ -13,10 +13,9 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { DraggableModal } from '@polkadot/extension-polkagate/src/fullscreen/governance/components/DraggableModal';
 import WaitScreen from '@polkadot/extension-polkagate/src/fullscreen/governance/partials/WaitScreen';
-import { EraUnclaimedPayouts } from '@polkadot/extension-polkagate/src/hooks/usePendingRewards2';
 import blockToDate from '@polkadot/extension-polkagate/src/popup/crowdloans/partials/blockToDate';
-import { LabelBalance, ValidatorEra } from '@polkadot/extension-polkagate/src/popup/staking/solo/rewards/PendingRewards';
-import { amountToHuman, toBN } from '@polkadot/extension-polkagate/src/util/utils';
+import { LabelBalance } from '@polkadot/extension-polkagate/src/popup/staking/solo/rewards/PendingRewards';
+import { amountToHuman } from '@polkadot/extension-polkagate/src/util/utils';
 import { BN, BN_ONE, BN_ZERO } from '@polkadot/util';
 
 import { Checkbox2, Identity, ShowBalance, TwoButtons } from '../../../../components';
@@ -250,6 +249,7 @@ export default function Pending({ address, setRefresh, setShow, show }: Props): 
                 <Grid item sx={{ fontSize: '13px' }} textAlign='left' xs={4.75}>
                   <Checkbox2
                     checked={!!expandedRewards?.length && selectedToPayout?.length === expandedRewards?.length}
+                    // disabled={!expandedRewards?.length}
                     iconStyle={{ transform: 'scale(0.9)' }}
                     onChange={onSelectAll}
                     style={{ paddingRight: '5px' }}

--- a/packages/extension-polkagate/src/hooks/index.ts
+++ b/packages/extension-polkagate/src/hooks/index.ts
@@ -94,3 +94,5 @@ export { default as useNativeTokenPrice } from './useNativeTokenPrice';
 export { default as useActiveValidators } from './useActiveValidators';
 export { default as useEstimatedFee } from './useEstimatedFee';
 export { default as useIsExtensionPopup } from './useIsExtensionPopup';
+export { default as usePendingRewards2 } from './usePendingRewards2';
+export { default as useActiveEraIndex } from './useActiveEraIndex';

--- a/packages/extension-polkagate/src/hooks/useActiveEraIndex.ts
+++ b/packages/extension-polkagate/src/hooks/useActiveEraIndex.ts
@@ -1,0 +1,28 @@
+// Copyright 2019-2024 @polkadot/extension-polkagate authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { useEffect, useState } from 'react';
+
+import { AccountId } from '@polkadot/types/interfaces/runtime';
+
+import { useApi } from '.';
+
+/**
+ * @description This hook is going to be used for users account existing in the extension
+ * */
+export default function useActiveEraIndex(address: AccountId | string | undefined): number | undefined {
+  const [index, setIndex] = useState<number>();
+  const api = useApi(address);
+
+  useEffect(() => {
+    api && api.query.staking && api.query.staking.activeEra().then((i) => {
+      setIndex(i.isSome ? i.unwrap().index.toNumber() : 0);
+    }).catch(console.error);
+  }, [api]);
+
+  return index;
+}
+
+/**
+ * @Details: the ActiveEra in Polkadot is the era that is currently active and operational within the network. It represents the set of active validators who are participating in the network's consensus mechanism and validating transactions. The ActiveEra is the era to which points and rewards are mapped, and it is the era where validators are actively validating blocks and contributing to the network's security and functionality.
+ */

--- a/packages/extension-polkagate/src/hooks/usePendingRewards2.ts
+++ b/packages/extension-polkagate/src/hooks/usePendingRewards2.ts
@@ -1,0 +1,290 @@
+// Copyright 2019-2024 @polkadot/extension-polkagate authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { StorageKey } from '@polkadot/types';
+import type { AnyTuple, Codec } from '@polkadot/types/types';
+
+import { useCallback, useEffect, useState } from 'react';
+
+import { BN, BN_ZERO } from '@polkadot/util';
+
+import { toBN } from '../util/utils';
+import { ExposureOverview, Others } from './useValidators';
+import { useActiveEraIndex, useInfo } from '.';
+
+export interface ExposureValue {
+  others: Others[];
+  own: BN;
+  total: BN;
+}
+
+// Record<era, EraUnclaimedPayouts>
+export interface Exposure {
+  keys: [number, string];
+  val: ExposureValue;
+}
+
+export interface ExposureInfo {
+  exposedPage: number,
+  myStaked: BN,
+  total: BN,
+  validatorAddress: string
+}
+export interface EraExposureInfo {
+  eraIndex: number;
+  exposureInfo: ExposureInfo[]
+}
+export interface EraValidaTorPair {
+  eraIndex: number;
+  validatorAddress: string
+}
+
+// Record<era, EraUnclaimedPayouts>
+export type UnclaimedPayouts = Record<string, EraUnclaimedPayouts> | null;
+
+// Record<validator, [page, amount]>
+export type EraUnclaimedPayouts = Record<string, [number, BN]>;
+
+export const PAGED_REWARD_START_ERA: Record<string, number> = {
+  Kusama: 6514,
+  Polkadot: 1420,
+  Westend: 7167
+};
+
+export type AnyApi = any;
+export type AnyJson = any;
+
+const isRewardsPaged = (chainName: string, era: number): boolean => {
+  const startEra = PAGED_REWARD_START_ERA[chainName];
+
+  return startEra ? era >= startEra : false;
+};
+
+export const MAX_SUPPORTED_PAYOUT_ERAS = 7; // TODO: can increase to more if needed after enough tests
+
+export default function usePendingRewards2 (address: string): UnclaimedPayouts | undefined {
+  const { api, chainName, formatted } = useInfo(address);
+  const activeEra = useActiveEraIndex(address);
+  const [pendingRewards, setPendingRewards] = useState<UnclaimedPayouts>();
+
+  const endEra = activeEra ? activeEra - MAX_SUPPORTED_PAYOUT_ERAS - 1 : 1;
+
+  const fetchEraExposure = useCallback(async (eraIndex: number): Promise<EraExposureInfo | null | undefined> => {
+    if (!api) {
+      return;
+    }
+
+    if (isRewardsPaged(chainName, eraIndex)) {
+      const overview: [StorageKey<AnyTuple>, Codec][] = await api.query.staking.erasStakersOverview.entries(eraIndex);
+
+      const validators = overview.reduce((prev: Record<string, Exposure>, [keys, value]) => {
+        const validator = keys.toHuman()[1] as string;
+        const { own, total } = value.unwrap() as ExposureOverview;
+
+        return { ...prev, [validator]: { own: toBN(own), total: toBN(total) } };
+      }, {});
+
+      const validatorKeys = Object.keys(validators);
+
+      const pagedResults: [StorageKey<AnyTuple>, Codec][][] = await Promise.all(
+        validatorKeys.map((v) =>
+          api.query.staking.erasStakersPaged.entries(eraIndex, v)
+        )
+      );
+
+      const result: ExposureInfo[] = [];
+
+      let i = 0;
+
+      for (const pagedResult of pagedResults) {
+        const validatorAddress = validatorKeys[i];
+
+        pagedResult.forEach(([, v], index) => {
+          const o = (v.unwrap()?.others || []) as Others[];
+
+          const found = o.find(({ who }) => who.toString() === formatted);
+
+          if (found) {
+            const { value } = found;
+            const { total } = validators[validatorAddress];
+
+            return result.push({
+              exposedPage: index,
+              myStaked: toBN(value),
+              total: toBN(total),
+              validatorAddress
+            });
+          }
+        });
+
+        i++;
+      }
+
+      return result.length ? { eraIndex, exposureInfo: result } : null;
+    }
+    // ignore depreciated case
+  }, [api, chainName, formatted]);
+
+  const getAllExposures = useCallback(async () => {
+    if (!api || !activeEra) {
+      return;
+    }
+
+    let currentEra = activeEra - 1;
+    const allExposures: EraExposureInfo[] = [];
+
+    while (endEra < currentEra) {
+      const eraExposureInfo = await fetchEraExposure(currentEra);
+
+      if (eraExposureInfo) {
+        allExposures.push(eraExposureInfo);
+      }
+
+      console.log('eraExposureInfo:', eraExposureInfo);
+      currentEra -= 1;
+    }
+
+    return allExposures;
+  }, [activeEra, api, endEra, fetchEraExposure]);
+
+  const getExposedPage = useCallback((_eraIndex, _validatorAddress, allExposures: EraExposureInfo[]): number | undefined => {
+    const found = allExposures.find(({ eraIndex }) => eraIndex === _eraIndex);
+
+    if (found) {
+      const { exposureInfo } = found;
+
+      return exposureInfo.find(({ validatorAddress }) => validatorAddress === _validatorAddress)?.exposedPage;
+    }
+
+    return undefined;
+  }, []);
+
+  const getEraExposure = useCallback((_eraIndex: number, _validatorAddress: string, allExposures: EraExposureInfo[]): ExposureInfo | null => {
+    const found = allExposures.find(({ eraIndex }) => eraIndex === _eraIndex);
+
+    if (found) {
+      const { exposureInfo } = found;
+
+      const foundInfo = exposureInfo.find(({ validatorAddress }) => validatorAddress === _validatorAddress);
+
+      return foundInfo || null;
+    }
+
+    return null;
+  }, []);
+
+  const handleUnclaimedRewards = useCallback(async (allExposures: EraExposureInfo[]) => {
+    if (!api) {
+      return;
+    }
+
+    const eraValidatorsToCheck: EraValidaTorPair[] = [];
+
+    allExposures.forEach((exposures) => {
+      const { eraIndex, exposureInfo } = exposures;
+
+      exposureInfo.forEach((info) => {
+        const { validatorAddress } = info;
+
+        eraValidatorsToCheck.push({ eraIndex, validatorAddress });
+      });
+    });
+
+    // History of claimed paged rewards by era and validator.
+    const claimedRewards = await Promise.all(
+      eraValidatorsToCheck.map(({ eraIndex, validatorAddress }) =>
+        api.query.staking.claimedRewards<AnyApi>(eraIndex, validatorAddress)
+      )
+    );
+
+    // Unclaimed rewards by validator. Record<validator, eraIndex[]>
+    const unclaimedRewards: Record<number, string[]> = {};
+
+    for (let i = 0; i < claimedRewards.length; i++) {
+      const pages = (claimedRewards[i].toHuman() || []) as string[];
+
+      const { eraIndex, validatorAddress } = eraValidatorsToCheck[i];
+      const exposedPage = getExposedPage(eraIndex, validatorAddress, allExposures);
+
+      // if payout page has not yet been claimed
+      if (!pages.includes(String(exposedPage))) {
+        if (unclaimedRewards?.[eraIndex]) {
+          unclaimedRewards[eraIndex].push(validatorAddress);
+        } else {
+          unclaimedRewards[eraIndex] = [validatorAddress];
+        }
+      }
+    }
+
+    // calls needed to calculate rewards.
+    const calls: AnyApi[] = [];
+
+    Object.entries(unclaimedRewards).forEach(([eraIndex, validators]) => {
+      if (validators.length > 0) {
+        calls.push(
+          Promise.all([
+            api.query.staking.erasValidatorReward<AnyApi>(eraIndex),
+            api.query.staking.erasRewardPoints<AnyApi>(eraIndex),
+            ...validators.map((validator: AnyJson) =>
+              api.query.staking.erasValidatorPrefs<AnyApi>(eraIndex, validator)
+            )
+          ])
+        );
+      }
+    });
+
+    // determine unclaimed payouts Record<era, Record<validator, unclaimedPayout>>.
+    const unclaimed: UnclaimedPayouts = {};
+    let i = 0;
+
+    for (const [eraTotalPayout, erasRewardPoints, ...prefs] of await Promise.all(calls)) {
+      const eraIndex = Object.keys(unclaimedRewards)[i];
+      const unclaimedValidators = unclaimedRewards[eraIndex];
+
+      let j = 0;
+
+      for (const eraValidatorPrefs of prefs) {
+        const commission = toBN(eraValidatorPrefs.commission).divn(10 ** 7);
+        const validator = (unclaimedValidators?.[j] || '') as string;
+        const exposureInfo = getEraExposure(Number(eraIndex), validator, allExposures);
+        const myStaked = exposureInfo?.myStaked || BN_ZERO;
+        const total = exposureInfo?.total || BN_ZERO;
+        const exposedPage = exposureInfo?.exposedPage || 0;
+        const totalRewardPoints = erasRewardPoints.total;
+        const validatorRewardPoints = new BN(erasRewardPoints.toHuman().individual?.[validator]?.replace(/,/g, '') || 0);
+        const available = toBN(eraTotalPayout).mul(validatorRewardPoints).div(totalRewardPoints);
+        const valCut = commission.mul(available).divn(100);
+
+        const unclaimedPayout = total.isZero()
+          ? BN_ZERO
+          : available.sub(valCut).mul(myStaked).div(total);
+
+        if (!unclaimedPayout.isZero()) {
+          unclaimed[eraIndex] = {
+            ...unclaimed[eraIndex],
+            [validator]: [exposedPage, unclaimedPayout]
+          };
+          j++;
+        }
+      }
+
+      i++;
+    }
+
+    setPendingRewards({ ...unclaimed });
+  }, [api, getEraExposure, getExposedPage]);
+
+  useEffect(() => {
+    if (!activeEra || !formatted) {
+      return;
+    }
+
+    getAllExposures().then((allExposures) => {
+      allExposures?.length && handleUnclaimedRewards(allExposures);
+    }).catch(console.error);
+  }, [address, api, activeEra, formatted, getAllExposures, handleUnclaimedRewards]);
+
+  console.log('pendingRewards:', pendingRewards);
+
+  return pendingRewards;
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new UI feature for managing and viewing pending staking rewards.
  - Added functionality to fetch and display the active era index for user accounts.

- **Enhancements**
  - Enhanced the calculation and display of pending rewards using a new data handling approach.
  - Improved reward selection and payout processes in the UI.

- **Refactor**
  - Updated and optimized reward management hooks for better performance and reliability.

- **Bug Fixes**
  - Fixed issues related to reward calculations and data inconsistencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->