### PR TITLE
fix issue :  when selection an asset with asset id and then click to go account details asset id get resets #1218 

### DIFF
--- a/packages/extension-polkagate/src/fullscreen/accountDetails/index.tsx
+++ b/packages/extension-polkagate/src/fullscreen/accountDetails/index.tsx
@@ -51,7 +51,7 @@ const isRelayChain = (chainName: string) =>
   chainName.toLowerCase() === 'polkadot' ||
   chainName.toLowerCase() === 'westend';
 
-export default function AccountDetails (): React.ReactElement {
+export default function AccountDetails(): React.ReactElement {
   useFullscreen();
   const { t } = useTranslation();
   const theme = useTheme();
@@ -128,8 +128,8 @@ export default function AccountDetails (): React.ReactElement {
   }, [selectedAsset]);
 
   useEffect(() => {
-    onAction(`/accountfs/${address}/${assetId || '0'}`);
-  }, [address, assetId, onAction]);
+    accountAssets !== undefined && onAction(`/accountfs/${address}/${assetId || '0'}`);
+  }, [accountAssets, address, assetId, onAction]);
 
   useEffect(() => {
     const mayBeAssetIdSelectedInHomePage = parseInt(paramAssetId);


### PR DESCRIPTION
close #1218 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the reliability of account asset actions by adding a check to ensure assets are defined before performing actions in the Account Details feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->