### PR TITLE
Display derived accounts in the import proxied list

### DIFF
--- a/packages/extension-polkagate/src/popup/import/importProxied/index.tsx
+++ b/packages/extension-polkagate/src/popup/import/importProxied/index.tsx
@@ -21,7 +21,7 @@ import ProxiedTable from './ProxiedTable';
 function ImportProxied (): React.ReactElement {
   const { t } = useTranslation();
   const onAction = useContext(ActionContext);
-  const { accounts, hierarchy } = useContext(AccountContext);
+  const { accounts } = useContext(AccountContext);
   const genesisOptions = useGenesisHashOptions();
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
   const chance = new Chance();
@@ -29,10 +29,10 @@ function ImportProxied (): React.ReactElement {
   const selectableChains = useMemo(() => genesisOptions.filter(({ value }) => PROXY_CHAINS.includes(value as string)), [genesisOptions]);
 
   const allAddresses = useMemo(() =>
-    hierarchy
+    accounts
       .filter(({ isExternal, isHardware, isQR }) => !isExternal || isQR || isHardware)
       .map(({ address, genesisHash, name }): [string, string | null, string | undefined] => [address, genesisHash || null, name])
-  , [hierarchy]);
+  , [accounts]);
 
   const [selectedAddress, setSelectedAddress] = useState<string | undefined>(undefined);
   const [selectedProxied, setSelectedProxied] = useState<string[]>([]);

--- a/packages/extension-polkagate/src/popup/import/importProxiedFullScreen/index.tsx
+++ b/packages/extension-polkagate/src/popup/import/importProxiedFullScreen/index.tsx
@@ -24,17 +24,17 @@ function ImportProxiedFS (): React.ReactElement {
   useFullscreen();
   const { t } = useTranslation();
   const theme = useTheme();
-  const { accounts, hierarchy } = useContext(AccountContext);
+  const { accounts } = useContext(AccountContext);
   const genesisOptions = useGenesisHashOptions();
   const chance = new Chance();
 
   const selectableChains = useMemo(() => genesisOptions.filter(({ value }) => PROXY_CHAINS.includes(value as string)), [genesisOptions]);
 
   const allAddresses = useMemo(() =>
-    hierarchy
+    accounts
       .filter(({ isExternal, isHardware, isQR }) => !isExternal || isQR || isHardware)
       .map(({ address, genesisHash, name }): [string, string | null, string | undefined] => [address, genesisHash || null, name])
-  , [hierarchy]);
+  , [accounts]);
 
   const [selectedAddress, setSelectedAddress] = useState<string | undefined>(undefined);
   const [selectedProxied, setSelectedProxied] = useState<string[]>([]);


### PR DESCRIPTION
Close: #1312 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated import functionality to use the `accounts` context instead of the `hierarchy` context for better consistency and performance improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->