### PR TITLE
address  Add "account" as a return value to useInfo hook #1266 

### DIFF
--- a/packages/extension-polkagate/src/components/AmountFee.tsx
+++ b/packages/extension-polkagate/src/components/AmountFee.tsx
@@ -24,7 +24,7 @@ interface Props {
   withFee?: boolean;
 }
 
-function AmountFee({ address, amount, children, fee, label, style = {}, showDivider = false, token, withFee }: Props): React.ReactElement {
+function AmountFee ({ address, amount, children, fee, label, style = {}, showDivider = false, token, withFee }: Props): React.ReactElement {
   const { t } = useTranslation();
   const account = useAccount(address);
 

--- a/packages/extension-polkagate/src/components/NewAddress.tsx
+++ b/packages/extension-polkagate/src/components/NewAddress.tsx
@@ -6,7 +6,7 @@
 import { Grid, SxProps, Theme, Typography, useTheme } from '@mui/material';
 import React, { useMemo } from 'react';
 
-import { useAccount, useChain, useFormatted, useTranslation } from '../hooks';
+import { useInfo, useTranslation } from '../hooks';
 import { Identicon, ShortAddress } from './';
 
 export interface Props {
@@ -16,12 +16,10 @@ export interface Props {
   showCopy?: boolean;
 }
 
-export default function NewAddress({ address, name, showCopy, style }: Props): React.ReactElement<Props> {
+export default function NewAddress ({ address, name, showCopy, style }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const theme = useTheme();
-  const account = useAccount(address);
-  const chain = useChain(address);
-  const formatted = useFormatted(address);
+  const { account, chain, formatted } = useInfo(address);
 
   const isDarkTheme = useMemo(() => theme.palette.mode === 'dark', [theme.palette]);
 
@@ -36,7 +34,7 @@ export default function NewAddress({ address, name, showCopy, style }: Props): R
         />
       </Grid>
       <Grid alignItems='flex-start' container direction='column' item style={{ maxWidth: '85%' }} xs>
-        <Typography fontSize='16px' fontWeight={400} maxWidth='95%' overflow='hidden' variant='h3' whiteSpace='nowrap' textOverflow='ellipsis'>
+        <Typography fontSize='16px' fontWeight={400} maxWidth='95%' overflow='hidden' textOverflow='ellipsis' variant='h3' whiteSpace='nowrap'>
           {name ?? account?.name ?? t('<unknown>')}
         </Typography>
         <Grid container item justifyContent='space-between'>

--- a/packages/extension-polkagate/src/components/RemoteNodeSelector.tsx
+++ b/packages/extension-polkagate/src/components/RemoteNodeSelector.tsx
@@ -3,7 +3,7 @@
 
 import React, { useCallback } from 'react';
 
-import { useAccount, useChainName, useEndpoint, useEndpoints, useTranslation } from '../hooks';
+import { useEndpoint, useEndpoints, useInfo, useTranslation } from '../hooks';
 import { Select } from '.';
 
 interface Props {
@@ -17,10 +17,9 @@ export type ChromeStorageGetResponse = {
   } | undefined;
 };
 
-export default function RemoteNodeSelector({ address, genesisHash }: Props): React.ReactElement {
+export default function RemoteNodeSelector ({ address, genesisHash }: Props): React.ReactElement {
   const { t } = useTranslation();
-  const chainName = useChainName(address);
-  const account = useAccount(address);
+  const { account, chainName } = useInfo(address);
   const endpointOptions = useEndpoints(genesisHash || account?.genesisHash);
   const endpoint = useEndpoint(address);
 

--- a/packages/extension-polkagate/src/components/SignArea2.tsx
+++ b/packages/extension-polkagate/src/components/SignArea2.tsx
@@ -21,7 +21,7 @@ import { cryptoWaitReady } from '@polkadot/util-crypto';
 
 import { DraggableModal } from '../fullscreen/governance/components/DraggableModal';
 import SelectProxyModal2 from '../fullscreen/governance/components/SelectProxyModal2';
-import { useAccount, useAccountDisplay, useInfo, useProxies, useTranslation } from '../hooks';
+import { useAccountDisplay, useInfo, useProxies, useTranslation } from '../hooks';
 import LedgerSign from '../popup/signing/LedgerSign';
 import Qr from '../popup/signing/Qr';
 import { CMD_MORTAL } from '../popup/signing/Request';
@@ -66,10 +66,9 @@ interface Props {
 export default function SignArea ({ address, call, disabled, extraInfo, isPasswordError, onSecondaryClick, params, previousStep, prevState, primaryBtn, primaryBtnText, proxyModalHeight, proxyTypeFilter, secondaryBtnText, selectedProxy, setIsPasswordError, setRefresh, setSelectedProxy, setStep, setTxInfo, showBackButtonWithUseProxy = true, steps, token }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const theme = useTheme();
-  const { api, chain, formatted } = useInfo(address);
+  const { account, api, chain, formatted } = useInfo(address);
   const senderName = useAccountDisplay(address);
   const selectedProxyName = useAccountDisplay(getSubstrateAddress(selectedProxy?.delegate));
-  const account = useAccount(address);
   const proxies = useProxies(api, formatted);
 
   const [proxyItems, setProxyItems] = useState<ProxyItem[]>();

--- a/packages/extension-polkagate/src/fullscreen/accountDetails/components/AccountInformation.tsx
+++ b/packages/extension-polkagate/src/fullscreen/accountDetails/components/AccountInformation.tsx
@@ -67,8 +67,8 @@ const Balance = ({ balanceToShow, isBalanceOutdated }: BalanceJSXType) => {
         : <Skeleton animation='wave' height={22} sx={{ my: '2.5px', transform: 'none' }} variant='text' width={90} />
       }
     </>
-  )
-}
+  );
+};
 
 interface BalanceRowJSXType {
   balanceToShow: BalancesInfo | undefined;
@@ -118,7 +118,6 @@ const SelectedAssetBox = ({ account, balanceToShow, isBalanceOutdated, isPriceOu
   );
 };
 
-
 interface AddressDetailsProps {
   address: string | undefined;
   api: ApiPromise | undefined;
@@ -136,11 +135,11 @@ interface AddressDetailsProps {
   setAssetIdOnAssetHub: React.Dispatch<React.SetStateAction<number | undefined>>;
 }
 
-export default function AccountInformation({ accountAssets, address, api, balances, chain, chainName, formatted, isDarkTheme, label, price, pricesInCurrency, selectedAsset, setAssetIdOnAssetHub, setSelectedAsset }: AddressDetailsProps): React.ReactElement {
+export default function AccountInformation ({ accountAssets, address, api, balances, chain, chainName, formatted, isDarkTheme, label, price, pricesInCurrency, selectedAsset, setAssetIdOnAssetHub, setSelectedAsset }: AddressDetailsProps): React.ReactElement {
   const { t } = useTranslation();
-
-  const account = useAccount(address);
   const theme = useTheme();
+  const account = useAccount(address);
+
   const [balanceToShow, setBalanceToShow] = useState<BalancesInfo>();
 
   const calculatePrice = useCallback((amount: BN, decimal: number, _price: number) => {

--- a/packages/extension-polkagate/src/fullscreen/accountDetails/components/AccountSetting.tsx
+++ b/packages/extension-polkagate/src/fullscreen/accountDetails/components/AccountSetting.tsx
@@ -12,7 +12,7 @@ import { Collapse, Divider, Grid, Typography, useTheme } from '@mui/material';
 import React, { useCallback, useContext, useMemo, useState } from 'react';
 
 import { ActionContext, SocialRecoveryIcon } from '../../../components';
-import { useAccount, useChain, useTranslation } from '../../../hooks';
+import { useInfo, useTranslation } from '../../../hooks';
 import { IDENTITY_CHAINS, PROXY_CHAINS, SOCIAL_RECOVERY_CHAINS } from '../../../util/constants';
 import { popupNumbers } from '..';
 import { TaskButton } from './CommonTasks';
@@ -25,9 +25,8 @@ interface Props {
 export default function AccountSetting ({ address, setDisplayPopup }: Props): React.ReactElement {
   const { t } = useTranslation();
   const theme = useTheme();
-  const account = useAccount(address);
+  const { account, chain } = useInfo(address);
   const onAction = useContext(ActionContext);
-  const chain = useChain(address);
 
   const [showAccountSettings, setShowAccountSettings] = useState<boolean>();
 

--- a/packages/extension-polkagate/src/fullscreen/accountDetails/index.tsx
+++ b/packages/extension-polkagate/src/fullscreen/accountDetails/index.tsx
@@ -11,7 +11,7 @@ import { useParams } from 'react-router';
 import { BN } from '@polkadot/util';
 
 import { AccountContext, ActionContext } from '../../components';
-import { useAccount, useAccountAssets, useBalances, useCurrency, useFullscreen, useInfo, usePrices, useTranslation } from '../../hooks';
+import { useAccountAssets, useBalances, useCurrency, useFullscreen, useInfo, usePrices, useTranslation } from '../../hooks';
 import { Lock } from '../../hooks/useAccountLocks';
 import { FetchedBalance } from '../../hooks/useAssetsBalances';
 import { getValue } from '../../popup/account/util';
@@ -56,11 +56,10 @@ export default function AccountDetails(): React.ReactElement {
   const { t } = useTranslation();
   const theme = useTheme();
   const { address, paramAssetId } = useParams<{ address: string, paramAssetId?: string }>();
-  const account = useAccount(address);
   const { accounts } = useContext(AccountContext);
 
   const currency = useCurrency();
-  const { api, chain, chainName, formatted } = useInfo(address);
+  const { account, api, chain, chainName, formatted } = useInfo(address);
   const onAction = useContext(ActionContext);
   const accountAssets = useAccountAssets(address);
   const pricesInCurrency = usePrices();

--- a/packages/extension-polkagate/src/fullscreen/homeFullScreen/partials/FullScreenAccountMenu.tsx
+++ b/packages/extension-polkagate/src/fullscreen/homeFullScreen/partials/FullScreenAccountMenu.tsx
@@ -9,12 +9,10 @@ import '@vaadin/icons';
 import { faAddressCard } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Divider, Grid, Popover, useTheme } from '@mui/material';
-import React, { useCallback, useContext, useState } from 'react';
+import React, { useCallback, useContext } from 'react';
 
-import { ActionContext, Chain, MenuItem, SocialRecoveryIcon } from '../../../components';
-import { useAccount, useChain, useGenesisHashOptions, useTranslation } from '../../../hooks';
-import { tieAccount } from '../../../messaging';
-import { FullScreenRemoteNode } from '../../../partials';
+import { ActionContext, MenuItem, SocialRecoveryIcon } from '../../../components';
+import { useInfo, useTranslation } from '../../../hooks';
 import { IDENTITY_CHAINS, PROXY_CHAINS, SOCIAL_RECOVERY_CHAINS } from '../../../util/constants';
 import { POPUPS_NUMBER } from './AccountInformation';
 
@@ -24,16 +22,13 @@ interface Props {
   setDisplayPopup: React.Dispatch<React.SetStateAction<number | undefined>>;
 }
 
-function FullScreenAccountMenu({ address, baseButton, setDisplayPopup }: Props): React.ReactElement<Props> {
+function FullScreenAccountMenu ({ address, baseButton, setDisplayPopup }: Props): React.ReactElement<Props> {
   const theme = useTheme();
   const { t } = useTranslation();
-  const chain = useChain(address);
-  const account = useAccount(address);
+  const { account, chain } = useInfo(address);
   const onAction = useContext(ActionContext);
-  const options = useGenesisHashOptions();
 
   const [anchorEl, setAnchorEl] = React.useState<HTMLButtonElement | null>(null);
-  const [genesisHash, setGenesis] = useState<string | undefined>(chain?.genesisHash);
 
   const handleClose = useCallback(() => {
     setAnchorEl(null);
@@ -54,12 +49,6 @@ function FullScreenAccountMenu({ address, baseButton, setDisplayPopup }: Props):
     address && setDisplayPopup(POPUPS_NUMBER.DERIVE_ACCOUNT);
     handleClose();
   }, [address, handleClose, setDisplayPopup]);
-
-  const onChangeNetwork = useCallback((newGenesisHash: string) => {
-    const availableGenesisHash = newGenesisHash.startsWith('0x') ? newGenesisHash : null;
-
-    address && tieAccount(address, availableGenesisHash).then(() => setGenesis(availableGenesisHash ?? undefined)).catch(console.error);
-  }, [address]);
 
   const onRenameAccount = useCallback(() => {
     address && setDisplayPopup(POPUPS_NUMBER.RENAME);
@@ -93,24 +82,6 @@ function FullScreenAccountMenu({ address, baseButton, setDisplayPopup }: Props):
 
   const AccountMenu = () => (
     <Grid alignItems='flex-start' container display='block' item sx={{ borderRadius: '10px', minWidth: '300px', p: '10px' }}>
-      {/* <Grid container item>
-        <Chain
-          address={address}
-          allowAnyChainOption
-          defaultValue={genesisHash ?? chain?.genesisHash ?? options[0].text}
-          label={t<string>('Chain')}
-          onChange={onChangeNetwork}
-          style={{ '> div div div div div div': { height: '23px', width: '23px' }, '> div div div#selectChain': { borderRadius: '5px', height: '30px' }, '> div p': { fontSize: '16px', p: 0 }, textAlign: 'left', width: '84%' }}
-        />
-        <Grid alignContent='flex-end' container item justifyContent='center' width='15%' zIndex={1}>
-          {(genesisHash ?? chain?.genesisHash) &&
-            <FullScreenRemoteNode
-              address={address}
-              iconSize={25}
-            />}
-        </Grid>
-      </Grid>
-      <Divider sx={{ bgcolor: 'secondary.light', height: '1px', my: '7px' }} /> */}
       <MenuItem
         disabled={isDisable(PROXY_CHAINS)}
         iconComponent={

--- a/packages/extension-polkagate/src/fullscreen/manageProxies/index.tsx
+++ b/packages/extension-polkagate/src/fullscreen/manageProxies/index.tsx
@@ -13,7 +13,7 @@ import { ApiPromise } from '@polkadot/api';
 import { BN, BN_ZERO } from '@polkadot/util';
 
 import { Warning } from '../../components';
-import { useAccount, useApi, useChain, useFullscreen, useTranslation } from '../../hooks';
+import { useFullscreen, useInfo, useTranslation } from '../../hooks';
 import { FULLSCREEN_WIDTH, PROXY_CHAINS } from '../../util/constants';
 import { Proxy, ProxyItem } from '../../util/types';
 import { FullScreenHeader } from '../governance/FullScreenHeader';
@@ -38,9 +38,7 @@ function ManageProxies (): React.ReactElement {
   const { t } = useTranslation();
   const theme = useTheme();
   const { address } = useParams<{ address: string; }>();
-  const account = useAccount(address);
-  const api = useApi(address);
-  const chain = useChain(address);
+  const { account, api, chain } = useInfo(address);
 
   const [step, setStep] = useState<number>(0);
   const [proxyItems, setProxyItems] = useState<ProxyItem[] | null | undefined>();

--- a/packages/extension-polkagate/src/fullscreen/sendFund/InputPage.tsx
+++ b/packages/extension-polkagate/src/fullscreen/sendFund/InputPage.tsx
@@ -82,7 +82,7 @@ const isAssethub = (genesisHash?: string) => ASSET_HUBS.includes(genesisHash || 
 export default function InputPage ({ address, assetId, balances, inputs, setInputs, setStep }: Props): React.ReactElement {
   const { t } = useTranslation();
   const theme = useTheme();
-  const {api, chain, formatted} = useInfo(address);
+  const { api, chain, formatted } = useInfo(address);
   const teleportState = useTeleport(address);
   const onAction = useContext(ActionContext);
 

--- a/packages/extension-polkagate/src/hooks/useAccount.ts
+++ b/packages/extension-polkagate/src/hooks/useAccount.ts
@@ -14,7 +14,7 @@ function findAccountByAddress (accounts: AccountJson[], address: string): Accoun
   return accounts.find((acc) => acc.address === address);
 }
 
-export default function useAccount(address: string | AccountId | null | undefined): AccountJson | undefined {
+export default function useAccount (address: string | AccountId | null | undefined): AccountJson | undefined {
   const [account, setAccount] = useState<AccountJson>();
 
   const { accounts } = useContext(AccountContext);

--- a/packages/extension-polkagate/src/hooks/useBalances.ts
+++ b/packages/extension-polkagate/src/hooks/useBalances.ts
@@ -16,20 +16,14 @@ import { updateMeta } from '../messaging';
 import { ASSET_HUBS } from '../util/constants';
 import getPoolAccounts from '../util/getPoolAccounts';
 import { BalancesInfo, SavedBalances } from '../util/types';
-import { useAccount, useApi, useChain, useChainName, useDecimal, useFormatted, useStakingAccount, useToken } from '.';
+import { useInfo, useStakingAccount } from '.';
 
 const assetsChains = createAssets();
 
 export default function useBalances (address: string | undefined, refresh?: boolean, setRefresh?: React.Dispatch<React.SetStateAction<boolean>>, onlyNew = false, assetId?: number): BalancesInfo | undefined {
   const stakingAccount = useStakingAccount(address);
-  const account = useAccount(address);
-  const api = useApi(address);
-  const chain = useChain(address);
-  const formatted = useFormatted(address);
+  const { account, api, chain, chainName, decimal: currentDecimal, formatted, token: currentToken } = useInfo(address);
   const isFetching = useContext(FetchingContext);
-  const chainName = useChainName(address);
-  const currentToken = useToken(address);
-  const currentDecimal = useDecimal(address);
 
   const mayBeAssetsOnMultiAssetChains = assetsChains[toCamelCase(chainName || '')];
   const isAssetHub = ASSET_HUBS.includes(chain?.genesisHash || '');

--- a/packages/extension-polkagate/src/hooks/useInfo.ts
+++ b/packages/extension-polkagate/src/hooks/useInfo.ts
@@ -4,13 +4,15 @@
 import { useMemo } from 'react';
 
 import { ApiPromise } from '@polkadot/api';
+import { AccountJson } from '@polkadot/extension-base/background/types';
 import { Chain } from '@polkadot/extension-chains/types';
 import { AccountId } from '@polkadot/types/interfaces/runtime';
 
 import { sanitizeChainName } from '../util/utils';
-import { useApi, useChain, useDecimal, useEndpoint, useFormatted, useToken } from '.';
+import { useAccount, useApi, useChain, useDecimal, useEndpoint, useFormatted, useToken } from '.';
 
 interface AddressInfo {
+  account: AccountJson | undefined;
   api: ApiPromise | undefined;
   chain: Chain | null | undefined;
   chainName: string | undefined;
@@ -22,14 +24,16 @@ interface AddressInfo {
 }
 
 export default function useInfo (address: AccountId | string | undefined): AddressInfo {
-  const token = useToken(address);
-  const decimal = useDecimal(address);
+  const account = useAccount(address);
   const api = useApi(address);
   const chain = useChain(address);
-  const formatted = useFormatted(address);
+  const decimal = useDecimal(address);
   const endpoint = useEndpoint(address);
+  const formatted = useFormatted(address);
+  const token = useToken(address);
 
   return useMemo(() => ({
+    account,
     api,
     chain,
     chainName: sanitizeChainName(chain?.name),
@@ -38,5 +42,5 @@ export default function useInfo (address: AccountId | string | undefined): Addre
     formatted,
     genesisHash: chain?.genesisHash,
     token
-  }), [api, chain, decimal, endpoint, formatted, token]);
+  }), [account, api, chain, decimal, endpoint, formatted, token]);
 }

--- a/packages/extension-polkagate/src/hooks/useStakingAccount.ts
+++ b/packages/extension-polkagate/src/hooks/useStakingAccount.ts
@@ -14,7 +14,7 @@ import { BN } from '@polkadot/util';
 import { updateMeta } from '../messaging';
 import { AccountStakingInfo } from '../util/types';
 import { isHexToBn } from '../util/utils';
-import { useAccount, useApi, useStashId, useToken } from '.';
+import { useInfo, useStashId } from '.';
 
 BN.prototype.toJSON = function () {
   return this.toString();
@@ -30,10 +30,9 @@ BN.prototype.toJSON = function () {
  * @returns account staking Info
  */
 export default function useStakingAccount (address: AccountId | string | undefined, stateInfo?: AccountStakingInfo, refresh?: boolean, setRefresh?: React.Dispatch<React.SetStateAction<boolean>>, onlyNew?: boolean): AccountStakingInfo | null | undefined {
-  const account = useAccount(address);
-  const api = useApi(address);
+  const { account, api, token: addressCurrentToken } = useInfo(address);
   const stashId = useStashId(address);
-  const addressCurrentToken = useToken(address);
+
   const [stakingInfo, setStakingInfo] = useState<AccountStakingInfo | null>();
 
   const fetch = useCallback(async () => {

--- a/packages/extension-polkagate/src/partials/AccountMenu.tsx
+++ b/packages/extension-polkagate/src/partials/AccountMenu.tsx
@@ -12,7 +12,7 @@ import { Divider, Grid, IconButton, Slide, useTheme } from '@mui/material';
 import React, { useCallback, useContext, useState } from 'react';
 
 import { ActionContext, Identity, MenuItem, RemoteNodeSelector, SelectChain, SocialRecoveryIcon } from '../components';
-import { useAccount, useGenesisHashOptions, useInfo, useTranslation } from '../hooks';
+import { useGenesisHashOptions, useInfo, useTranslation } from '../hooks';
 import { tieAccount, windowOpen } from '../messaging';
 import { IDENTITY_CHAINS, PROXY_CHAINS, SOCIAL_RECOVERY_CHAINS } from '../util/constants';
 import getLogo from '../util/getLogo';
@@ -28,8 +28,7 @@ function AccountMenu ({ address, isMenuOpen, noMargin, setShowMenu }: Props): Re
   const { t } = useTranslation();
   const theme = useTheme();
   const options = useGenesisHashOptions();
-  const { api, chain, formatted } = useInfo(address);
-  const account = useAccount(address);
+  const { account, api, chain, formatted } = useInfo(address);
 
   const [genesisHash, setGenesis] = useState<string | undefined>();
 

--- a/packages/extension-polkagate/src/partials/ChainSwitch.tsx
+++ b/packages/extension-polkagate/src/partials/ChainSwitch.tsx
@@ -11,7 +11,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 
 import { twoItemCurveBackgroundBlack, twoItemCurveBackgroundWhite } from '../assets/icons';
-import { useAccount, useChainName, useGenesisHashOptions, useIsTestnetEnabled } from '../hooks';
+import { useGenesisHashOptions, useInfo, useIsTestnetEnabled } from '../hooks';
 import { tieAccount } from '../messaging';
 import { CHAINS_WITH_BLACK_LOGO, CROWDLOANS_CHAINS, GOVERNANCE_CHAINS, STAKING_CHAINS } from '../util/constants';
 import getLogo from '../util/getLogo';
@@ -24,16 +24,16 @@ interface Props {
   externalChainNamesToShow?: (string | undefined)[] | undefined;
 }
 
-function ChainSwitch({ address, children, externalChainNamesToShow, invert }: Props): React.ReactElement<Props> {
+function ChainSwitch ({ address, children, externalChainNamesToShow, invert }: Props): React.ReactElement<Props> {
   const theme = useTheme();
   const { pathname } = useLocation();
-  const account = useAccount(address);
+  const { account, chainName: currentChainNameFromAccount } = useInfo(address);
+  const genesisHashes = useGenesisHashOptions();
+  const isTestnetEnabled = useIsTestnetEnabled();
+
   const [showOtherChains, setShowOtherChains] = useState<boolean>(false);
   const [notFirstTime, setFirstTime] = useState<boolean>(false);
-  const genesisHashes = useGenesisHashOptions();
-  const currentChainNameFromAccount = useChainName(address);
   const [currentChainName, setCurrentChainName] = useState<string | undefined>(currentChainNameFromAccount);
-  const isTestnetEnabled = useIsTestnetEnabled();
 
   const isTestnetDisabled = useCallback((name: string | undefined) => !isTestnetEnabled && name?.toLowerCase() === 'westend', [isTestnetEnabled]);
 
@@ -161,7 +161,7 @@ function ChainSwitch({ address, children, externalChainNamesToShow, invert }: Pr
     chainNamesToShow && (chainNamesToShow.length > 1
       ? setShowOtherChains(!showOtherChains)
       : selectNetwork(chainNamesToShow[0]))
-    , [chainNamesToShow, selectNetwork, showOtherChains]);
+  , [chainNamesToShow, selectNetwork, showOtherChains]);
   const closeChainSwitch = useCallback(() => setShowOtherChains(false), [setShowOtherChains]);
 
   return (
@@ -195,7 +195,8 @@ function ChainSwitch({ address, children, externalChainNamesToShow, invert }: Pr
                   sx={{
                     borderRadius: '50%',
                     filter: (CHAINS_WITH_BLACK_LOGO.includes(currentChainName) && theme.palette.mode === 'dark') ? 'invert(1)' : '',
-                    height: '28px', width: '28px'
+                    height: '28px',
+                    width: '28px'
                   }}
                 />
               </Grid>

--- a/packages/extension-polkagate/src/partials/FullScreenRemoteNode.tsx
+++ b/packages/extension-polkagate/src/partials/FullScreenRemoteNode.tsx
@@ -10,9 +10,9 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { ApiPromise } from '@polkadot/api';
 
 import { ChromeStorageGetResponse } from '../components/RemoteNodeSelector';
-import { useAccount, useChainName, useEndpoint, useEndpoints } from '../hooks';
-import CalculateNodeDelay from '../util/calculateNodeDelay';
+import { useEndpoint, useEndpoints, useInfo } from '../hooks';
 import useIsExtensionPopup from '../hooks/useIsExtensionPopup';
+import CalculateNodeDelay from '../util/calculateNodeDelay';
 
 interface Props {
   address: string | undefined;
@@ -21,15 +21,14 @@ interface Props {
 
 type EndpointsDelay = { name: string, delay: number | null | undefined, value: string }[];
 
-function FullScreenRemoteNode({ address, iconSize = 35 }: Props): React.ReactElement {
+function FullScreenRemoteNode ({ address, iconSize = 35 }: Props): React.ReactElement {
   const theme = useTheme();
-  const account = useAccount(address);
+  const { account, chainName } = useInfo(address);
   const genesisHash = account?.genesisHash;
   const endpointOptions = useEndpoints(genesisHash);
   const onExtension = useIsExtensionPopup();
-
   const endpointUrl = useEndpoint(address);
-  const chainName = useChainName(address);
+
   const isLightClient = endpointUrl?.startsWith('light');
 
   const [currentDelay, setCurrentDelay] = useState<number | undefined>();

--- a/packages/extension-polkagate/src/partials/QuickAction.tsx
+++ b/packages/extension-polkagate/src/partials/QuickAction.tsx
@@ -15,7 +15,7 @@ import { useHistory } from 'react-router-dom';
 import { AccountId } from '@polkadot/types/interfaces/runtime';
 
 import { HorizontalMenuItem, PoolStakingIcon } from '../components';
-import { useAccount, useApi, useFormatted, useTranslation } from '../hooks';
+import { useInfo, useTranslation } from '../hooks';
 import { windowOpen } from '../messaging';
 import { CROWDLOANS_CHAINS, GOVERNANCE_CHAINS, STAKING_CHAINS } from '../util/constants';
 
@@ -27,14 +27,11 @@ interface Props {
 
 const ICON_SIZE = 10;
 
-export default function QuickAction({ address, quickActionOpen, setQuickActionOpen }: Props): React.ReactElement<Props> {
+export default function QuickAction ({ address, quickActionOpen, setQuickActionOpen }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const theme = useTheme();
-  const formatted = useFormatted(address);
   const history = useHistory();
-
-  const account = useAccount(address);
-  const api = useApi(address);
+  const { account, api, formatted } = useInfo(address);
 
   const handleOpen = useCallback(() => setQuickActionOpen(String(address)), [address, setQuickActionOpen]);
   const handleClose = useCallback(() => quickActionOpen === address && setQuickActionOpen(undefined), [address, quickActionOpen, setQuickActionOpen]);
@@ -86,7 +83,7 @@ export default function QuickAction({ address, quickActionOpen, setQuickActionOp
         minWidth: 'calc(100% - 50px)',
         pl: '20px',
         pr: '10px',
-        pt:'5px',
+        pt: '5px',
         width: 'calc(100% - 50px)'
       }}
     >

--- a/packages/extension-polkagate/src/partials/RecentChains.tsx
+++ b/packages/extension-polkagate/src/partials/RecentChains.tsx
@@ -22,12 +22,13 @@ interface Props {
   currentChainName: string | undefined;
 }
 
-function RecentChains({ address, currentChainName }: Props): React.ReactElement<Props> {
+function RecentChains ({ address, currentChainName }: Props): React.ReactElement<Props> {
   const theme = useTheme();
   const account = useAccount(address);
+  const genesisHashes = useGenesisHashOptions();
+
   const [showRecentChains, setShowRecentChains] = useState<boolean>(false);
   const [notFirstTime, setFirstTime] = useState<boolean>(false);
-  const genesisHashes = useGenesisHashOptions();
   const [recentChains, setRecentChains] = useState<string[]>();
   const [isTestnetEnabled, setIsTestnetEnabled] = useState<boolean>();
   const [currentSelectedChain, setCurrentSelectedChain] = useState<string | undefined>(currentChainName);

--- a/packages/extension-polkagate/src/popup/account/AccountBrief.tsx
+++ b/packages/extension-polkagate/src/popup/account/AccountBrief.tsx
@@ -19,7 +19,7 @@ import { useHistory, useLocation } from 'react-router-dom';
 
 import { subscan } from '../../assets/icons/';
 import { Infotip, OptionalCopyButton, ShortAddress2 } from '../../components';
-import { useAccount, useChainName, useFormatted, useTranslation } from '../../hooks';
+import { useInfo, useTranslation } from '../../hooks';
 
 interface Props {
   address: string;
@@ -28,11 +28,9 @@ interface Props {
   showDivider?: boolean;
 }
 
-function AccountBrief({ address, identity, showDivider = true, showName = true }: Props): React.ReactElement<Props> {
+function AccountBrief ({ address, identity, showDivider = true, showName = true }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
-  const formatted = useFormatted(address);
-  const account = useAccount(address);
-  const chainName = useChainName(address);
+  const { account, chainName, formatted } = useInfo(address);
   const history = useHistory();
   const { pathname } = useLocation();
 

--- a/packages/extension-polkagate/src/popup/crowdloans/index.tsx
+++ b/packages/extension-polkagate/src/popup/crowdloans/index.tsx
@@ -11,11 +11,11 @@ import type { Balance } from '@polkadot/types/interfaces';
 
 import { Language as LanguageIcon } from '@mui/icons-material';
 import { Avatar, Box, Container, Divider, Grid, Link, Typography, useTheme } from '@mui/material';
+import { createWsEndpoints } from '@polkagate/apps-config';
 import { Crowdloan } from 'extension-polkagate/src/util/types';
 import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router';
 
-import { createWsEndpoints } from '@polkagate/apps-config';
 import { Chain } from '@polkadot/extension-chains/types';
 import { SettingsStruct } from '@polkadot/ui-settings/types';
 import { decodeAddress, encodeAddress } from '@polkadot/util-crypto';
@@ -23,7 +23,7 @@ import { decodeAddress, encodeAddress } from '@polkadot/util-crypto';
 import { auctionBlack, auctionRed, auctionWhite, crowdloanHomeBlack, crowdloanHomeRed, crowdloanHomeWhite, pastCrowdloanBlack, pastCrowdloanRed, pastCrowdloanWhite } from '../../assets/icons';
 import { ActionContext, HorizontalMenuItem, Identicon, Identity, Progress, ShowBalance, Warning } from '../../components';
 import { SettingsContext } from '../../components/contexts';
-import { useAccount, useApi, useAuction, useChain, useChainName, useCurrentBlockNumber, useDecimal, useFormatted, useMyAccountIdentity, useToken, useTranslation } from '../../hooks';
+import { useAuction, useCurrentBlockNumber, useInfo, useMyAccountIdentity, useTranslation } from '../../hooks';
 import useIsExtensionPopup from '../../hooks/useIsExtensionPopup';
 import { ChainSwitch, HeaderBrand } from '../../partials';
 import BouncingSubTitle from '../../partials/BouncingSubTitle';
@@ -49,7 +49,7 @@ const TAB_MAP = {
   PAST_CROWDLOANS: 3
 };
 
-export default function CrowdLoans(): React.ReactElement {
+export default function CrowdLoans (): React.ReactElement {
   const { t } = useTranslation();
   const onAction = useContext(ActionContext);
   const theme = useTheme();
@@ -57,14 +57,8 @@ export default function CrowdLoans(): React.ReactElement {
   const { address } = useParams<{ address: string }>();
   const currentBlockNumber = useCurrentBlockNumber(address);
   const auction = useAuction(address);
-  const account = useAccount(address);
-  const formatted = useFormatted(address);
-  const chain = useChain(address);
-  const api = useApi(address);
+  const { account, api, chain, chainName, decimal, formatted, token } = useInfo(address);
   const identity = useMyAccountIdentity(address);
-  const token = useToken(address);
-  const decimal = useDecimal(address);
-  const chainName = useChainName(address);
   const onExtension = useIsExtensionPopup();
 
   const [myContributions, setMyContributions] = useState<Map<string, Balance> | undefined>();
@@ -357,7 +351,7 @@ export default function CrowdLoans(): React.ReactElement {
                 >
                   {t<string>('No contribution yet.')}
                 </Warning>
-                <Typography fontWeight={400} fontSize='14px' p='7px 41px' align='center'>
+                <Typography align='center' fontSize='14px' fontWeight={400} p='7px 41px'>
                   {t('You can find Crowdloans to contribute by clicking on “Active” button below.')}
                 </Typography>
               </Grid>
@@ -448,7 +442,8 @@ export default function CrowdLoans(): React.ReactElement {
                   : theme.palette.mode === 'light'
                     ? crowdloanHomeBlack as string
                     : crowdloanHomeWhite as string}
-              sx={{ height: '35px' }} />
+              sx={{ height: '35px' }}
+            />
           }
           onClick={showMyContribution}
           textSelected={itemShow === TAB_MAP.MY_CONTRIBUTION}
@@ -484,7 +479,8 @@ export default function CrowdLoans(): React.ReactElement {
                   : theme.palette.mode === 'light'
                     ? auctionBlack as string
                     : auctionWhite as string}
-              sx={{ height: '35px' }} />}
+              sx={{ height: '35px' }}
+            />}
           onClick={showAuction}
           textSelected={itemShow === TAB_MAP.AUCTION}
           title={t<string>('Auction')}
@@ -501,7 +497,8 @@ export default function CrowdLoans(): React.ReactElement {
                     ? pastCrowdloanBlack as string
                     : pastCrowdloanWhite as string
               }
-              sx={{ height: '35px' }} />}
+              sx={{ height: '35px' }}
+            />}
           onClick={showPastCrowdloans}
           textSelected={itemShow === TAB_MAP.PAST_CROWDLOANS}
           title={t<string>('Past')}

--- a/packages/extension-polkagate/src/popup/manageProxies/index.tsx
+++ b/packages/extension-polkagate/src/popup/manageProxies/index.tsx
@@ -11,14 +11,19 @@ import { useParams } from 'react-router-dom';
 import { BN, BN_ZERO } from '@polkadot/util';
 
 import { ActionContext, PButton, ProxyTable, ShowBalance } from '../../components';
-import { useAccount, useApi, useMetadata, useTranslation } from '../../hooks';
+import { useInfo, useTranslation } from '../../hooks';
 import { HeaderBrand } from '../../partials';
 import { Proxy, ProxyItem } from '../../util/types';
 import { getFormattedAddress } from '../../util/utils';
 import AddProxy from './AddProxy';
 import Review from './Review';
 
-export default function ManageProxies(): React.ReactElement {
+export default function ManageProxies (): React.ReactElement {
+  const { t } = useTranslation();
+  const onAction = useContext(ActionContext);
+  const { address } = useParams<{ address: string }>();
+  const { account, api, chain } = useInfo(address);
+
   const [proxyItems, setProxyItems] = useState<ProxyItem[] | undefined>();
   const [showAddProxy, setShowAddProxy] = useState<boolean>(false);
   const [showReviewProxy, setShowReviewProxy] = useState<boolean>(false);
@@ -28,13 +33,6 @@ export default function ManageProxies(): React.ReactElement {
   const [disableAddProxyButton, setEnableAddProxyButton] = useState<boolean>(true);
   const [disableToConfirmButton, setEnableToConfirmButton] = useState<boolean>(true);
   const [available, setAvailable] = useState<number>(0);
-
-  const onAction = useContext(ActionContext);
-  const { t } = useTranslation();
-  const { address } = useParams<{ address: string; }>();
-  const account = useAccount(address);
-  const chain = useMetadata(account?.genesisHash, true);
-  const api = useApi(account?.address);
 
   const proxyDepositBase = api ? api.consts.proxy.proxyDepositBase as unknown as BN : BN_ZERO;
   const proxyDepositFactor = api ? api.consts.proxy.proxyDepositFactor as unknown as BN : BN_ZERO;


### PR DESCRIPTION
closes #1266 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced several components such as `NewAddress`, `RemoteNodeSelector`, `ManageProxies`, and `Crowdloans` by centralizing data access through a new `useInfo` hook for a more streamlined codebase.
- **Style**
	- Updated layout and styling in the `Crowdloans` component for improved visual presentation.
- **Bug Fixes**
	- Addressed minor display issues in components due to previous hook implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->