### PR TITLE
Utilize useAccountInfo2 instead of api.derive.accounts.info in ProxyManagement in FL and Extension mode

### DIFF
--- a/packages/extension-polkagate/src/popup/manageProxies/AddProxy.tsx
+++ b/packages/extension-polkagate/src/popup/manageProxies/AddProxy.tsx
@@ -4,7 +4,6 @@
 /* eslint-disable react/jsx-max-props-per-line */
 
 import type { ApiPromise } from '@polkadot/api';
-import type { DeriveAccountInfo } from '@polkadot/api-derive/types';
 
 import { Grid, Typography, useTheme } from '@mui/material';
 import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
@@ -12,7 +11,7 @@ import React, { useCallback, useContext, useEffect, useMemo, useState } from 're
 import { Chain } from '@polkadot/extension-chains/types';
 
 import { AccountContext, AddressInput, InputWithLabel, PButton, Select, Warning } from '../../components';
-import { useAccountIdOrName, useFormatted, useTranslation } from '../../hooks';
+import { useAccountIdOrName, useAccountInfo2, useFormatted, useTranslation } from '../../hooks';
 import { CHAIN_PROXY_TYPES } from '../../util/constants';
 import getAllAddresses from '../../util/getAllAddresses';
 import { Proxy, ProxyItem } from '../../util/types';
@@ -39,7 +38,7 @@ const isEqualProxy = (a: Proxy, b: Proxy) => {
   return a.delay === b.delay && a.delegate === b.delegate && a.proxyType === b.proxyType;
 };
 
-export default function AddProxy({ address, api, chain, onChange, proxyItems, setProxyItems, setShowAddProxy, showAddProxy }: Props): React.ReactElement {
+export default function AddProxy ({ address, api, chain, onChange, proxyItems, setProxyItems, setShowAddProxy, showAddProxy }: Props): React.ReactElement {
   const { t } = useTranslation();
   const { hierarchy } = useContext(AccountContext);
   const formatted = useFormatted(address);
@@ -50,8 +49,9 @@ export default function AddProxy({ address, api, chain, onChange, proxyItems, se
   const [realAddress, setRealAddress] = useState<string | undefined>();
   const [selectedProxyType, setSelectedProxyType] = useState<string | null>('Any');
   const [delay, setDelay] = useState<number>(0);
-  const [accountInfo, setAccountInfo] = useState<DeriveAccountInfo | undefined | null>();
   const [addButtonDisabled, setAddButtonDisabled] = useState<boolean>(true);
+
+  const proxyAccountIdentity = useAccountInfo2(api, realAddress);
 
   const myselfAsProxy = useMemo(() => formatted === realAddress, [formatted, realAddress]);
   const possibleProxy = useMemo(() => ({ delay, delegate: realAddress, proxyType: selectedProxyType }) as Proxy, [delay, realAddress, selectedProxyType]);
@@ -87,7 +87,6 @@ export default function AddProxy({ address, api, chain, onChange, proxyItems, se
   useEffect(() => {
     if (!realAddress || !selectedProxyType || myselfAsProxy) {
       setAddButtonDisabled(true);
-      setAccountInfo(undefined);
 
       return;
     }
@@ -101,26 +100,16 @@ export default function AddProxy({ address, api, chain, onChange, proxyItems, se
     setAddButtonDisabled(false);
   }, [alreadyExisting, myselfAsProxy, realAddress, selectedProxyType]);
 
-  useEffect(() => {
-    realAddress && api && api.derive.accounts.info(realAddress).then((info) => {
-      if (info.identity.display) {
-        setAccountInfo(info.identity);
-      } else {
-        setAccountInfo(null);
-      }
-    });
-  }, [api, realAddress]);
-
   return (
     <>
       <Typography fontSize='14px' fontWeight={300} m='20px auto 15px' textAlign='left' width='90%'>
-        {t<string>("You can add an account included in this extension as a proxy of {{accountDisplayName}} to sign certain types of transactions on {{accountDisplayName}}'s behalf.", { replace: { accountDisplayName } })}
+        {t("You can add an account included in this extension as a proxy of {{accountDisplayName}} to sign certain types of transactions on {{accountDisplayName}}'s behalf.", { replace: { accountDisplayName } })}
       </Typography>
       <AddressInput
         address={realAddress}
         allAddresses={allAddresses}
         chain={chain}
-        helperText={t<string>('The account address which will be a proxy account')}
+        helperText={t('The account address which will be a proxy account')}
         label='Account ID'
         setAddress={setRealAddress}
         showIdenticon
@@ -132,8 +121,8 @@ export default function AddProxy({ address, api, chain, onChange, proxyItems, se
       <Grid sx={{ m: 'auto', width: '92%' }}>
         <Select
           defaultValue={proxyTypeOptions[0].value}
-          helperText={t<string>('The permissions allowed for this proxy account')}
-          label={t<string>('Proxy type')}
+          helperText={t('The permissions allowed for this proxy account')}
+          label={t('Proxy type')}
           onChange={_selectProxyType}
           options={proxyTypeOptions}
           value={selectedProxyType || proxyTypeOptions[0].value}
@@ -142,19 +131,19 @@ export default function AddProxy({ address, api, chain, onChange, proxyItems, se
       <Grid alignItems='end' container sx={{ m: '15px auto', width: '92%' }}>
         <Grid item xs={4}>
           <InputWithLabel
-            helperText={t<string>('The announcement period required of the initial proxy. Generally will be zero.')}
-            label={t<string>('Delay')}
+            helperText={t('The announcement period required of the initial proxy. Generally will be zero.')}
+            label={t('Delay')}
             onChange={_selectDelay}
             value={delay.toString()}
           />
         </Grid>
         <Typography fontSize='16px' fontWeight={300} pb='4px' pl='10px'>
-          {t<string>('Block(s)')}
+          {t('Block(s)')}
         </Typography>
       </Grid>
       {realAddress && !(myselfAsProxy || alreadyExisting) &&
         <ShowIdentity
-          accountIdentity={accountInfo}
+          accountIdentity={proxyAccountIdentity?.identity}
           style={{ m: 'auto', width: '92%' }}
         />
       }
@@ -168,15 +157,15 @@ export default function AddProxy({ address, api, chain, onChange, proxyItems, se
             theme={theme}
           >
             {myselfAsProxy
-              ? t<string>('Cannot set your account as a proxy for itself.')
-              : t<string>('You\'ve already included this proxy.')}
+              ? t('Cannot set your account as a proxy for itself.')
+              : t('You\'ve already included this proxy.')}
           </Warning>
         </Grid>
       }
       <PButton
         _onClick={_addProxy}
         disabled={addButtonDisabled}
-        text={t<string>('Add')}
+        text={t('Add')}
       />
     </>
   );

--- a/packages/extension-polkagate/src/popup/manageProxies/partials/ShowIdentity.tsx
+++ b/packages/extension-polkagate/src/popup/manageProxies/partials/ShowIdentity.tsx
@@ -52,35 +52,35 @@ export default function ShowIdentity ({ accountIdentity, style }: Props): React.
 
   return (
     <Grid sx={{ ...style }}>
-      <Label label={t<string>('Identity')}>
+      <Label label={t('Identity')}>
         <Grid container sx={{ bgcolor: 'background.paper', border: '1px solid', borderColor: 'secondary.light', borderRadius: '5px', maxHeight: '170px', minHeight: '38px', overflow: 'hidden' }}>
           {accountIdentity
             ? <Grid container item>
               <Grid display='block' item sx={{ borderRight: '1px solid', borderRightColor: 'secondary.light', p: '10px' }} xs={4}>
                 <Typography fontSize='12px' fontWeight={400}>
-                  {t<string>('Display')}:
+                  {t('Display')}:
                 </Typography>
                 <Typography fontSize='12px' fontWeight={400}>
-                  {t<string>('Legal')}:
+                  {t('Legal')}:
                 </Typography>
                 <Typography fontSize='12px' fontWeight={400}>
-                  {t<string>('Email')}:
+                  {t('Email')}:
                 </Typography>
                 <Typography fontSize='12px' fontWeight={400}>
-                  {t<string>('Element')}:
+                  {t('Element')}:
                 </Typography>
                 <Typography fontSize='12px' fontWeight={400}>
-                  {t<string>('Twitter')}:
+                  {t('Twitter')}:
                 </Typography>
                 <Typography fontSize='12px' fontWeight={400}>
-                  {t<string>('Web')}:
+                  {t('Web')}:
                 </Typography>
               </Grid>
               <Grid display='block' item p='10px' xs={8}>
                 {identity &&
                   Object.entries(identity).map(([key, value]) => (
-                    <Typography fontSize='12px' fontWeight={300} key={key} visibility={value ? 'visible' : 'hidden'}>
-                      {value ?? 'nan'}
+                    <Typography fontSize='12px' fontWeight={300} key={key}>
+                      {value || '--- ---'}
                     </Typography>
                   ))}
               </Grid>
@@ -92,7 +92,7 @@ export default function ShowIdentity ({ accountIdentity, style }: Props): React.
                   icon={faExclamationTriangle}
                 />
                 <Typography fontSize='12px' fontWeight={400} lineHeight='20px' pl='8px'>
-                  {t<string>('No identity found')}
+                  {t('No identity found')}
                 </Typography>
               </Grid>
               : <Grid alignItems='center' container justifyContent='center'>
@@ -100,7 +100,7 @@ export default function ShowIdentity ({ accountIdentity, style }: Props): React.
                   <Circle color='#99004F' scaleEnd={0.7} scaleStart={0.4} size={25} />
                 </Grid>
                 <Typography fontSize='13px' lineHeight='41px' pl='10px'>
-                  {t<string>('looking for identity...')}
+                  {t('looking for identity...')}
                 </Typography>
               </Grid>
           }


### PR DESCRIPTION
## works Done

1. Use useAccountInfo2  instead of api.derive.accounts.info to fetch selected proxy address identity in AddProxy component in both full-screen and extension modes
2. Update ShowIdentity component

Related to #1227 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the proxy management interface to simplify the process of adding and managing proxy accounts.
- **Refactor**
	- Improved how account identity information is retrieved and displayed across different components.
- **Style**
	- Updated text labels to remove explicit type annotations, streamlining translation handling within the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->