### PR TITLE
Add import proxied to extension mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@vaadin/icons": "^23.2.3",
     "babel-plugin-transform-import-meta": "^2.1.1",
     "better-react-spinkit": "^2.0.4",
+    "chance": "^1.1.11",
     "chart.js": "^4.2.1",
     "country-flag-icons": "^1.5.9",
     "css-loader": "^6.7.3",

--- a/packages/extension-polkagate/src/components/Progress.tsx
+++ b/packages/extension-polkagate/src/components/Progress.tsx
@@ -10,10 +10,11 @@ interface Props {
   title?: string;
   pt?: number | string;
   size?: number;
+  gridSize?: number;
   type?: 'circle' | 'cubes' | 'grid';
 }
 
-function Progress({ fontSize = 13, pt = '50px', size = 25, title, type = 'circle' }: Props): React.ReactElement<Props> {
+function Progress ({ fontSize = 13, gridSize = 135, pt = '50px', size = 25, title, type = 'circle' }: Props): React.ReactElement<Props> {
   const theme = useTheme();
 
   return (
@@ -46,7 +47,7 @@ function Progress({ fontSize = 13, pt = '50px', size = 25, title, type = 'circle
           col={3}
           color={theme.palette.secondary.main}
           row={3}
-          size={135}
+          size={gridSize}
           style={{ margin: 'auto', opacity: '0.4' }}
         />
       }

--- a/packages/extension-polkagate/src/components/Select.tsx
+++ b/packages/extension-polkagate/src/components/Select.tsx
@@ -5,7 +5,7 @@
 
 import { Avatar, FormControl, Grid, InputBase, MenuItem, Select, SelectChangeEvent, Typography } from '@mui/material';
 import { styled, useTheme } from '@mui/material/styles';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 import { CHAINS_WITH_BLACK_LOGO } from '@polkadot/extension-polkagate/src/util/constants';
 
@@ -25,13 +25,16 @@ interface Props {
   _mt?: string | number;
   helperText?: string;
   disabledItems?: string[] | number[];
+  fullWidthDropdown?: boolean;
 }
 
-function CustomizedSelect({ _mt = 0, defaultValue, disabledItems, helperText, isDisabled = false, label, onChange, options, showLogo = false, value }: Props) {
+function CustomizedSelect({ _mt = 0, defaultValue, disabledItems, fullWidthDropdown, helperText, isDisabled = false, label, onChange, options, showLogo = false, value }: Props) {
   const theme = useTheme();
 
   const [showMenu, setShowMenu] = useState<boolean>(false);
   const [selectedValue, setSelectedValue] = useState<string | number>();
+
+  const selectRef = useRef();
 
   useEffect(() => {
     setSelectedValue(value || defaultValue);
@@ -108,7 +111,7 @@ function CustomizedSelect({ _mt = 0, defaultValue, disabledItems, helperText, is
                 borderColor: 'secondary.light',
                 borderRadius: '7px',
                 filter: 'drop-shadow(-4px 4px 4px rgba(0, 0, 0, 0.15))',
-                mt: '10px',
+                mt: '5px',
                 overflow: 'hidden',
                 overflowY: 'scroll'
               }
@@ -120,6 +123,7 @@ function CustomizedSelect({ _mt = 0, defaultValue, disabledItems, helperText, is
           onChange={_onChange}
           onClick={toggleMenu}
           open={showMenu}
+          ref={selectRef}
           // eslint-disable-next-line react/jsx-no-bind
           renderValue={(value) => {
             const textToShow = options.find((option) => value === option.value || value === option.text)?.text;
@@ -155,7 +159,7 @@ function CustomizedSelect({ _mt = 0, defaultValue, disabledItems, helperText, is
             <MenuItem
               disabled={disabledItems?.includes(value) || disabledItems?.includes(text)}
               key={value}
-              sx={{ fontSize: '14px', fontWeight: 300, letterSpacing: '-0.015em' }}
+              sx={{ fontSize: '14px', fontWeight: 300, letterSpacing: '-0.015em', width: fullWidthDropdown ? `${selectRef?.current?.offsetWidth}px` : 'auto' }}
               value={value || text}
             >
               <Grid container height={showLogo ? '32px' : 'auto'} justifyContent='space-between'>

--- a/packages/extension-polkagate/src/components/SelectChain.tsx
+++ b/packages/extension-polkagate/src/components/SelectChain.tsx
@@ -28,9 +28,10 @@ interface Props {
   icon?: string;
   style: SxProps<Theme> | undefined;
   disabledItems?: string[] | number[];
+  fullWidthDropdown?: boolean;
 }
 
-function SelectChain({ address, defaultValue, disabledItems, icon = undefined, label, onChange, options, style }: Props) {
+function SelectChain({ address, defaultValue, disabledItems, fullWidthDropdown, icon = undefined, label, onChange, options, style }: Props) {
   const currentChainName = useChainName(address !== 'dummy' ? address : undefined);
   const theme = useTheme();
   const isTestnetEnabled = useIsTestnetEnabled();
@@ -85,6 +86,7 @@ function SelectChain({ address, defaultValue, disabledItems, icon = undefined, l
         <Select
           defaultValue={defaultValue}
           disabledItems={_disabledItems}
+          fullWidthDropdown={fullWidthDropdown}
           isDisabled={!address}
           label={label}
           onChange={onChangeNetwork}

--- a/packages/extension-polkagate/src/components/SelectChain.tsx
+++ b/packages/extension-polkagate/src/components/SelectChain.tsx
@@ -3,6 +3,8 @@
 
 /* eslint-disable react/jsx-max-props-per-line */
 
+import { faQuestion } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Avatar, Grid, SxProps, Theme, useTheme } from '@mui/material';
 import React, { useCallback, useMemo } from 'react';
 
@@ -93,7 +95,13 @@ function SelectChain({ address, defaultValue, disabledItems, icon = undefined, l
       <Grid item sx={{ ml: '10px', width: 'fit-content' }}>
         {icon
           ? <Avatar src={icon} sx={{ filter: (CHAINS_WITH_BLACK_LOGO.includes(currentChainName) && theme.palette.mode === 'dark') ? 'invert(1)' : '', borderRadius: '50%', height: 31, width: 31 }} variant='square' />
-          : <Grid sx={{ bgcolor: 'action.disabledBackground', border: '1px solid', borderColor: 'secondary.light', borderRadius: '50%', height: '31px', width: '31px' }}>
+          : <Grid sx={{ bgcolor: 'divider', border: '1px solid', borderColor: 'secondary.light', borderRadius: '50%', height: '31px', width: '31px' }}>
+            <FontAwesomeIcon
+              color={theme.palette.secondary.light}
+              fontSize='22px'
+              icon={faQuestion}
+              style={{ paddingLeft: '8px', paddingTop: '4px' }}
+            />
           </Grid>
         }
       </Grid>

--- a/packages/extension-polkagate/src/fullscreen/homeFullScreen/partials/ImportAccSubMenuFullScreen.tsx
+++ b/packages/extension-polkagate/src/fullscreen/homeFullScreen/partials/ImportAccSubMenuFullScreen.tsx
@@ -5,6 +5,8 @@
 
 import '@vaadin/icons';
 
+import { faSitemap } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { ArrowForwardIos as ArrowForwardIosIcon } from '@mui/icons-material';
 import { Collapse, Grid, useTheme } from '@mui/material';
 import React, { useCallback } from 'react';
@@ -34,6 +36,10 @@ function ImportAccSubMenuFullScreen ({ show, toggleSettingSubMenu }: Props): Rea
 
   const onAddWatchOnlyFullScreen = useCallback(() => {
     openOrFocusTab('/import/add-watch-only-full-screen');
+  }, []);
+
+  const onImportProxiedFullScreen = useCallback(() => {
+    openOrFocusTab('/import/proxied-full-screen');
   }, []);
 
   const onAttachQrFullScreen = useCallback(() => {
@@ -71,6 +77,19 @@ function ImportAccSubMenuFullScreen ({ show, toggleSettingSubMenu }: Props): Rea
             isSubMenu
             onClick={onAddWatchOnlyFullScreen}
             text={t('Add watch-only account')}
+          />
+          <TaskButton
+            icon={
+              <FontAwesomeIcon
+                color={theme.palette.text.primary}
+                fontSize='18px'
+                icon={faSitemap}
+                style={{ transform: 'rotate(180deg)' }}
+              />
+            }
+            isSubMenu
+            onClick={onImportProxiedFullScreen}
+            text={t('Import proxied accounts')}
           />
           <TaskButton
             disabled={settings.camera !== 'on'}

--- a/packages/extension-polkagate/src/hooks/index.ts
+++ b/packages/extension-polkagate/src/hooks/index.ts
@@ -98,3 +98,4 @@ export { default as useActiveEraIndex } from './useActiveEraIndex';
 export { default as useIsValidator } from './useIsValidator';
 export { default as useUnstakingAmount } from './useUnstakingAmount';
 export { default as useAvailableToSoloStake } from './useAvailableToSoloStake';
+export { default as useProxiedAccounts } from './useProxiedAccounts';

--- a/packages/extension-polkagate/src/hooks/useProxiedAccounts.ts
+++ b/packages/extension-polkagate/src/hooks/useProxiedAccounts.ts
@@ -1,0 +1,61 @@
+// Copyright 2019-2024 @polkadot/extension-polkagate authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import { useCallback, useEffect, useState } from 'react';
+
+import { Chain } from '@polkadot/extension-chains/types';
+
+import { ProxiedAccounts, Proxy } from '../util/types';
+import { getFormattedAddress } from '../util/utils';
+import useApiWithChain from './useApiWithChain';
+
+/**
+ * @description
+ * this hook returns proxied accounts on a proxy account
+ * */
+
+export default function useProxiedAccounts (address: string | undefined, chain: Chain | null | undefined): ProxiedAccounts | undefined {
+  const api = useApiWithChain(chain);
+  const formatted = address && getFormattedAddress(address, chain, 42);
+
+  const [proxied, setProxied] = useState<ProxiedAccounts>();
+
+  const getProxiedAccounts = useCallback(() => {
+    api && api.query.proxy?.proxies.entries().then((proxies) => {
+      if (proxies.length === 0) {
+        return;
+      }
+
+      const proxiedAccounts: string[] = [];
+
+      for (let index = 0; index < proxies.length; index++) {
+        const proxy = proxies[index];
+
+        const fetchedProxy = JSON.parse(JSON.stringify(proxy[1][0])) as Proxy[];
+
+        const found = fetchedProxy.find(({ delegate }) => delegate === formatted);
+
+        found && proxiedAccounts.push(...proxy[0].toHuman() as string);
+      }
+
+      setProxied({
+        proxied: proxiedAccounts,
+        proxy: formatted
+      });
+    }).catch(console.error);
+  }, [api, formatted]);
+
+  useEffect(() => {
+    if (!address || !chain || !api || !formatted || (proxied && proxied.proxy === formatted)) {
+      return;
+    }
+
+    if (proxied && proxied.proxy !== formatted) {
+      setProxied(undefined);
+    }
+
+    getProxiedAccounts();
+  }, [address, api, chain, formatted, getProxiedAccounts, proxied]);
+
+  return proxied;
+}

--- a/packages/extension-polkagate/src/hooks/useProxiedAccounts.ts
+++ b/packages/extension-polkagate/src/hooks/useProxiedAccounts.ts
@@ -3,20 +3,16 @@
 
 import { useCallback, useEffect, useState } from 'react';
 
-import { Chain } from '@polkadot/extension-chains/types';
-
 import { ProxiedAccounts, Proxy } from '../util/types';
-import { getFormattedAddress } from '../util/utils';
-import useApiWithChain from './useApiWithChain';
+import useInfo from './useInfo';
 
 /**
  * @description
- * this hook returns proxied accounts on a proxy account
+ * this hook returns proxied accounts of a proxy account
  * */
 
-export default function useProxiedAccounts (address: string | undefined, chain: Chain | null | undefined): ProxiedAccounts | undefined {
-  const api = useApiWithChain(chain);
-  const formatted = address && getFormattedAddress(address, chain, 42);
+export default function useProxiedAccounts (address: string | undefined): ProxiedAccounts | undefined {
+  const { api, formatted } = useInfo(address);
 
   const [proxied, setProxied] = useState<ProxiedAccounts>();
 
@@ -46,7 +42,7 @@ export default function useProxiedAccounts (address: string | undefined, chain: 
   }, [api, formatted]);
 
   useEffect(() => {
-    if (!address || !chain || !api || !formatted || (proxied && proxied.proxy === formatted)) {
+    if (!address || !api || !formatted || (proxied && proxied.proxy === formatted)) {
       return;
     }
 
@@ -55,7 +51,7 @@ export default function useProxiedAccounts (address: string | undefined, chain: 
     }
 
     getProxiedAccounts();
-  }, [address, api, chain, formatted, getProxiedAccounts, proxied]);
+  }, [address, api, formatted, getProxiedAccounts, proxied]);
 
   return proxied;
 }

--- a/packages/extension-polkagate/src/partials/ImportAccSubMenu.tsx
+++ b/packages/extension-polkagate/src/partials/ImportAccSubMenu.tsx
@@ -5,6 +5,8 @@
 
 import '@vaadin/icons';
 
+import { faSitemap } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { ArrowForwardIos as ArrowForwardIosIcon } from '@mui/icons-material';
 import { Collapse, Divider, Grid, useTheme } from '@mui/material';
 import React, { useCallback, useContext } from 'react';
@@ -45,6 +47,10 @@ function ImportAccSubMenu ({ show, toggleSettingSubMenu }: Props): React.ReactEl
     windowOpen('/account/import-ledger').catch(console.error);
   }, []);
 
+  const onImportProxied = useCallback((): void => {
+    onAction('/import/proxied');
+  }, [onAction]);
+
   return (
     <Collapse easing={{ enter: '200ms', exit: '100ms' }} in={show} sx={{ width: '100%' }}>
       <Grid container item>
@@ -78,6 +84,21 @@ function ImportAccSubMenu ({ show, toggleSettingSubMenu }: Props): React.ReactEl
             onClick={onAddWatchOnly}
             py='4px'
             text={t('Add watch-only account')}
+            withHoverEffect
+          />
+          <MenuItem
+            fontSize='17px'
+            iconComponent={
+              <FontAwesomeIcon
+                color={theme.palette.text.primary}
+                fontSize='18px'
+                icon={faSitemap}
+                style={{ transform: 'rotate(180deg)' }}
+              />
+            }
+            onClick={onImportProxied}
+            py='4px'
+            text={t('Import proxied account(s)')}
             withHoverEffect
           />
           <MenuItem

--- a/packages/extension-polkagate/src/popup/import/importProxied/ProxiedTable.tsx
+++ b/packages/extension-polkagate/src/popup/import/importProxied/ProxiedTable.tsx
@@ -1,0 +1,121 @@
+// Copyright 2019-2024 @polkadot/extension-polkagate authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+/* eslint-disable react/jsx-max-props-per-line */
+
+import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Checkbox, FormControlLabel, Grid, SxProps, Theme, Typography } from '@mui/material';
+import React, { useCallback } from 'react';
+
+import { ApiPromise } from '@polkadot/api';
+import { Chain } from '@polkadot/extension-chains/types';
+
+import { Identity, Label, Progress } from '../../../components';
+import { useTranslation } from '../../../hooks';
+
+interface Props {
+  api: ApiPromise | undefined;
+  chain: Chain | undefined;
+  label: string;
+  style?: SxProps<Theme>;
+  maxHeight?: string;
+  minHeight?: string;
+  proxiedAccounts: string[] | null | undefined;
+  selectedProxied: string[];
+  setSelectedProxied: React.Dispatch<React.SetStateAction<string[]>>
+}
+
+export default function ProxiedTable ({ api, chain, label, maxHeight = '120px', minHeight = '70px', proxiedAccounts, selectedProxied, setSelectedProxied, style }: Props): React.ReactElement {
+  const { t } = useTranslation();
+
+  // const isAvailable = useCallback((proxy: Proxy): NameAddress | undefined =>
+  //   accounts?.find((a) => a.address === getSubstrateAddress(proxy.delegate) && (proxyTypeFilter ? proxyTypeFilter.includes(proxy.proxyType) : true))
+  //   , [accounts, proxyTypeFilter]);
+
+  console.log('proxiedAccounts:', proxiedAccounts);
+
+  const handleSelect = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    const proxied = proxiedAccounts && proxiedAccounts[Number(event.target.value)];
+    const alreadyAdded = selectedProxied.includes(proxied as string);
+
+    if (proxied && alreadyAdded) {
+      setSelectedProxied(selectedProxied.filter((selected) => selected !== proxied));
+    } else if (proxied && !alreadyAdded) {
+      setSelectedProxied([...selectedProxied, proxied]);
+    }
+  }, [proxiedAccounts, selectedProxied, setSelectedProxied]);
+
+  const Select = ({ index, proxied }: { proxied: string, index: number }) => (
+    <FormControlLabel
+      checked={selectedProxied.includes(proxied)}
+      control={
+        <Checkbox
+          onChange={handleSelect}
+          size='medium'
+          sx={{ '&.Mui-disabled': { color: 'text.disabled' }, color: 'secondary.main' }}
+          value={index}
+        />
+      }
+      label=''
+      sx={{ m: 'auto' }}
+      value={index}
+    />
+  );
+
+  // const fade = (toCheck: ProxyItem) => {
+  //   if (mode === 'Delete') {
+  //     return (toCheck.status === 'remove');
+  //   }
+
+  //   if (mode === 'Availability' || mode === 'Select') {
+  //     return !(isAvailable(toCheck.proxy));
+  //   }
+
+  //   return false;
+  // };
+
+  return (
+    <Grid container item sx={{ ...style }}>
+      <Label label={label} style={{ fontWeight: 300, position: 'relative', width: '100%' }}>
+        <Grid container direction='column' item sx={{ '> div:not(:last-child:not(:only-child))': { borderBottom: '1px solid', borderBottomColor: 'secondary.light' }, bgcolor: 'background.paper', border: '1px solid', borderColor: 'secondary.light', borderRadius: '5px', display: 'block', maxHeight, minHeight, overflowY: 'scroll', textAlign: 'center' }}>
+          <Grid container item sx={{ '> div:not(:last-child)': { borderRight: '1px solid', borderRightColor: 'secondary.light' }, textAlign: 'center' }}>
+            <Grid container item xs={10}>
+              <Typography fontSize='12px' fontWeight={300} lineHeight='25px' pl='20px'>
+                {t('Account')}
+              </Typography>
+            </Grid>
+            <Grid container item xs={2}>
+              <Typography fontSize='12px' fontWeight={300} lineHeight='25px' sx={{ textAlign: 'center', width: '100%' }}>
+                {t('Select')}
+              </Typography>
+            </Grid>
+          </Grid>
+          {proxiedAccounts === undefined &&
+            <Grid alignItems='center' container justifyContent='center'>
+              <Progress gridSize={75} pt='10px' title={t('Looking for proxied accounts ...')} type='grid' />
+            </Grid>
+          }
+          {(proxiedAccounts === null || (proxiedAccounts && proxiedAccounts.length === 0)) &&
+            <Grid display='inline-flex' p='10px'>
+              <FontAwesomeIcon className='warningImage' icon={faExclamationTriangle} />
+              <Typography fontSize='12px' fontWeight={400} lineHeight='20px' pl='8px'>
+                {t('This isn\'t a proxy account on {{chainName}}!', { replace: { chainName: chain?.name } })}
+              </Typography>
+            </Grid>
+          }
+          {proxiedAccounts && proxiedAccounts.length > 0 && proxiedAccounts.map((proxiedAccount, index) =>
+            <Grid container item key={index} sx={{ '> div:not(:last-child)': { borderRight: '1px solid', borderRightColor: 'secondary.light' }, height: '41px', textAlign: 'center' }}>
+              <Grid alignItems='center' container item justifyContent='left' pl='10px' xs={10}>
+                <Identity api={api} chain={chain} formatted={proxiedAccount} identiconSize={25} showShortAddress showSocial={false} style={{ fontSize: '12px', maxWidth: '100%' }} subIdOnly />
+              </Grid>
+              <Grid alignItems='center' container height='100%' item justifyContent='center' xs={2}>
+                <Select index={index} proxied={proxiedAccount} />
+              </Grid>
+            </Grid>
+          )}
+        </Grid>
+      </Label>
+    </Grid>
+  );
+}

--- a/packages/extension-polkagate/src/popup/import/importProxied/ProxiedTable.tsx
+++ b/packages/extension-polkagate/src/popup/import/importProxied/ProxiedTable.tsx
@@ -3,16 +3,17 @@
 
 /* eslint-disable react/jsx-max-props-per-line */
 
+import { faSquare, faSquareCheck } from '@fortawesome/free-regular-svg-icons';
 import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { Checkbox, FormControlLabel, Grid, SxProps, Theme, Typography } from '@mui/material';
-import React, { useCallback } from 'react';
+import { Button, Checkbox, FormControlLabel, Grid, Skeleton, SxProps, Theme, Typography, useTheme } from '@mui/material';
+import React, { useCallback, useMemo } from 'react';
 
 import { ApiPromise } from '@polkadot/api';
 import { Chain } from '@polkadot/extension-chains/types';
 
 import { Identity, Label, Progress } from '../../../components';
-import { useTranslation } from '../../../hooks';
+import { useIsExtensionPopup, useTranslation } from '../../../hooks';
 
 interface Props {
   api: ApiPromise | undefined;
@@ -28,12 +29,14 @@ interface Props {
 
 export default function ProxiedTable ({ api, chain, label, maxHeight = '120px', minHeight = '70px', proxiedAccounts, selectedProxied, setSelectedProxied, style }: Props): React.ReactElement {
   const { t } = useTranslation();
+  const isExtensionMode = useIsExtensionPopup();
+  const theme = useTheme();
+
+  const isDarkMode = useMemo(() => theme.palette.mode === 'dark', [theme.palette.mode]);
 
   // const isAvailable = useCallback((proxy: Proxy): NameAddress | undefined =>
   //   accounts?.find((a) => a.address === getSubstrateAddress(proxy.delegate) && (proxyTypeFilter ? proxyTypeFilter.includes(proxy.proxyType) : true))
   //   , [accounts, proxyTypeFilter]);
-
-  console.log('proxiedAccounts:', proxiedAccounts);
 
   const handleSelect = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
     const proxied = proxiedAccounts && proxiedAccounts[Number(event.target.value)];
@@ -63,6 +66,29 @@ export default function ProxiedTable ({ api, chain, label, maxHeight = '120px', 
     />
   );
 
+  const onSelect = useCallback((selectAll: boolean) => () => {
+    proxiedAccounts && setSelectedProxied(selectAll ? proxiedAccounts : []);
+  }, [proxiedAccounts, setSelectedProxied]);
+
+  const SelectDeselectButton = ({ allSelected, disable }: { allSelected: boolean, disable?: boolean }) => (
+    <Button
+      disabled={disable}
+      endIcon={
+        <FontAwesomeIcon
+          color={theme.palette.secondary.light}
+          fontSize='20px'
+          icon={allSelected ? faSquare : faSquareCheck}
+        />
+      }
+      onClick={onSelect(!allSelected)}
+      style={{ color: theme.palette.text.primary, textDecoration: 'underline' }}
+      sx={{ '&:hover': { bgcolor: 'unset' }, '&:onclick': { bgcolor: 'unset' }, '> span': { mr: 0 }, fontSize: '14px', fontWeight: 400, p: 0, textTransform: 'none', width: 'fit-content' }}
+      variant='text'
+    >
+      {allSelected ? t('Deselect') : t('Select all')}
+    </Button>
+  );
+
   // const fade = (toCheck: ProxyItem) => {
   //   if (mode === 'Delete') {
   //     return (toCheck.status === 'remove');
@@ -77,45 +103,54 @@ export default function ProxiedTable ({ api, chain, label, maxHeight = '120px', 
 
   return (
     <Grid container item sx={{ ...style }}>
-      <Label label={label} style={{ fontWeight: 300, position: 'relative', width: '100%' }}>
-        <Grid container direction='column' item sx={{ '> div:not(:last-child:not(:only-child))': { borderBottom: '1px solid', borderBottomColor: 'secondary.light' }, bgcolor: 'background.paper', border: '1px solid', borderColor: 'secondary.light', borderRadius: '5px', display: 'block', maxHeight, minHeight, overflowY: 'scroll', textAlign: 'center' }}>
+      <Label label={label} style={{ fontWeight: isExtensionMode ? 300 : 400, position: 'relative', width: '100%' }}>
+        <Grid container direction='column' item sx={{ '> div:not(:last-child:not(:only-child))': { borderBottom: '1px solid', borderBottomColor: 'secondary.light' }, bgcolor: 'background.paper', border: isExtensionMode || isDarkMode ? '1px solid' : 'none', borderColor: 'secondary.light', borderRadius: isExtensionMode ? '5px' : '0px', boxShadow: !isExtensionMode && !isDarkMode ? 'rgba(0, 0, 0, 0.1) 2px 3px 4px 0px' : 'none', display: 'block', maxHeight, minHeight, overflowY: 'scroll', textAlign: 'center' }}>
           <Grid container item sx={{ '> div:not(:last-child)': { borderRight: '1px solid', borderRightColor: 'secondary.light' }, textAlign: 'center' }}>
-            <Grid container item xs={10}>
-              <Typography fontSize='12px' fontWeight={300} lineHeight='25px' pl='20px'>
+            <Grid container item xs={isExtensionMode ? 10 : 11}>
+              <Typography fontSize={isExtensionMode ? '12px' : '14px'} fontWeight={isExtensionMode ? 300 : 400} lineHeight={isExtensionMode ? '25px' : '35px'} pl='20px'>
                 {t('Account')}
               </Typography>
             </Grid>
-            <Grid container item xs={2}>
-              <Typography fontSize='12px' fontWeight={300} lineHeight='25px' sx={{ textAlign: 'center', width: '100%' }}>
+            <Grid container item xs={isExtensionMode ? 2 : 1}>
+              <Typography fontSize={isExtensionMode ? '12px' : '14px'} fontWeight={isExtensionMode ? 300 : 400} lineHeight={isExtensionMode ? '25px' : '35px'} sx={{ textAlign: 'center', width: '100%' }}>
                 {t('Select')}
               </Typography>
             </Grid>
           </Grid>
           {proxiedAccounts === undefined &&
             <Grid alignItems='center' container justifyContent='center'>
-              <Progress gridSize={75} pt='10px' title={t('Looking for proxied accounts ...')} type='grid' />
+              <Progress gridSize={isExtensionMode ? 50 : 90} pt={isExtensionMode ? '10px' : '20px'} title={t('Looking for proxied accounts ...')} type='grid' />
             </Grid>
           }
           {(proxiedAccounts === null || (proxiedAccounts && proxiedAccounts.length === 0)) &&
             <Grid display='inline-flex' p='10px'>
               <FontAwesomeIcon className='warningImage' icon={faExclamationTriangle} />
-              <Typography fontSize='12px' fontWeight={400} lineHeight='20px' pl='8px'>
+              <Typography fontSize={isExtensionMode ? '12px' : '16px'} fontWeight={400} lineHeight='20px' pl='8px'>
                 {t('This isn\'t a proxy account on {{chainName}}!', { replace: { chainName: chain?.name } })}
               </Typography>
             </Grid>
           }
           {proxiedAccounts && proxiedAccounts.length > 0 && proxiedAccounts.map((proxiedAccount, index) =>
-            <Grid container item key={index} sx={{ '> div:not(:last-child)': { borderRight: '1px solid', borderRightColor: 'secondary.light' }, height: '41px', textAlign: 'center' }}>
-              <Grid alignItems='center' container item justifyContent='left' pl='10px' xs={10}>
-                <Identity api={api} chain={chain} formatted={proxiedAccount} identiconSize={25} showShortAddress showSocial={false} style={{ fontSize: '12px', maxWidth: '100%' }} subIdOnly />
+            <Grid container item key={index} sx={{ '> div:not(:last-child)': { borderRight: '1px solid', borderRightColor: 'secondary.light' }, height: isExtensionMode ? '41px' : '50px', textAlign: 'center' }}>
+              <Grid alignItems='center' container item justifyContent='left' pl='10px' xs={isExtensionMode ? 10 : 11}>
+                <Identity api={api} chain={chain} formatted={proxiedAccount} identiconSize={25} showShortAddress showSocial={false} style={{ fontSize: isExtensionMode ? '12px' : '16px', maxWidth: '100%' }} subIdOnly />
               </Grid>
-              <Grid alignItems='center' container height='100%' item justifyContent='center' xs={2}>
+              <Grid alignItems='center' container height='100%' item justifyContent='center' xs={isExtensionMode ? 2 : 1}>
                 <Select index={index} proxied={proxiedAccount} />
               </Grid>
             </Grid>
           )}
         </Grid>
       </Label>
+      <Grid container item justifyContent='space-between' p='5px 10px 0'>
+        {proxiedAccounts
+          ? <Typography fontSize='14px' fontWeight={400}>
+            {t('{{selectedCount}} of {{proxiedCount}} is selected', { replace: { proxiedCount: proxiedAccounts.length, selectedCount: selectedProxied.length } })}
+          </Typography>
+          : <Skeleton animation='wave' height='30px' width='100px' />
+        }
+        <SelectDeselectButton allSelected={selectedProxied.length === proxiedAccounts?.length} disable={!proxiedAccounts} />
+      </Grid>
     </Grid>
   );
 }

--- a/packages/extension-polkagate/src/popup/import/importProxied/ProxiedTable.tsx
+++ b/packages/extension-polkagate/src/popup/import/importProxied/ProxiedTable.tsx
@@ -6,7 +6,7 @@
 import { faSquare, faSquareCheck } from '@fortawesome/free-regular-svg-icons';
 import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { Button, Checkbox, FormControlLabel, Grid, Skeleton, SxProps, Theme, Typography, useTheme } from '@mui/material';
+import { Checkbox, FormControlLabel, Grid, Skeleton, SxProps, Theme, Typography, useTheme } from '@mui/material';
 import React, { useCallback, useMemo } from 'react';
 
 import { ApiPromise } from '@polkadot/api';
@@ -33,6 +33,7 @@ export default function ProxiedTable ({ api, chain, label, maxHeight = '120px', 
   const theme = useTheme();
 
   const isDarkMode = useMemo(() => theme.palette.mode === 'dark', [theme.palette.mode]);
+  const allSelected = useMemo(() => selectedProxied.length === proxiedAccounts?.length, [proxiedAccounts?.length, selectedProxied.length]);
 
   // const isAvailable = useCallback((proxy: Proxy): NameAddress | undefined =>
   //   accounts?.find((a) => a.address === getSubstrateAddress(proxy.delegate) && (proxyTypeFilter ? proxyTypeFilter.includes(proxy.proxyType) : true))
@@ -70,25 +71,6 @@ export default function ProxiedTable ({ api, chain, label, maxHeight = '120px', 
     proxiedAccounts && setSelectedProxied(selectAll ? proxiedAccounts : []);
   }, [proxiedAccounts, setSelectedProxied]);
 
-  const SelectDeselectButton = ({ allSelected, disable }: { allSelected: boolean, disable?: boolean }) => (
-    <Button
-      disabled={disable}
-      endIcon={
-        <FontAwesomeIcon
-          color={theme.palette.secondary.light}
-          fontSize='20px'
-          icon={allSelected ? faSquare : faSquareCheck}
-        />
-      }
-      onClick={onSelect(!allSelected)}
-      style={{ color: theme.palette.text.primary, textDecoration: 'underline' }}
-      sx={{ '&:hover': { bgcolor: 'unset' }, '&:onclick': { bgcolor: 'unset' }, '> span': { mr: 0 }, fontSize: '14px', fontWeight: 400, p: 0, textTransform: 'none', width: 'fit-content' }}
-      variant='text'
-    >
-      {allSelected ? t('Deselect') : t('Select all')}
-    </Button>
-  );
-
   // const fade = (toCheck: ProxyItem) => {
   //   if (mode === 'Delete') {
   //     return (toCheck.status === 'remove');
@@ -103,19 +85,21 @@ export default function ProxiedTable ({ api, chain, label, maxHeight = '120px', 
 
   return (
     <Grid container item sx={{ ...style }}>
-      <Label label={label} style={{ fontWeight: isExtensionMode ? 300 : 400, position: 'relative', width: '100%' }}>
+      <Label label={label} style={{ fontWeight: 400, position: 'relative', width: '100%' }}>
         <Grid container direction='column' item sx={{ '> div:not(:last-child:not(:only-child))': { borderBottom: '1px solid', borderBottomColor: 'secondary.light' }, bgcolor: 'background.paper', border: isExtensionMode || isDarkMode ? '1px solid' : 'none', borderColor: 'secondary.light', borderRadius: isExtensionMode ? '5px' : '0px', boxShadow: !isExtensionMode && !isDarkMode ? 'rgba(0, 0, 0, 0.1) 2px 3px 4px 0px' : 'none', display: 'block', maxHeight, minHeight, overflowY: 'scroll', textAlign: 'center' }}>
-          <Grid container item sx={{ '> div:not(:last-child)': { borderRight: '1px solid', borderRightColor: 'secondary.light' }, textAlign: 'center' }}>
-            <Grid container item xs={isExtensionMode ? 10 : 11}>
-              <Typography fontSize={isExtensionMode ? '12px' : '14px'} fontWeight={isExtensionMode ? 300 : 400} lineHeight={isExtensionMode ? '25px' : '35px'} pl='20px'>
-                {t('Account')}
-              </Typography>
+          <Grid container item sx={{ textAlign: 'center' }}>
+            <Grid alignItems='center' container item width='fit-content'>
+              <Grid alignItems='center' container item onClick={onSelect(!allSelected)} sx={{ cursor: !proxiedAccounts ? 'default' : 'pointer', pl: isExtensionMode ? '18px' : '20px', width: 'fit-content' }}>
+                <FontAwesomeIcon
+                  color={theme.palette.secondary.light}
+                  fontSize='21px'
+                  icon={allSelected ? faSquareCheck : faSquare}
+                />
+              </Grid>
             </Grid>
-            <Grid container item xs={isExtensionMode ? 2 : 1}>
-              <Typography fontSize={isExtensionMode ? '12px' : '14px'} fontWeight={isExtensionMode ? 300 : 400} lineHeight={isExtensionMode ? '25px' : '35px'} sx={{ textAlign: 'center', width: '100%' }}>
-                {t('Select')}
-              </Typography>
-            </Grid>
+            <Typography fontSize={'14px'} fontWeight={isExtensionMode ? 300 : 400} lineHeight={isExtensionMode ? '25px' : '35px'} pl={isExtensionMode ? '30px' : '35px'}>
+              {t('Proxied Account(s)')}
+            </Typography>
           </Grid>
           {proxiedAccounts === undefined &&
             <Grid alignItems='center' container justifyContent='center'>
@@ -131,12 +115,12 @@ export default function ProxiedTable ({ api, chain, label, maxHeight = '120px', 
             </Grid>
           }
           {proxiedAccounts && proxiedAccounts.length > 0 && proxiedAccounts.map((proxiedAccount, index) =>
-            <Grid container item key={index} sx={{ '> div:not(:last-child)': { borderRight: '1px solid', borderRightColor: 'secondary.light' }, height: isExtensionMode ? '41px' : '50px', textAlign: 'center' }}>
-              <Grid alignItems='center' container item justifyContent='left' pl='10px' xs={isExtensionMode ? 10 : 11}>
-                <Identity api={api} chain={chain} formatted={proxiedAccount} identiconSize={25} showShortAddress showSocial={false} style={{ fontSize: isExtensionMode ? '12px' : '16px', maxWidth: '100%' }} subIdOnly />
-              </Grid>
+            <Grid container item key={index} sx={{ height: isExtensionMode ? '41px' : '50px', textAlign: 'center' }}>
               <Grid alignItems='center' container height='100%' item justifyContent='center' xs={isExtensionMode ? 2 : 1}>
                 <Select index={index} proxied={proxiedAccount} />
+              </Grid>
+              <Grid alignItems='center' container item justifyContent='left' pl='10px' xs={isExtensionMode ? 10 : 11}>
+                <Identity api={api} chain={chain} formatted={proxiedAccount} identiconSize={25} showShortAddress showSocial={false} style={{ fontSize: isExtensionMode ? '12px' : '16px', maxWidth: '100%' }} subIdOnly />
               </Grid>
             </Grid>
           )}
@@ -149,7 +133,6 @@ export default function ProxiedTable ({ api, chain, label, maxHeight = '120px', 
           </Typography>
           : <Skeleton animation='wave' height='30px' width='100px' />
         }
-        <SelectDeselectButton allSelected={selectedProxied.length === proxiedAccounts?.length} disable={!proxiedAccounts} />
       </Grid>
     </Grid>
   );

--- a/packages/extension-polkagate/src/popup/import/importProxied/ProxiedTable.tsx
+++ b/packages/extension-polkagate/src/popup/import/importProxied/ProxiedTable.tsx
@@ -3,16 +3,15 @@
 
 /* eslint-disable react/jsx-max-props-per-line */
 
-import { faSquare, faSquareCheck } from '@fortawesome/free-regular-svg-icons';
 import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { Checkbox, FormControlLabel, Grid, Skeleton, SxProps, Theme, Typography, useTheme } from '@mui/material';
+import { Grid, Skeleton, SxProps, Theme, Typography, useTheme } from '@mui/material';
 import React, { useCallback, useContext, useMemo } from 'react';
 
 import { ApiPromise } from '@polkadot/api';
 import { Chain } from '@polkadot/extension-chains/types';
 
-import { AccountContext, Identity, Label, Progress } from '../../../components';
+import { AccountContext, Checkbox2 as Checkbox, Identity, Label, Progress } from '../../../components';
 import { useIsExtensionPopup, useTranslation } from '../../../hooks';
 import { getSubstrateAddress } from '../../../util/utils';
 
@@ -34,13 +33,17 @@ export default function ProxiedTable ({ api, chain, label, maxHeight = '120px', 
   const theme = useTheme();
   const { accounts } = useContext(AccountContext);
 
-  const isDarkMode = useMemo(() => theme.palette.mode === 'dark', [theme.palette.mode]);
-  const allSelected = useMemo(() => selectedProxied.length === proxiedAccounts?.length, [proxiedAccounts?.length, selectedProxied.length]);
-
   const isAvailable = useCallback((proxied: string): boolean => !!accounts?.find(({ address }) => address === getSubstrateAddress(proxied)), [accounts]);
 
-  const handleSelect = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
-    const proxied = proxiedAccounts && proxiedAccounts[Number(event.target.value)];
+  const isDarkMode = useMemo(() => theme.palette.mode === 'dark', [theme.palette.mode]);
+  const allSelected = useMemo(() => 
+    proxiedAccounts &&
+    proxiedAccounts.length > 0 &&
+    selectedProxied.length === proxiedAccounts.filter((proxied) => !isAvailable(proxied))?.length
+  , [isAvailable, proxiedAccounts, selectedProxied.length]);
+
+  const handleSelect = useCallback((index: number) => () => {
+    const proxied = proxiedAccounts && proxiedAccounts[index];
     const alreadyAdded = selectedProxied.includes(proxied as string);
 
     if (proxied && alreadyAdded) {
@@ -50,41 +53,11 @@ export default function ProxiedTable ({ api, chain, label, maxHeight = '120px', 
     }
   }, [proxiedAccounts, selectedProxied, setSelectedProxied]);
 
-  const Select = ({ disabled, index, proxied }: { proxied: string, index: number, disabled: boolean }) => (
-    <FormControlLabel
-      checked={selectedProxied.includes(proxied)}
-      control={
-        <Checkbox
-          onChange={handleSelect}
-          size='medium'
-          sx={{ '&.Mui-disabled': { color: 'text.disabled' }, color: 'secondary.main' }}
-          value={index}
-        />
-      }
-      disabled={disabled}
-      label=''
-      sx={{ m: 'auto' }}
-      value={index}
-    />
-  );
-
   const onSelect = useCallback((selectAll: boolean) => () => {
     const toSelect = proxiedAccounts?.filter((proxied) => !isAvailable(proxied));
 
     proxiedAccounts && setSelectedProxied(selectAll ? toSelect ?? [] : []);
   }, [isAvailable, proxiedAccounts, setSelectedProxied]);
-
-  // const fade = (toCheck: ProxyItem) => {
-  //   if (mode === 'Delete') {
-  //     return (toCheck.status === 'remove');
-  //   }
-
-  //   if (mode === 'Availability' || mode === 'Select') {
-  //     return !(isAvailable(toCheck.proxy));
-  //   }
-
-  //   return false;
-  // };
 
   return (
     <Grid container item sx={{ ...style }}>
@@ -93,10 +66,8 @@ export default function ProxiedTable ({ api, chain, label, maxHeight = '120px', 
           <Grid container item sx={{ textAlign: 'center' }}>
             <Grid alignItems='center' container item width='fit-content'>
               <Grid alignItems='center' container item onClick={onSelect(!allSelected)} sx={{ cursor: !proxiedAccounts ? 'default' : 'pointer', pl: isExtensionMode ? '18px' : '20px', width: 'fit-content' }}>
-                <FontAwesomeIcon
-                  color={theme.palette.secondary.light}
-                  fontSize='21px'
-                  icon={allSelected ? faSquareCheck : faSquare}
+                <Checkbox
+                  checked={allSelected}
                 />
               </Grid>
             </Grid>
@@ -120,7 +91,12 @@ export default function ProxiedTable ({ api, chain, label, maxHeight = '120px', 
           {proxiedAccounts && proxiedAccounts.length > 0 && proxiedAccounts.map((proxiedAccount, index) =>
             <Grid container item key={index} sx={{ height: isExtensionMode ? '41px' : '50px', opacity: isAvailable(proxiedAccount) ? '0.5' : 1, textAlign: 'center' }}>
               <Grid alignItems='center' container height='100%' item justifyContent='center' xs={isExtensionMode ? 2 : 1}>
-                <Select disabled={isAvailable(proxiedAccount)} index={index} proxied={proxiedAccount} />
+                {/* <Select disabled={isAvailable(proxiedAccount)} index={index} proxied={proxiedAccount} /> */}
+                <Checkbox
+                  checked={selectedProxied?.includes(proxiedAccount)}
+                  disabled={isAvailable(proxiedAccount)}
+                  onChange={handleSelect(index)}
+                />
               </Grid>
               <Grid alignItems='center' container item justifyContent='left' pl='10px' xs={isExtensionMode ? 10 : 11}>
                 <Identity api={api} chain={chain} formatted={proxiedAccount} identiconSize={25} showShortAddress showSocial={false} style={{ fontSize: isExtensionMode ? '12px' : '16px', maxWidth: '100%' }} subIdOnly />

--- a/packages/extension-polkagate/src/popup/import/importProxied/index.tsx
+++ b/packages/extension-polkagate/src/popup/import/importProxied/index.tsx
@@ -103,7 +103,7 @@ function ImportProxied (): React.ReactElement {
           withoutChainLogo
         />
       </Label>
-      <SelectChain
+      {selectedAddress && <SelectChain
         address={selectedAddress}
         fullWidthDropdown
         icon={getLogo(chain ?? undefined)}
@@ -111,7 +111,7 @@ function ImportProxied (): React.ReactElement {
         onChange={onChangeGenesis}
         options={selectableChains}
         style={{ m: '15px auto', width: '92%' }}
-      />
+      />}
       {selectedAddress && chain &&
         <ProxiedTable
           api={api}

--- a/packages/extension-polkagate/src/popup/import/importProxied/index.tsx
+++ b/packages/extension-polkagate/src/popup/import/importProxied/index.tsx
@@ -63,7 +63,7 @@ function ImportProxied (): React.ReactElement {
   const onImport = useCallback(() => {
     setIsBusy(true);
     selectedProxied.forEach((address, index) => {
-      createAccountExternal(`Proxied Address ${index}`, address, chain?.genesisHash ?? WESTEND_GENESIS_HASH).catch((error: Error) => {
+      createAccountExternal(`Proxied ${index + 1}`, address, chain?.genesisHash ?? WESTEND_GENESIS_HASH).catch((error: Error) => {
         setIsBusy(false);
         console.error(error);
       });

--- a/packages/extension-polkagate/src/popup/import/importProxied/index.tsx
+++ b/packages/extension-polkagate/src/popup/import/importProxied/index.tsx
@@ -112,7 +112,7 @@ function ImportProxied (): React.ReactElement {
           api={api}
           chain={chain}
           label={t('Proxied account(s)')}
-          maxHeight='155px'
+          maxHeight='140px'
           proxiedAccounts={proxiedAccounts?.proxy === formatted ? proxiedAccounts?.proxied : undefined}
           selectedProxied={selectedProxied}
           setSelectedProxied={setSelectedProxied}

--- a/packages/extension-polkagate/src/popup/import/importProxied/index.tsx
+++ b/packages/extension-polkagate/src/popup/import/importProxied/index.tsx
@@ -4,6 +4,7 @@
 /* eslint-disable react/jsx-max-props-per-line */
 
 import { Typography } from '@mui/material';
+import Chance from 'chance';
 import React, { useCallback, useContext, useMemo, useState } from 'react';
 
 import { Chain } from '@polkadot/extension-chains/types';
@@ -23,6 +24,8 @@ function ImportProxied (): React.ReactElement {
   const onAction = useContext(ActionContext);
   const { accounts, hierarchy } = useContext(AccountContext);
   const genesisOptions = useGenesisHashOptions();
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
+  const chance = new Chance();
 
   const selectableChains = useMemo(() => genesisOptions.filter(({ value }) => PROXY_CHAINS.includes(value as string)), [genesisOptions]);
 
@@ -63,14 +66,16 @@ function ImportProxied (): React.ReactElement {
   const onImport = useCallback(() => {
     setIsBusy(true);
     selectedProxied.forEach((address, index) => {
-      createAccountExternal(`Proxied ${index + 1}`, address, chain?.genesisHash ?? WESTEND_GENESIS_HASH).catch((error: Error) => {
+      const randomName = (chance?.name() as string)?.split(' ')?.[0] || `Proxied ${index + 1}`;
+
+      createAccountExternal(randomName, address, chain?.genesisHash ?? WESTEND_GENESIS_HASH).catch((error: Error) => {
         setIsBusy(false);
         console.error(error);
       });
     });
 
     onAction('/');
-  }, [chain?.genesisHash, onAction, selectedProxied]);
+  }, [chain?.genesisHash, chance, onAction, selectedProxied]);
 
   const onBackClick = useCallback(() => {
     onAction('/');

--- a/packages/extension-polkagate/src/popup/import/importProxied/index.tsx
+++ b/packages/extension-polkagate/src/popup/import/importProxied/index.tsx
@@ -1,0 +1,132 @@
+// Copyright 2019-2024 @polkadot/extension-polkagate authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+/* eslint-disable react/jsx-max-props-per-line */
+
+import { Typography } from '@mui/material';
+import React, { useCallback, useContext, useMemo, useState } from 'react';
+
+import { Chain } from '@polkadot/extension-chains/types';
+
+import { AccountContext, ActionContext, Label, PButton, SelectChain } from '../../../components';
+import { useApiWithChain, useGenesisHashOptions, useProxiedAccounts, useTranslation } from '../../../hooks';
+import { createAccountExternal, getMetadata } from '../../../messaging';
+import HeaderBrand from '../../../partials/HeaderBrand';
+import { PROXY_CHAINS, WESTEND_GENESIS_HASH } from '../../../util/constants';
+import getLogo from '../../../util/getLogo';
+import { getFormattedAddress } from '../../../util/utils';
+import AddressDropdown from '../../newAccount/deriveAccount/AddressDropdown';
+import ProxiedTable from './ProxiedTable';
+
+function ImportProxied (): React.ReactElement {
+  const { t } = useTranslation();
+  const onAction = useContext(ActionContext);
+  const { accounts, hierarchy } = useContext(AccountContext);
+  const genesisOptions = useGenesisHashOptions();
+
+  const selectableChains = useMemo(() => genesisOptions.filter(({ value }) => PROXY_CHAINS.includes(value as string)), [genesisOptions]);
+
+  const allAddresses = useMemo(() =>
+    hierarchy
+      .filter(({ isExternal }) => !isExternal)
+      .map(({ address, genesisHash, name }): [string, string | null, string | undefined] => [address, genesisHash || null, name])
+  , [hierarchy]);
+
+  const [selectedAddress, setSelectedAddress] = useState<string | undefined>(undefined);
+  const [selectedProxied, setSelectedProxied] = useState<string[]>([]);
+  const [chain, setChain] = useState<Chain | null>(null);
+  const [isBusy, setIsBusy] = useState(false);
+
+  const formatted = selectedAddress && getFormattedAddress(selectedAddress, chain, 42);
+  const proxiedAccounts = useProxiedAccounts(selectedAddress, chain);
+  const api = useApiWithChain(chain);
+
+  const { accountGenesishash, accountName } = useMemo(() => {
+    const selectedAccount = accounts.find(({ address }) => address === selectedAddress);
+
+    return { accountGenesishash: selectedAccount?.genesisHash, accountName: selectedAccount?.name };
+  }, [accounts, selectedAddress]);
+
+  const onChangeGenesis = useCallback((genesisHash?: string | null) => {
+    setSelectedProxied([]);
+
+    genesisHash && getMetadata(genesisHash, true)
+      .then(setChain)
+      .catch(console.error);
+  }, []);
+
+  const onParentChange = useCallback((address: string) => {
+    setSelectedProxied([]);
+    setSelectedAddress(address);
+  }, []);
+
+  const onImport = useCallback(() => {
+    setIsBusy(true);
+    selectedProxied.forEach((address, index) => {
+      createAccountExternal(`Proxied Address ${index}`, address, chain?.genesisHash ?? WESTEND_GENESIS_HASH).catch((error: Error) => {
+        setIsBusy(false);
+        console.error(error);
+      });
+    });
+
+    onAction('/');
+  }, [chain?.genesisHash, onAction, selectedProxied]);
+
+  const onBackClick = useCallback(() => {
+    onAction('/');
+  }, [onAction]);
+
+  return (
+    <>
+      <HeaderBrand
+        onBackClick={onBackClick}
+        showBackArrow
+        text={t('Import Proxied')}
+      />
+      <Typography fontSize='14px' fontWeight={300} m='25px auto' textAlign='left' width='88%'>
+        {t('Import proxied account(s) to have it as watch-only account in the extension.')}
+      </Typography>
+      <Label
+        label={t('Choose proxy account')}
+        style={{ margin: 'auto', width: '92%' }}
+      >
+        <AddressDropdown
+          allAddresses={allAddresses}
+          onSelect={onParentChange}
+          selectedAddress={selectedAddress}
+          selectedGenesis={accountGenesishash}
+          selectedName={accountName}
+          withoutChainLogo
+        />
+      </Label>
+      <SelectChain
+        address={selectedAddress}
+        icon={getLogo(chain ?? undefined)}
+        label={t('Select the chain')}
+        onChange={onChangeGenesis}
+        options={selectableChains}
+        style={{ m: '15px auto', width: '92%' }}
+      />
+      {selectedAddress && chain &&
+        <ProxiedTable
+          api={api}
+          chain={chain}
+          label={t('Proxied account(s)')}
+          maxHeight='155px'
+          proxiedAccounts={proxiedAccounts?.proxy === formatted ? proxiedAccounts?.proxied : undefined}
+          selectedProxied={selectedProxied}
+          setSelectedProxied={setSelectedProxied}
+          style={{ m: '0 auto', width: '92%' }}
+        />
+      }
+      <PButton
+        _isBusy={isBusy}
+        _onClick={onImport}
+        disabled={!selectedAddress || !chain || selectedProxied.length === 0}
+        text={t('Import selected')}
+      />
+    </>
+  );
+}
+
+export default React.memo(ImportProxied);

--- a/packages/extension-polkagate/src/popup/import/importProxied/index.tsx
+++ b/packages/extension-polkagate/src/popup/import/importProxied/index.tsx
@@ -30,7 +30,7 @@ function ImportProxied (): React.ReactElement {
 
   const allAddresses = useMemo(() =>
     hierarchy
-      .filter(({ isExternal }) => !isExternal)
+      .filter(({ isExternal, isHardware, isQR }) => !isExternal || isQR || isHardware)
       .map(({ address, genesisHash, name }): [string, string | null, string | undefined] => [address, genesisHash || null, name])
   , [hierarchy]);
 

--- a/packages/extension-polkagate/src/popup/import/importProxiedFullScreen/index.tsx
+++ b/packages/extension-polkagate/src/popup/import/importProxiedFullScreen/index.tsx
@@ -1,0 +1,160 @@
+// Copyright 2019-2024 @polkadot/extension-polkagate authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+/* eslint-disable react/jsx-max-props-per-line */
+
+import { faSitemap } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Grid, Typography, useTheme } from '@mui/material';
+import React, { useCallback, useContext, useMemo, useState } from 'react';
+
+import { Chain } from '@polkadot/extension-chains/types';
+
+import { AccountContext, Label, SelectChain, TwoButtons } from '../../../components';
+import { FullScreenHeader } from '../../../fullscreen/governance/FullScreenHeader';
+import { useFullscreen, useGenesisHashOptions, useInfo, useProxiedAccounts, useTranslation } from '../../../hooks';
+import { createAccountExternal, getMetadata, tieAccount } from '../../../messaging';
+import { FULLSCREEN_WIDTH, PROXY_CHAINS, WESTEND_GENESIS_HASH } from '../../../util/constants';
+import getLogo from '../../../util/getLogo';
+import AddressDropdownFullScreen from '../../newAccount/deriveFromAccountsFullscreen/AddressDropdownFullScreen';
+import ProxiedTable from '../importProxied/ProxiedTable';
+
+function ImportProxiedFS (): React.ReactElement {
+  useFullscreen();
+  const { t } = useTranslation();
+  const theme = useTheme();
+  const { accounts, hierarchy } = useContext(AccountContext);
+  const genesisOptions = useGenesisHashOptions();
+
+  const selectableChains = useMemo(() => genesisOptions.filter(({ value }) => PROXY_CHAINS.includes(value as string)), [genesisOptions]);
+
+  const allAddresses = useMemo(() =>
+    hierarchy
+      .filter(({ isExternal }) => !isExternal)
+      .map(({ address, genesisHash, name }): [string, string | null, string | undefined] => [address, genesisHash || null, name])
+  , [hierarchy]);
+
+  const [selectedAddress, setSelectedAddress] = useState<string | undefined>(undefined);
+  const [selectedProxied, setSelectedProxied] = useState<string[]>([]);
+  const [chain, setChain] = useState<Chain | null>(null);
+  const [isBusy, setIsBusy] = useState(false);
+
+  const proxiedAccounts = useProxiedAccounts(chain ? selectedAddress : undefined);
+  const { api, formatted } = useInfo(chain ? selectedAddress : undefined);
+
+  const { accountGenesishash, accountName } = useMemo(() => {
+    const selectedAccount = accounts.find(({ address }) => address === selectedAddress);
+
+    return { accountGenesishash: selectedAccount?.genesisHash, accountName: selectedAccount?.name };
+  }, [accounts, selectedAddress]);
+
+  const onChangeGenesis = useCallback((genesisHash?: string | null) => {
+    setSelectedProxied([]);
+
+    genesisHash && tieAccount(selectedAddress ?? '', genesisHash)
+      .then(() => getMetadata(genesisHash, true))
+      .then(setChain)
+      .catch(console.error);
+  }, [selectedAddress]);
+
+  const onParentChange = useCallback((address: string) => {
+    setSelectedProxied([]);
+    setSelectedAddress(address);
+  }, []);
+
+  const onImport = useCallback(() => {
+    setIsBusy(true);
+    selectedProxied.forEach((address, index) => {
+      createAccountExternal(`Proxied Address ${index}`, address, chain?.genesisHash ?? WESTEND_GENESIS_HASH).catch((error: Error) => {
+        setIsBusy(false);
+        console.error(error);
+      });
+    });
+
+    window.close();
+  }, [chain?.genesisHash, selectedProxied]);
+
+  const backHome = useCallback(() => {
+    window.close();
+  }, []);
+
+  return (
+    <Grid bgcolor='backgroundFL.primary' container item justifyContent='center'>
+      <FullScreenHeader
+        noAccountDropDown
+        noChainSwitch
+      />
+      <Grid container item justifyContent='center' sx={{ bgcolor: 'backgroundFL.secondary', height: 'calc(100vh - 70px)', maxWidth: FULLSCREEN_WIDTH, overflow: 'scroll', position: 'relative' }}>
+        <Grid container item sx={{ display: 'block', mb: '20px', px: '10%' }}>
+          <Grid alignContent='center' alignItems='center' container item>
+            <Grid item sx={{ mr: '20px' }}>
+              <FontAwesomeIcon
+                color={theme.palette.text.primary}
+                fontSize='38px'
+                icon={faSitemap}
+                style={{ transform: 'rotate(180deg)' }}
+              />
+            </Grid>
+            <Grid item>
+              <Typography fontSize='30px' fontWeight={700} py='20px' width='100%'>
+                {t('Import proxied accounts')}
+              </Typography>
+            </Grid>
+          </Grid>
+          <Typography fontSize='16px' fontWeight={400} textAlign='left' width='100%'>
+            {t('Import proxied account(s) to have it as watch-only account in the extension.')}
+          </Typography>
+          <Grid container item sx={{ my: '30px' }}>
+            <Label
+              label={t('Choose proxy account')}
+              style={{ margin: 'auto', width: '100%' }}
+            >
+              <AddressDropdownFullScreen
+                allAddresses={allAddresses}
+                onSelect={onParentChange}
+                selectedAddress={selectedAddress}
+                selectedGenesis={accountGenesishash}
+                selectedName={accountName}
+                withoutChainLogo
+              />
+            </Label>
+            <SelectChain
+              address={selectedAddress}
+              fullWidthDropdown
+              icon={getLogo(chain ?? undefined)}
+              label={t('Select the chain')}
+              onChange={onChangeGenesis}
+              options={selectableChains}
+              style={{ m: '15px 0', width: '60%' }}
+            />
+            {selectedAddress && chain &&
+              <ProxiedTable
+                api={api}
+                chain={chain}
+                label={t('Proxied account(s)')}
+                maxHeight='200px'
+                proxiedAccounts={proxiedAccounts?.proxy === formatted ? proxiedAccounts?.proxied : undefined}
+                selectedProxied={selectedProxied}
+                setSelectedProxied={setSelectedProxied}
+                style={{ m: '0 auto' }}
+              />
+            }
+            <Grid container item sx={{ '> div': { m: 0, width: '64%' }, borderTop: '1px solid', borderTopColor: 'divider', bottom: '40px', height: '50px', justifyContent: 'flex-end', left: '10%', position: 'absolute', width: '80%' }}>
+              <TwoButtons
+                disabled={!selectedAddress || !chain || selectedProxied.length === 0}
+                isBusy={isBusy}
+                mt='1px'
+                onPrimaryClick={onImport}
+                onSecondaryClick={backHome}
+                primaryBtnText={t('Import selected')}
+                secondaryBtnText={t('Cancel')}
+              />
+            </Grid>
+          </Grid>
+        </Grid>
+      </Grid>
+    </Grid>
+  );
+}
+
+export default React.memo(ImportProxiedFS);

--- a/packages/extension-polkagate/src/popup/import/importProxiedFullScreen/index.tsx
+++ b/packages/extension-polkagate/src/popup/import/importProxiedFullScreen/index.tsx
@@ -65,7 +65,7 @@ function ImportProxiedFS (): React.ReactElement {
   const onImport = useCallback(() => {
     setIsBusy(true);
     selectedProxied.forEach((address, index) => {
-      createAccountExternal(`Proxied Address ${index}`, address, chain?.genesisHash ?? WESTEND_GENESIS_HASH).catch((error: Error) => {
+      createAccountExternal(`Proxied ${index + 1}`, address, chain?.genesisHash ?? WESTEND_GENESIS_HASH).catch((error: Error) => {
         setIsBusy(false);
         console.error(error);
       });

--- a/packages/extension-polkagate/src/popup/import/importProxiedFullScreen/index.tsx
+++ b/packages/extension-polkagate/src/popup/import/importProxiedFullScreen/index.tsx
@@ -32,7 +32,7 @@ function ImportProxiedFS (): React.ReactElement {
 
   const allAddresses = useMemo(() =>
     hierarchy
-      .filter(({ isExternal }) => !isExternal)
+      .filter(({ isExternal, isHardware, isQR }) => !isExternal || isQR || isHardware)
       .map(({ address, genesisHash, name }): [string, string | null, string | undefined] => [address, genesisHash || null, name])
   , [hierarchy]);
 

--- a/packages/extension-polkagate/src/popup/import/importProxiedFullScreen/index.tsx
+++ b/packages/extension-polkagate/src/popup/import/importProxiedFullScreen/index.tsx
@@ -6,6 +6,7 @@
 import { faSitemap } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Grid, Typography, useTheme } from '@mui/material';
+import Chance from 'chance';
 import React, { useCallback, useContext, useMemo, useState } from 'react';
 
 import { Chain } from '@polkadot/extension-chains/types';
@@ -25,6 +26,7 @@ function ImportProxiedFS (): React.ReactElement {
   const theme = useTheme();
   const { accounts, hierarchy } = useContext(AccountContext);
   const genesisOptions = useGenesisHashOptions();
+  const chance = new Chance();
 
   const selectableChains = useMemo(() => genesisOptions.filter(({ value }) => PROXY_CHAINS.includes(value as string)), [genesisOptions]);
 
@@ -65,14 +67,16 @@ function ImportProxiedFS (): React.ReactElement {
   const onImport = useCallback(() => {
     setIsBusy(true);
     selectedProxied.forEach((address, index) => {
-      createAccountExternal(`Proxied ${index + 1}`, address, chain?.genesisHash ?? WESTEND_GENESIS_HASH).catch((error: Error) => {
+      const randomName = (chance?.name() as string)?.split(' ')?.[0] || `Proxied ${index + 1}`;
+
+      createAccountExternal(randomName, address, chain?.genesisHash ?? WESTEND_GENESIS_HASH).catch((error: Error) => {
         setIsBusy(false);
         console.error(error);
       });
     });
 
     window.close();
-  }, [chain?.genesisHash, selectedProxied]);
+  }, [chain?.genesisHash, chance, selectedProxied]);
 
   const backHome = useCallback(() => {
     window.close();

--- a/packages/extension-polkagate/src/popup/newAccount/deriveAccount/AddressDropdown.tsx
+++ b/packages/extension-polkagate/src/popup/newAccount/deriveAccount/AddressDropdown.tsx
@@ -4,56 +4,68 @@
 /* eslint-disable react/jsx-max-props-per-line */
 
 import { ArrowForwardIos as ArrowForwardIosIcon } from '@mui/icons-material';
-import { Grid } from '@mui/material';
+import { Grid, Typography } from '@mui/material';
 import React, { useCallback, useRef, useState } from 'react';
 
 import { Address, ChainLogo } from '../../../components';
-import { useOutsideClick } from '../../../hooks';
+import { useOutsideClick, useTranslation } from '../../../hooks';
 
 interface Props {
   allAddresses: [string, string | null, string | undefined][];
   onSelect: (address: string) => void;
-  selectedAddress: string;
+  selectedAddress: string | undefined;
   selectedName: string | null;
   selectedGenesis: string | undefined;
+  withoutChainLogo?: boolean;
 }
 
-export default function AddressDropdown ({ allAddresses, onSelect, selectedAddress, selectedGenesis, selectedName }: Props): React.ReactElement<Props> {
+export default function AddressDropdown({ allAddresses, onSelect, selectedAddress, selectedGenesis, selectedName, withoutChainLogo = false }: Props): React.ReactElement<Props> {
+  const { t } = useTranslation();
   const [isDropdownVisible, setDropdownVisible] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
-  const _hideDropdown = useCallback(() => setDropdownVisible(false), []);
-  const _toggleDropdown = useCallback(() => setDropdownVisible(!isDropdownVisible), [isDropdownVisible]);
-  const _selectParent = useCallback((newParent: string) => () => onSelect(newParent), [onSelect]);
+  const hideDropdown = useCallback(() => setDropdownVisible(false), []);
+  const toggleDropdown = useCallback(() => setDropdownVisible(!isDropdownVisible), [isDropdownVisible]);
+  const selectParent = useCallback((newParent: string) => () => onSelect(newParent), [onSelect]);
 
-  useOutsideClick([ref], _hideDropdown);
+  useOutsideClick([ref], hideDropdown);
 
   return (
     <div style={{ position: 'relative' }}>
       <Grid container overflow='hidden' sx={{ bgcolor: 'background.paper', border: '1px solid', borderColor: 'secondary.light', borderRadius: '5px', position: 'relative' }}>
         <Grid alignItems='center' container item justifyContent='space-around' xs={11}>
-          <Grid item maxWidth='245px'>
-            <Address
-              address={selectedAddress}
-              className='address'
-              genesisHash={selectedGenesis}
-              name={selectedName}
-              showCopy={false}
-              style={{ border: 'none', borderRadius: 0, m: 0, pl: '5px', px: 0, width: '245px' }}
-            />
-          </Grid>
-          <Grid item width='30px'>
-            <ChainLogo genesisHash={selectedGenesis} />
-          </Grid>
+          {selectedAddress
+            ? <>
+              <Grid item maxWidth={withoutChainLogo ? '275px' : '245px'}>
+                <Address
+                  address={selectedAddress}
+                  className='address'
+                  genesisHash={selectedGenesis}
+                  name={selectedName}
+                  showCopy={false}
+                  style={{ border: 'none', borderRadius: 0, m: 0, pl: '5px', px: 0, width: withoutChainLogo ? '275px' : '245px' }}
+                />
+              </Grid>
+              {!withoutChainLogo &&
+                <Grid item width='30px'>
+                  <ChainLogo genesisHash={selectedGenesis} />
+                </Grid>}
+            </>
+            : <Grid alignItems='center' container height='70px' item>
+              <Typography fontSize='14px' fontWeight={400} sx={{ pl: '30px' }}>
+                {t('Select an account')}
+              </Typography>
+            </Grid>
+          }
         </Grid>
-        <Grid alignItems='center' container item onClick={_toggleDropdown} ref={ref} sx={{ borderLeft: '1px solid', borderLeftColor: 'secondary.light', cursor: 'pointer' }} xs={1}>
+        <Grid alignItems='center' container item onClick={toggleDropdown} ref={ref} sx={{ borderLeft: '1px solid', borderLeftColor: 'secondary.light', cursor: 'pointer' }} xs={1}>
           <ArrowForwardIosIcon sx={{ color: 'secondary.light', fontSize: 18, m: 'auto', stroke: '#BA2882', strokeWidth: '2px', transform: isDropdownVisible ? 'rotate(-90deg)' : 'rotate(90deg)', transitionDuration: '0.3s', transitionProperty: 'transform' }} />
         </Grid>
       </Grid>
       <Grid container sx={{ '> .tree:last-child': { border: 'none' }, bgcolor: 'background.paper', border: '2px solid', borderColor: 'secondary.light', borderRadius: '5px', boxShadow: '0px 3px 10px rgba(255, 255, 255, 0.25)', maxHeight: '220px', overflow: 'hidden', overflowY: 'scroll', position: 'absolute', top: '75px', transform: isDropdownVisible ? 'scaleY(1)' : 'scaleY(0)', transformOrigin: 'top', transitionDuration: '0.3s', transitionProperty: 'transform', visibility: isDropdownVisible ? 'visible' : 'hidden', zIndex: 10 }}>
         {allAddresses.map(([address, genesisHash, name]) => (
-          <Grid alignItems='center' className='tree' container item key={address} onClick={_selectParent(address)} sx={{ borderBottom: '1px solid', borderBottomColor: 'secondary.light', cursor: 'pointer', pr: '30px' }}>
-            <Grid item xs={10.7}>
+          <Grid alignItems='center' className='tree' container item key={address} onClick={selectParent(address)} sx={{ borderBottom: '1px solid', borderBottomColor: 'secondary.light', cursor: 'pointer', pr: '30px' }}>
+            <Grid item xs={withoutChainLogo ? 12 : 10.7}>
               <Address
                 address={address}
                 className='address'
@@ -63,9 +75,11 @@ export default function AddressDropdown ({ allAddresses, onSelect, selectedAddre
                 style={{ border: 'none', m: 0, px: 'auto', width: '100%' }}
               />
             </Grid>
-            <Grid item>
-              <ChainLogo genesisHash={genesisHash} />
-            </Grid>
+            {!withoutChainLogo &&
+              <Grid item>
+                <ChainLogo genesisHash={genesisHash} />
+              </Grid>
+            }
           </Grid>
         ))}
       </Grid>

--- a/packages/extension-polkagate/src/popup/newAccount/deriveFromAccountsFullscreen/AddressDropdownFullScreen.tsx
+++ b/packages/extension-polkagate/src/popup/newAccount/deriveFromAccountsFullscreen/AddressDropdownFullScreen.tsx
@@ -4,22 +4,24 @@
 /* eslint-disable react/jsx-max-props-per-line */
 
 import { ArrowForwardIos as ArrowForwardIosIcon } from '@mui/icons-material';
-import { Collapse, Grid, SxProps, Theme, useTheme } from '@mui/material';
+import { Collapse, Grid, SxProps, Theme, Typography, useTheme } from '@mui/material';
 import React, { useCallback, useMemo, useRef, useState } from 'react';
 
 import { ChainLogo, NewAddress } from '../../../components';
-import { useOutsideClick } from '../../../hooks';
+import { useOutsideClick, useTranslation } from '../../../hooks';
 
 interface Props {
   allAddresses: [string, string | null, string | undefined][];
   onSelect: (address: string) => void;
-  selectedAddress: string;
+  selectedAddress: string | undefined;
   selectedName: string | null | undefined;
   selectedGenesis: string | null | undefined;
   style?: SxProps<Theme> | undefined;
+  withoutChainLogo?: boolean;
 }
 
-export default function AddressDropdownFullScreen({ allAddresses, onSelect, selectedAddress, selectedGenesis, selectedName, style }: Props): React.ReactElement<Props> {
+export default function AddressDropdownFullScreen ({ allAddresses, onSelect, selectedAddress, selectedGenesis, selectedName, style, withoutChainLogo }: Props): React.ReactElement<Props> {
+  const { t } = useTranslation();
   const theme = useTheme();
   const ref = useRef<HTMLDivElement>(null);
 
@@ -27,29 +29,39 @@ export default function AddressDropdownFullScreen({ allAddresses, onSelect, sele
 
   const isDarkMode = useMemo(() => theme.palette.mode === 'dark', [theme.palette.mode]);
 
-  const _hideDropdown = useCallback(() => setDropdownVisible(false), []);
-  const _toggleDropdown = useCallback(() => setDropdownVisible(!isDropdownVisible), [isDropdownVisible]);
-  const _selectParent = useCallback((newParent: string) => () => onSelect(newParent), [onSelect]);
+  const hideDropdown = useCallback(() => setDropdownVisible(false), []);
+  const toggleDropdown = useCallback(() => setDropdownVisible(!isDropdownVisible), [isDropdownVisible]);
+  const selectParent = useCallback((newParent: string) => () => onSelect(newParent), [onSelect]);
 
-  useOutsideClick([ref], _hideDropdown);
+  useOutsideClick([ref], hideDropdown);
 
   return (
     <Grid container item sx={{ position: 'relative', ...style }}>
       <Grid container overflow='hidden' sx={{ bgcolor: 'background.paper', border: isDarkMode ? '1px solid' : 'none', borderColor: 'secondary.light', borderRadius: '1px', boxShadow: '2px 3px 4px 0px #0000001A', position: 'relative' }}>
         <Grid alignItems='center' container item justifyContent='space-around' px='15px' xs>
-          <Grid container item xs>
-            <NewAddress
-              address={selectedAddress}
-              name={selectedName}
-              showCopy={false}
-              style={{ border: 'none', borderRadius: 0, boxShadow: 'none', m: 0, pl: '5px', px: 0 }}
-            />
-          </Grid>
-          <Grid container item width='fit-content'>
-            <ChainLogo genesisHash={selectedGenesis} />
-          </Grid>
+          {selectedAddress
+            ? <>
+              <Grid container item xs>
+                <NewAddress
+                  address={selectedAddress}
+                  name={selectedName}
+                  showCopy={false}
+                  style={{ border: 'none', borderRadius: 0, boxShadow: 'none', m: 0, pl: '5px', px: 0 }}
+                />
+              </Grid>
+              {!withoutChainLogo &&
+                <Grid container item width='fit-content'>
+                  <ChainLogo genesisHash={selectedGenesis} />
+                </Grid>}
+            </>
+            : <Grid alignItems='center' container height='70px' item>
+              <Typography fontSize='14px' fontWeight={400} sx={{ pl: '30px' }}>
+                {t('Select an account')}
+              </Typography>
+            </Grid>
+          }
         </Grid>
-        <Grid alignItems='center' container item onClick={_toggleDropdown} ref={ref} sx={{ borderLeft: '1px solid', borderLeftColor: isDarkMode ? 'secondary.light' : 'divider', cursor: 'pointer', px: '10px', width: 'fit-content' }}>
+        <Grid alignItems='center' container item onClick={toggleDropdown} ref={ref} sx={{ borderLeft: '1px solid', borderLeftColor: isDarkMode ? 'secondary.light' : 'divider', cursor: 'pointer', px: '10px', width: 'fit-content' }}>
           <ArrowForwardIosIcon sx={{ color: 'secondary.light', fontSize: 18, m: 'auto', stroke: '#BA2882', strokeWidth: '2px', transform: isDropdownVisible ? 'rotate(-90deg)' : 'rotate(90deg)', transitionDuration: '0.3s', transitionProperty: 'transform' }} />
         </Grid>
       </Grid>
@@ -57,7 +69,7 @@ export default function AddressDropdownFullScreen({ allAddresses, onSelect, sele
         <Collapse in={isDropdownVisible} sx={{ width: '100%' }}>
           <Grid container sx={{ bgcolor: 'background.paper', border: isDarkMode ? '1px solid' : 'none', borderColor: 'secondary.light', borderRadius: '1px', boxShadow: `0px 3px 10px ${isDarkMode ? '#ffffff40' : '#0000001A'}`, maxHeight: '250px', overflow: 'hidden', overflowY: 'scroll' }}>
             {allAddresses.map(([address, genesisHash, name]) => (
-              <Grid alignItems='center' container item key={address} onClick={_selectParent(address)} sx={{ borderBottom: '1px solid', borderBottomColor: isDarkMode ? 'secondary.light' : 'divider', cursor: 'pointer', px: '25px' }}>
+              <Grid alignItems='center' container item key={address} onClick={selectParent(address)} sx={{ borderBottom: '1px solid', borderBottomColor: isDarkMode ? 'secondary.light' : 'divider', cursor: 'pointer', px: '25px' }}>
                 <Grid container item xs>
                   <NewAddress
                     address={address}
@@ -66,9 +78,10 @@ export default function AddressDropdownFullScreen({ allAddresses, onSelect, sele
                     style={{ border: 'none', borderRadius: 0, boxShadow: 'none', m: 0, pl: '5px', px: 0 }}
                   />
                 </Grid>
-                <Grid container item width='fit-content'>
-                  <ChainLogo genesisHash={genesisHash} />
-                </Grid>
+                {!withoutChainLogo &&
+                  <Grid container item width='fit-content'>
+                    <ChainLogo genesisHash={genesisHash} />
+                  </Grid>}
               </Grid>
             ))}
           </Grid>

--- a/packages/extension-polkagate/src/util/types.ts
+++ b/packages/extension-polkagate/src/util/types.ts
@@ -792,3 +792,8 @@ export enum CanPayStatements {
   CANNOTPAYDEPOSIT,
   PROXYCANPAYFEE,
 }
+
+export type ProxiedAccounts = {
+  proxy: string;
+  proxied: string[];
+};

--- a/packages/extension-ui/src/Popup/index.tsx
+++ b/packages/extension-ui/src/Popup/index.tsx
@@ -53,6 +53,7 @@ import AddWatchOnlyFullScreen from '../../../extension-polkagate/src/popup/impor
 import AttachQR from '../../../extension-polkagate/src/popup/import/attachQR';
 import AttachQrFullScreen from '../../../extension-polkagate/src/popup/import/attachQrFullScreen';
 import ImportLedger from '../../../extension-polkagate/src/popup/import/importLedger';
+import ImportProxied from '../../../extension-polkagate/src/popup/import/importProxied';
 import ImportSeed from '../../../extension-polkagate/src/popup/import/importSeedFullScreen';
 import RestoreJson from '../../../extension-polkagate/src/popup/import/restoreJSONFullScreen';
 import ManageProxies from '../../../extension-polkagate/src/popup/manageProxies';
@@ -302,6 +303,7 @@ export default function Popup (): React.ReactElement {
                                     <Route path='/import/add-watch-only-full-screen'>{wrapWithErrorBoundary(<AddWatchOnlyFullScreen />, 'import-add-watch-only-full-screen')}</Route>
                                     <Route path='/import/attach-qr'>{wrapWithErrorBoundary(<AttachQR />, 'attach-qr')}</Route>
                                     <Route path='/import/attach-qr-full-screen'>{wrapWithErrorBoundary(<AttachQrFullScreen />, 'attach-qr-full-screen')}</Route>
+                                    <Route path='/import/proxied'>{wrapWithErrorBoundary(<ImportProxied />, 'import-proxied')}</Route>
                                     <Route path='/login-password'>{wrapWithErrorBoundary(<LoginPassword />, 'manage-login-password')}</Route>
                                     <Route path='/manageProxies/:address'>{wrapWithErrorBoundary(<ManageProxies />, 'manageProxies')}</Route>
                                     <Route path='/manageIdentity/:address'>{wrapWithErrorBoundary(<ManageIdentity />, 'manage-identity')}</Route>

--- a/packages/extension-ui/src/Popup/index.tsx
+++ b/packages/extension-ui/src/Popup/index.tsx
@@ -54,6 +54,7 @@ import AttachQR from '../../../extension-polkagate/src/popup/import/attachQR';
 import AttachQrFullScreen from '../../../extension-polkagate/src/popup/import/attachQrFullScreen';
 import ImportLedger from '../../../extension-polkagate/src/popup/import/importLedger';
 import ImportProxied from '../../../extension-polkagate/src/popup/import/importProxied';
+import ImportProxiedFullScreen from '../../../extension-polkagate/src/popup/import/importProxiedFullScreen';
 import ImportSeed from '../../../extension-polkagate/src/popup/import/importSeedFullScreen';
 import RestoreJson from '../../../extension-polkagate/src/popup/import/restoreJSONFullScreen';
 import ManageProxies from '../../../extension-polkagate/src/popup/manageProxies';
@@ -304,6 +305,7 @@ export default function Popup (): React.ReactElement {
                                     <Route path='/import/attach-qr'>{wrapWithErrorBoundary(<AttachQR />, 'attach-qr')}</Route>
                                     <Route path='/import/attach-qr-full-screen'>{wrapWithErrorBoundary(<AttachQrFullScreen />, 'attach-qr-full-screen')}</Route>
                                     <Route path='/import/proxied'>{wrapWithErrorBoundary(<ImportProxied />, 'import-proxied')}</Route>
+                                    <Route path='/import/proxied-full-screen'>{wrapWithErrorBoundary(<ImportProxiedFullScreen />, 'import-add-watch-only-full-screen')}</Route>
                                     <Route path='/login-password'>{wrapWithErrorBoundary(<LoginPassword />, 'manage-login-password')}</Route>
                                     <Route path='/manageProxies/:address'>{wrapWithErrorBoundary(<ManageProxies />, 'manageProxies')}</Route>
                                     <Route path='/manageIdentity/:address'>{wrapWithErrorBoundary(<ManageIdentity />, 'manage-identity')}</Route>

--- a/packages/extension-ui/src/Popup/index.tsx
+++ b/packages/extension-ui/src/Popup/index.tsx
@@ -55,6 +55,7 @@ import AttachQrFullScreen from '../../../extension-polkagate/src/popup/import/at
 import ImportLedger from '../../../extension-polkagate/src/popup/import/importLedger';
 import ImportProxied from '../../../extension-polkagate/src/popup/import/importProxied';
 import ImportProxiedFullScreen from '../../../extension-polkagate/src/popup/import/importProxiedFullScreen';
+import ImportRawSeed from '../../../extension-polkagate/src/popup/import/importRawSeedFullScreen';
 import ImportSeed from '../../../extension-polkagate/src/popup/import/importSeedFullScreen';
 import RestoreJson from '../../../extension-polkagate/src/popup/import/restoreJSONFullScreen';
 import ManageProxies from '../../../extension-polkagate/src/popup/manageProxies';

--- a/packages/extension/public/locales/en/translation.json
+++ b/packages/extension/public/locales/en/translation.json
@@ -1252,5 +1252,17 @@
   "This account is a validator!": "",
   "Social recovery": "",
   "Send fund": "",
-  "Receive fund": ""
+  "Receive fund": "",
+  "Import proxied accounts": "",
+  "Import proxied account(s)": "",
+  "Import Proxied": "",
+  "Import proxied account(s) to have it as watch-only account in the extension.": "",
+  "Choose proxy account": "",
+  "Proxied account(s)": "",
+  "Import selected": "",
+  "Proxied Account(s)": "",
+  "Looking for proxied accounts ...": "",
+  "This isn't a proxy account on {{chainName}}!": "",
+  "{{selectedCount}} of {{proxiedCount}} is selected": "",
+  "Select an account": ""
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9124,6 +9124,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chance@npm:^1.1.11":
+  version: 1.1.11
+  resolution: "chance@npm:1.1.11"
+  checksum: 2e871fcc76584d274f860f0f25380b6ab547caf0d22d8b043a313be73d5c3db38941373241f83aeba049e7511f752f9746dc722a0f2b0182020d493c4e11da84
+  languageName: node
+  linkType: hard
+
 "changelog-parser@npm:^2.0.0":
   version: 2.8.0
   resolution: "changelog-parser@npm:2.8.0"
@@ -19673,6 +19680,7 @@ resolve@^2.0.0-next.3:
     "@vaadin/icons": ^23.2.3
     babel-plugin-transform-import-meta: ^2.1.1
     better-react-spinkit: ^2.0.4
+    chance: ^1.1.11
     chart.js: ^4.2.1
     country-flag-icons: ^1.5.9
     css-loader: ^6.7.3


### PR DESCRIPTION
## Works Done

1. cubeSize prop added to the `Progress.tsx`.
2. Create `useProxiedAccounts.ts` hook.
3. Import proxy option added to the extension mode menu.
4. Create `ProxiedTable.tsx`.
5. `AddressDropdown.tsx` updated.
6. New path `'/import/proxied'` added to the rout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new component for importing proxied accounts.
  - Added a table component to display and manage proxied accounts.
  - Implemented a new full-screen view for importing proxied accounts.

- **Enhancements**
  - Updated the chain selection component to include an icon for additional information.
  - Improved dropdown menu styling to support full-width rendering.

- **Dependencies**
  - Added `chance` package for enhanced functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->