### PR TITLE
truncate sub ID name to 32 bytes

### DIFF
--- a/packages/extension-polkagate/src/fullscreen/manageIdentity/partial/SubIdForm.tsx
+++ b/packages/extension-polkagate/src/fullscreen/manageIdentity/partial/SubIdForm.tsx
@@ -12,6 +12,7 @@ import { Chain } from '@polkadot/extension-chains/types';
 
 import { InputWithLabel } from '../../../components';
 import { useTranslation } from '../../../components/translate';
+import { truncString32Bytes } from '../../../util/utils';
 import SubIdInput from '../component/SubIdInput';
 
 interface Props {
@@ -32,7 +33,7 @@ export default function SubIdForm ({ address, addressesToSelect, api, chain, err
   const theme = useTheme();
 
   const onNameChange = useCallback((value: string | null) => {
-    setSubName && setSubName(value, index);
+    setSubName && setSubName(truncString32Bytes(value), index);
   }, [index, setSubName]);
 
   const onAddressChange = useCallback((value: string | null) => {
@@ -69,7 +70,7 @@ export default function SubIdForm ({ address, addressesToSelect, api, chain, err
             />
           </Grid>
           <Typography fontSize='16px' fontWeight={400} sx={{ textDecoration: 'underline' }}>
-            {t<string>('Remove')}
+            {t('Remove')}
           </Typography>
         </Grid>
       </Grid>

--- a/packages/extension-polkagate/src/util/utils.ts
+++ b/packages/extension-polkagate/src/util/utils.ts
@@ -376,3 +376,20 @@ export const isUrl = (input: string | undefined) => {
 export const pgBoxShadow = (theme: Theme): string => theme.palette.mode === 'dark' ? '0px 4px 4px rgba(255, 255, 255, 0.25)' : '2px 3px 4px 0px rgba(0, 0, 0, 0.10)';
 
 export const noop = () => null;
+
+export const truncString32Bytes = (input: string | null | undefined): string | null | undefined => {
+  if (!input) {
+    return input;
+  }
+
+  const encoder = new TextEncoder();
+  let byteLength = encoder.encode(input).length;
+  let inputVal = input;
+
+  while (byteLength > 32) {
+    inputVal = inputVal.substring(0, inputVal.length - 1);
+    byteLength = encoder.encode(inputVal).length;
+  }
+
+  return inputVal;
+};


### PR DESCRIPTION
Close #1275 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the identity management feature to automatically truncate names to 32 bytes for consistency.
- **Refactor**
  - Improved localization by updating translation methods for better user interface consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->