### PR TITLE
Fix Pool unstaking issue, Update the Pool staking Entry buttons design

### DIFF
--- a/packages/extension-polkagate/src/fullscreen/stake/partials/PoolOptionsBig.tsx
+++ b/packages/extension-polkagate/src/fullscreen/stake/partials/PoolOptionsBig.tsx
@@ -13,14 +13,14 @@ import { useTranslation } from '../../../components/translate';
 import { useInfo, usePoolConsts } from '../../../hooks';
 import { openOrFocusTab } from '../../accountDetails/components/CommonTasks';
 import { STEPS } from '..';
-import StakingOption from './StakingOption';
+import StakingMode from './StakingMode';
 
 interface Props {
   address: string
   setStep: React.Dispatch<React.SetStateAction<number>>;
 }
 
-export default function PoolOptionsBig({ address, setStep }: Props): React.ReactElement {
+export default function PoolOptionsBig ({ address, setStep }: Props): React.ReactElement {
   const { t } = useTranslation();
   const theme = useTheme();
   const { api, chainName } = useInfo(address);
@@ -45,7 +45,7 @@ export default function PoolOptionsBig({ address, setStep }: Props): React.React
         {t('Options are available to commence pool staking in {{chainName}}. Please select your preference, taking into consideration the minimum requirements for receiving rewards per era.', { replace: { chainName } })}
       </Typography>
       <Grid alignItems='center' container item justifyContent='flex-start' pt='40px'>
-        <StakingOption
+        <StakingMode
           api={api}
           balance={poolConsts?.minJoinBond}
           balanceText={t('Minimum to receive rewards')}
@@ -63,7 +63,7 @@ export default function PoolOptionsBig({ address, setStep }: Props): React.React
           text={t('You can join existing pools, which will be shown to you in a list,')}
           title={t('Join a Pool')}
         />
-        <StakingOption
+        <StakingMode
           api={api}
           balance={poolConsts?.minCreationBond}
           balanceText={t('Minimum to receive rewards')}


### PR DESCRIPTION
## Works Done

1. Delete useless helper buttons on Unstaking popup
2. Disable go to review button when there ar some warnings like: you can't unbond all, unstaking more than staked amount, ...
3. Update the Pool staking entry page buttons design to  StakingMode 


Closes: #1320, #1310 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the `PoolOptionsBig` component to use `StakingMode` instead of `StakingOption`.

- **Improvements**
  - Consolidated helper text logic in the `Unstake` component for better clarity and maintainability.
  - Simplified state management for helper text in the `Unstake` component, improving the user interface responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->