### PR TITLE
fixes issue: Staking FS: Can not insert 0 after . like 1.002 in unstake page

### DIFF
--- a/packages/extension-polkagate/src/fullscreen/stake/pool/unstake/index.tsx
+++ b/packages/extension-polkagate/src/fullscreen/stake/pool/unstake/index.tsx
@@ -46,6 +46,8 @@ export default function Unstake ({ address, setRefresh, setShow, show }: Props):
   const [inputs, setInputs] = useState<Inputs>();
   const [estimatedFee, setEstimatedFee] = useState<Balance | undefined>();
   const [amountAsBN, setAmountAsBN] = useState<BN>();
+  const [amount, setAmount] = useState<string | undefined>();
+
   const [alert, setAlert] = useState<string | undefined>();
   const [unstakeMaxAmount, setUnstakeMaxAmount] = useState<boolean>(false);
 
@@ -164,16 +166,18 @@ export default function Unstake ({ address, setRefresh, setShow, show }: Props):
     }
 
     setAmountAsBN(amountToMachine(value.slice(0, MAX_AMOUNT_LENGTH), decimal));
+    setAmount(value.slice(0, MAX_AMOUNT_LENGTH));
   }, [decimal]);
 
   const onMaxAmount = useCallback(() => {
-    if (!myPool || !formatted || !poolConsts || !staked || staked.isZero()) {
+    if (!decimal || !myPool || !formatted || !poolConsts || !staked || staked.isZero()) {
       return;
     }
 
     if ((isPoolRoot || isPoolDepositor) && poolState === 'Destroying' && poolMemberCounter === 1) {
       setUnstakeMaxAmount(true);
       setAmountAsBN(staked);
+      setAmount(amountToHuman(staked, decimal));
 
       return;
     }
@@ -182,7 +186,11 @@ export default function Unstake ({ address, setRefresh, setShow, show }: Props):
       const partial = staked.sub(poolConsts.minCreateBond);
 
       setUnstakeMaxAmount(false);
-      !partial.isZero() && setAmountAsBN(partial);
+
+      if (!partial.isZero()) {
+        setAmountAsBN(partial);
+        setAmount(amountToHuman(partial, decimal));
+      }
 
       return;
     }
@@ -190,8 +198,9 @@ export default function Unstake ({ address, setRefresh, setShow, show }: Props):
     if (!isPoolDepositor && !isPoolRoot) {
       setUnstakeMaxAmount(true);
       setAmountAsBN(staked);
+      setAmount(amountToHuman(staked, decimal));
     }
-  }, [formatted, isPoolDepositor, isPoolRoot, myPool, poolConsts, poolMemberCounter, poolState, staked]);
+  }, [decimal, formatted, isPoolDepositor, isPoolRoot, myPool, poolConsts, poolMemberCounter, poolState, staked]);
 
   useEffect(() => {
     const handleInput = async () => {
@@ -287,7 +296,7 @@ export default function Unstake ({ address, setRefresh, setShow, show }: Props):
                 onChangeAmount={onChangeAmount}
                 onPrimary={onMaxAmount}
                 primaryBtnText={t('Max amount')}
-                value={amountToHuman(amountAsBN, decimal)}
+                value={amount}
               />
               {alert &&
                 <Warn belowInput iconDanger text={alert} />


### PR DESCRIPTION
fixes  #1327

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved staking pool unstake functionality by adding dynamic amount handling.
  
- **Enhancements**
  - Enhanced user experience by updating the amount field based on specific conditions for more accurate unstaking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->