### PR TITLE
add stake bar

### DIFF
--- a/packages/extension-polkagate/src/fullscreen/stake/partials/DisplayBalance.tsx
+++ b/packages/extension-polkagate/src/fullscreen/stake/partials/DisplayBalance.tsx
@@ -8,7 +8,7 @@ import type { Balance } from '@polkadot/types/interfaces';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { ArrowForwardIosRounded as ArrowForwardIosRoundedIcon } from '@mui/icons-material';
-import { Collapse, Divider, Grid, Typography, useTheme } from '@mui/material';
+import { Box, Collapse, Divider, Grid, Typography, useTheme } from '@mui/material';
 import React, { useCallback, useMemo, useState } from 'react';
 
 import { useTranslation } from '@polkadot/extension-polkagate/src/components/translate';
@@ -71,13 +71,27 @@ export default function DisplayBalance ({ actions, address, amount, icons, isUns
   const [showUnstaking, setShowUnstaking] = useState<boolean>(false);
 
   const isDarkTheme = useMemo(() => theme.palette.mode === 'dark', [theme.palette]);
+  const triangleColor = useMemo(() => {
+    switch (title) {
+      case (t('Staked')):
+        return theme.palette.aye.main;
+      case (t('Redeemable')):
+        return theme.palette.approval.main;
+      case (t('Unstaking')):
+        return theme.palette.support.main;
+      case (t('Available to stake')):
+        return theme.palette.warning.main;
+      default:
+        return undefined;
+    }
+  }, [t, theme, title]);
 
   const toggleShowUnstaking = useCallback(() => {
     toBeReleased?.length && setShowUnstaking(!showUnstaking);
   }, [showUnstaking, toBeReleased?.length]);
 
   return (
-    <Grid alignItems='center' container item justifyContent='space-between' sx={{ bgcolor: 'background.paper', border: isDarkTheme ? '1px solid' : 'none', borderColor: 'secondary.light', borderRadius: '5px', boxShadow: '2px 3px 4px 0px rgba(0, 0, 0, 0.1)', mt: { marginTop }, p: '5px 30px' }}>
+    <Grid alignItems='center' container item justifyContent='space-between' sx={{ bgcolor: 'background.paper', border: isDarkTheme ? '1px solid' : 'none', borderColor: isDarkTheme ? 'secondary.light' : undefined, borderRadius: '5px', boxShadow: '2px 3px 4px 0px rgba(0, 0, 0, 0.1)', mt: { marginTop }, p: '5px 30px', position: 'relative' }}>
       <Grid alignItems='center' container item justifyContent='space-between' sx={{ minHeight: '67px' }}>
         <Typography fontSize='18px' fontWeight={400} width='28%'>
           {title}
@@ -148,6 +162,25 @@ export default function DisplayBalance ({ actions, address, amount, icons, isUns
           toBeReleased={toBeReleased}
           token={token}
         />}
+      {amount && !amount.isZero() &&
+      <Box
+        sx={{
+          '&::before': {
+            borderBottom: `20px solid ${triangleColor}`,
+            borderBottomLeftRadius: '20%',
+            borderRight: '20px solid transparent',
+            bottom: 0,
+            content: '""',
+            height: 0,
+            left: 0,
+            position: 'absolute',
+            width: 0
+          },
+          bottom: 0,
+          left: 0,
+          position: 'absolute'
+        }}
+      />}
     </Grid>
   );
 }

--- a/packages/extension-polkagate/src/fullscreen/stake/pool/PoolStaked.tsx
+++ b/packages/extension-polkagate/src/fullscreen/stake/pool/PoolStaked.tsx
@@ -23,6 +23,7 @@ import { STAKING_CHAINS } from '../../../util/constants';
 import Bread from '../../partials/Bread';
 import { Title } from '../../sendFund/InputPage';
 import DisplayBalance from '../partials/DisplayBalance';
+import StakedBar from '../solo/StakedBar';
 import ClaimedRewardsChart from './partials/ClaimedRewardsChart';
 import Info from './partials/Info';
 import PoolCommonTasks from './partials/PoolCommonTasks';
@@ -47,6 +48,7 @@ export default function PoolStaked ({ address, balances, pool, redeemable, setSh
 
   const staked = useMemo(() => pool === undefined ? undefined : new BN(pool?.member?.points ?? 0), [pool]);
   const claimable = useMemo(() => pool === undefined ? undefined : new BN(pool?.myClaimable ?? 0), [pool]);
+  const availableBalance = useMemo(() => getValue('available', balances), [balances]);
 
   const onUnstake = useCallback(() => {
     staked && !staked?.isZero() && setShow(MODAL_IDS.UNSTAKE);
@@ -85,6 +87,13 @@ export default function PoolStaked ({ address, balances, pool, redeemable, setSh
       />
       <Grid container item justifyContent='space-between' mb='15px'>
         <Grid container direction='column' item mb='10px' minWidth='735px' rowGap='10px' width='calc(100% - 320px - 3%)'>
+          <StakedBar
+            availableBalance={availableBalance}
+            balances={balances}
+            redeemable={redeemable}
+            staked={staked}
+            unlockingAmount={unlockingAmount}
+          />
           <Grid container item sx={{ overflowY: 'scroll' }}>
             <DisplayBalance
               actions={[t('unstake')]}
@@ -122,7 +131,7 @@ export default function PoolStaked ({ address, balances, pool, redeemable, setSh
               actions={[staked && !staked.isZero() ? t('stake extra') : t('stake')]}
               address={address}
               /** to disable action button until fetching has done */
-              amount={!staked || !redeemable || !unlockingAmount ? undefined : getValue('available', balances)}
+              amount={!staked || !redeemable || !unlockingAmount ? undefined : availableBalance}
               icons={[faPlus]}
               onClicks={[onStakeOrExtra]}
               title={t('Available to stake')}

--- a/packages/extension-polkagate/src/fullscreen/stake/solo/StakedBar.tsx
+++ b/packages/extension-polkagate/src/fullscreen/stake/solo/StakedBar.tsx
@@ -1,0 +1,71 @@
+// Copyright 2019-2024 @polkadot/extension-polkagate authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+/* eslint-disable react/jsx-max-props-per-line */
+
+import { Box, Grid, Tooltip, useTheme } from '@mui/material';
+import React, { useMemo } from 'react';
+
+import { useTranslation } from '@polkadot/extension-polkagate/src/components/translate';
+import { getValue } from '@polkadot/extension-polkagate/src/popup/account/util';
+import { BalancesInfo } from '@polkadot/extension-polkagate/src/util/types';
+import { BN, BN_HUNDRED, BN_ZERO } from '@polkadot/util';
+
+interface Props {
+  availableBalance: BN | undefined;
+  unlockingAmount: BN | undefined;
+  redeemable: BN | undefined;
+  staked: BN | undefined;
+  balances: BalancesInfo | undefined
+}
+
+export default function StakedBar ({ availableBalance, balances, redeemable, staked, unlockingAmount }: Props): React.ReactElement {
+  const { t } = useTranslation();
+  const theme = useTheme();
+
+  const total = useMemo(() => getValue('total', balances), [balances]);
+
+  const stakedPercent = useMemo(() => total ? Number(staked) * 100 / Number(total) : undefined, [staked, total]);
+  const redeemablePercent = useMemo(() => total && redeemable ? Number(redeemable) * 100 / Number(total) : undefined, [redeemable, total]);
+  const unlockingPercent = useMemo(() => total && unlockingAmount ? Number(unlockingAmount) * 100 / Number(total) : undefined, [total, unlockingAmount]);
+  const availablePercent = useMemo(() => total && availableBalance ? Number(availableBalance) * 100 / Number(total) : undefined, [availableBalance, total]);
+  const reminderPercent = useMemo(() =>
+    Number((total || BN_HUNDRED).sub((availableBalance || BN_ZERO).add(staked || BN_ZERO).add(redeemable || BN_ZERO).add(unlockingAmount || BN_ZERO))) * 100 / Number(total)
+  , [availableBalance, redeemable, staked, total, unlockingAmount]);
+
+  const Bar = ({ bgcolor, percent, tooltipText }: {bgcolor?: string, tooltipText?: string, percent?: number}) => (
+    <Tooltip placement='top-end' title={tooltipText || ''}>
+      <Box bgcolor={bgcolor} height='5px' width={percent ? `${percent}%` : undefined} />
+    </Tooltip>
+  );
+
+  return (
+    <Grid container item>
+      <Bar
+        bgcolor={theme.palette.aye.main}
+        percent ={stakedPercent }
+        tooltipText={t('Staked')}
+      />
+      <Bar
+        bgcolor={theme.palette.approval.main}
+        percent ={redeemablePercent}
+        tooltipText={t('Redeemable')}
+      />
+      <Bar
+        bgcolor={theme.palette.support.main}
+        percent ={unlockingPercent }
+        tooltipText={t('Unstaking')}
+      />
+      <Bar
+        bgcolor={theme.palette.warning.main}
+        percent ={availablePercent}
+        tooltipText={t('Available to stake')}
+      />
+      <Bar
+        bgcolor={theme.palette.action.disabled}
+        percent ={reminderPercent }
+        tooltipText={t('Others')}
+      />
+    </Grid>
+  );
+}

--- a/packages/extension-polkagate/src/fullscreen/stake/solo/StakedSolo.tsx
+++ b/packages/extension-polkagate/src/fullscreen/stake/solo/StakedSolo.tsx
@@ -21,6 +21,7 @@ import ActiveValidators from './partials/ActiveValidators';
 import CommonTasks from './partials/CommonTasks';
 import Info from './partials/Info';
 import RewardsChart from './partials/RewardsChart';
+import StakedBar from './StakedBar';
 import { MODAL_IDS } from '.';
 
 interface SessionIfo {
@@ -130,6 +131,13 @@ export default function StakedSolo ({ balances, setRefresh, setShow, stakingAcco
       />
       <Grid container item justifyContent='space-between' mb='15px'>
         <Grid container direction='column' item mb='10px' minWidth='715px' rowGap='10px' width='calc(100% - 320px - 3%)'>
+          <StakedBar
+            availableBalance={availableToSoloStake}
+            balances={balances}
+            redeemable={redeemable}
+            staked={staked}
+            unlockingAmount={unlockingAmount}
+          />
           <Grid container item>
             <DisplayBalance
               actions={[t('unstake'), t('fast unstake')]}


### PR DESCRIPTION
closes  #1216

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a `StakedBar` component to visualize various stake-related percentages using colored bars.
  - Added detailed staking information display in `StakedSolo` using the new `StakedBar` component.

- **Enhancements**
  - Improved balance calculations with new visual indicators for staked, redeemable, unlocking, and available amounts.
  - Enhanced styling for better readability and visual appeal in balance display sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->