### PR TITLE
Add reserved detail

### DIFF
--- a/packages/extension-polkagate/src/fullscreen/accountDetails/components/DisplayBalance.tsx
+++ b/packages/extension-polkagate/src/fullscreen/accountDetails/components/DisplayBalance.tsx
@@ -6,7 +6,7 @@
 import type { Balance } from '@polkadot/types/interfaces';
 
 import { ArrowForwardIosRounded as ArrowForwardIosRoundedIcon } from '@mui/icons-material';
-import { Divider, Grid, IconButton, Theme, Typography } from '@mui/material';
+import { Divider, Grid, IconButton, Theme, Typography, useTheme } from '@mui/material';
 import React from 'react';
 
 import { noop } from '@polkadot/extension-polkagate/src/util/utils';
@@ -14,18 +14,19 @@ import { BN } from '@polkadot/util';
 
 import { FormatPrice, ShowBalance } from '../../../components';
 
-interface DisplayBalanceProps {
+interface Props {
   amount: BN | Balance | undefined;
   title: string;
   token: string | undefined;
   decimal: number | undefined;
   price: number | undefined;
   onClick?: () => void;
-  theme?: Theme;
   disabled?: boolean;
 }
 
-export default function DisplayBalance ({ amount, decimal, disabled, onClick, price, theme, title, token }: DisplayBalanceProps): React.ReactElement {
+export default function DisplayBalance ({ amount, decimal, disabled, onClick, price, title, token }: Props): React.ReactElement {
+  const theme = useTheme();
+  
   return (
     <Grid alignItems='center' container item justifyContent='space-between' sx={{ bgcolor: 'background.paper', borderRadius: '5px', boxShadow: '2px 3px 4px 0px rgba(0, 0, 0, 0.1)', p: '15px 40px' }}>
       <Typography fontSize='18px' fontWeight={400}>
@@ -50,7 +51,7 @@ export default function DisplayBalance ({ amount, decimal, disabled, onClick, pr
             skeletonHeight={20}
           />
         </Grid>
-        {onClick && theme &&
+        {onClick &&
           <Grid item m='auto' pl='8px'>
             <IconButton
               onClick={disabled ? noop : onClick}

--- a/packages/extension-polkagate/src/fullscreen/accountDetails/components/ShowReservedDetails.tsx
+++ b/packages/extension-polkagate/src/fullscreen/accountDetails/components/ShowReservedDetails.tsx
@@ -1,0 +1,184 @@
+// Copyright 2019-2024 @polkadot/extension-ui authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+/* eslint-disable react/jsx-max-props-per-line */
+
+import type { PalletRecoveryRecoveryConfig, PalletReferendaReferendumInfoRankedCollectiveTally, PalletReferendaReferendumStatusRankedCollectiveTally } from '@polkadot/types/lookup';
+
+import { ArrowBackIos as ArrowBackIosIcon } from '@mui/icons-material';
+import { Grid, Typography, useTheme } from '@mui/material';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+
+import { Progress } from '@polkadot/extension-polkagate/src/components';
+import { useActiveRecoveries, useInfo, useTranslation } from '@polkadot/extension-polkagate/src/hooks';
+import { PROXY_CHAINS } from '@polkadot/extension-polkagate/src/util/constants';
+import { BN, BN_ZERO } from '@polkadot/util';
+
+import { toTitleCase } from '../../governance/utils/util';
+import { Proxy } from '../,,/../../../util/types';
+import DisplayBalance from './DisplayBalance';
+
+interface Props {
+  address: string;
+  setShowReservedDetails: React.Dispatch<React.SetStateAction<boolean>>
+
+}
+
+type Item = 'identity' | 'proxy';
+type Reserved = { [key in Item]?: BN };
+
+export default function ShowReservedDetails ({ address, setShowReservedDetails }: Props): React.ReactElement {
+  const { t } = useTranslation();
+  const theme = useTheme();
+
+  const { api, decimal, formatted, genesisHash, token } = useInfo(address);
+  const activeRecoveries = useActiveRecoveries(api);
+  const [reserved, setReserved] = useState<Reserved>({});
+
+  const activeLost = useMemo(() =>
+    activeRecoveries && formatted
+      ? activeRecoveries.filter((active) => active.lost === String(formatted)).at(-1) ?? null
+      : activeRecoveries === null
+        ? null
+        : undefined
+  , [activeRecoveries, formatted]);
+
+  const onBackClick = useCallback(() => {
+    setShowReservedDetails(false);
+  }, [setShowReservedDetails]);
+
+  useEffect(() => {
+    if (!api || !genesisHash) {
+      return;
+    }
+
+    const subAccountDeposit = api.consts.identity?.subAccountDeposit;
+
+    // TODO: needs to incorporate people chain
+    /** fetch identity reserved */
+    api.query?.identity?.identityOf(formatted).then((id) => {
+      const basicDeposit = api.consts.identity.basicDeposit;
+
+      !id.isEmpty && setReserved((prev) => {
+        prev.identity = basicDeposit as unknown as BN;
+
+        return prev;
+      });
+    }).catch(console.error);
+
+    /** fetch proxy reserved */
+    if (api.query?.proxy && PROXY_CHAINS.includes(genesisHash)) {
+      const proxyDepositBase = api.consts.proxy.proxyDepositBase as unknown as BN;
+      const proxyDepositFactor = api.consts.proxy.proxyDepositFactor as unknown as BN;
+
+      api.query.proxy.proxies(formatted).then((p) => {
+        const fetchedProxies = JSON.parse(JSON.stringify(p[0])) as unknown as Proxy[];
+        const proxyCount = fetchedProxies.length;
+
+        if (proxyCount > 0) {
+          setReserved((prev) => {
+            prev.proxy = proxyDepositBase.add(proxyDepositFactor.muln(proxyCount));
+
+            return prev;
+          });
+        }
+      }).catch(console.error);
+    }
+
+    /** fetch social recovery reserved */
+    api?.query?.recovery && api.query.recovery.recoverable(formatted).then((r) => {
+      const recoveryInfo = r.isSome ? r.unwrap() as unknown as PalletRecoveryRecoveryConfig : null;
+
+      recoveryInfo?.deposit && setReserved((prev) => {
+        prev.recovery = (recoveryInfo.deposit as unknown as BN).add(activeLost?.deposit as unknown as BN || BN_ZERO);
+
+        return prev;
+      });
+    }).catch(console.error);
+
+    /** Fetch referenda reserved */
+    if (api.query?.referenda?.referendumInfoFor) {
+      let referendaDepositSum = BN_ZERO;
+
+      api.query.referenda.referendumInfoFor.entries().then((referenda) => {
+        referenda.forEach(([_, value]) => {
+          if (value.isSome) {
+            const ref = (value.unwrap()) as PalletReferendaReferendumInfoRankedCollectiveTally | undefined;
+
+            if (!ref) {
+              return;
+            }
+
+            const info = (ref.isCancelled
+              ? ref.asCancelled
+              : ref.isRejected
+                ? ref.asRejected
+                : ref.isOngoing
+                  ? ref.asOngoing
+                  : ref.isApproved ? ref.asApproved : undefined) as PalletReferendaReferendumStatusRankedCollectiveTally | undefined;
+
+            if (info?.submissionDeposit && info.submissionDeposit.who.toString() === formatted) {
+              referendaDepositSum = referendaDepositSum.add(info.submissionDeposit.amount);
+            }
+
+            if (info?.decisionDeposit?.isSome) {
+              const decisionDeposit = info?.decisionDeposit.unwrap();
+
+              if (decisionDeposit.who.toString() === formatted) {
+                referendaDepositSum = referendaDepositSum.add(decisionDeposit.amount);
+              }
+            }
+          }
+        });
+
+        if (!referendaDepositSum.isZero()) {
+          setReserved((prev) => {
+            prev.referenda = referendaDepositSum;
+
+            return prev;
+          });
+        }
+      }).catch(console.error);
+    }
+  }, [activeLost?.deposit, api, formatted, genesisHash]);
+
+  return (
+    <Grid alignItems='center' container item>
+      <Grid alignItems='flex-start' container mb='10px'>
+        <Grid item xs={0.3}>
+          <ArrowBackIosIcon
+            onClick={onBackClick}
+            sx={{
+              color: 'secondary.light',
+              cursor: 'pointer',
+              fontSize: 25,
+              stroke: theme.palette.secondary.light,
+              strokeWidth: 1
+            }}
+          />
+        </Grid>
+        <Grid item>
+          <Typography fontSize='20px' fontWeight={500} ml='5px'>
+            {t('Reserved details')}
+          </Typography>
+        </Grid>
+      </Grid>
+      {Object.entries(reserved)?.length
+        ? <Grid container direction='column' item mb='10px' minWidth='735px' rowGap='10px'>
+          {Object.entries(reserved)?.map(([key, value], index) => (
+            <DisplayBalance
+              amount={value}
+              decimal={decimal}
+              key={index}
+              price={0}
+              title={toTitleCase(key)}
+              token={token}
+            />
+          ))
+          }
+        </Grid>
+        : <Progress pt='40px' title={t('Loading information ...')} type='grid' />
+      }
+    </Grid>
+  );
+}

--- a/packages/extension-polkagate/src/fullscreen/accountDetails/components/TotalChart.tsx
+++ b/packages/extension-polkagate/src/fullscreen/accountDetails/components/TotalChart.tsx
@@ -19,10 +19,8 @@ import { Prices } from '../../../util/types';
 import { amountToHuman } from '../../../util/utils';
 import { adjustColor } from '../../homeFullScreen/partials/TotalBalancePieChart';
 
-interface TotalChartProps {
-  isDarkTheme: boolean;
+interface Props {
   accountAssets: FetchedBalance[] | null | undefined;
-  nativeAssetPrice: number | undefined;
   pricesInCurrency: Prices | null | undefined
 }
 
@@ -32,7 +30,7 @@ interface AssetsToShow extends FetchedBalance {
   color: string
 }
 
-export default function TotalChart({ accountAssets, isDarkTheme, pricesInCurrency }: TotalChartProps): React.ReactElement {
+export default function TotalChart ({ accountAssets, pricesInCurrency }: Props): React.ReactElement {
   const { t } = useTranslation();
   const theme = useTheme();
   const currency = useCurrency();

--- a/packages/extension-polkagate/src/popup/import/importProxied/ProxiedTable.tsx
+++ b/packages/extension-polkagate/src/popup/import/importProxied/ProxiedTable.tsx
@@ -91,7 +91,6 @@ export default function ProxiedTable ({ api, chain, label, maxHeight = '120px', 
           {proxiedAccounts && proxiedAccounts.length > 0 && proxiedAccounts.map((proxiedAccount, index) =>
             <Grid container item key={index} sx={{ height: isExtensionMode ? '41px' : '50px', opacity: isAvailable(proxiedAccount) ? '0.5' : 1, textAlign: 'center' }}>
               <Grid alignItems='center' container height='100%' item justifyContent='center' xs={isExtensionMode ? 2 : 1}>
-                {/* <Select disabled={isAvailable(proxiedAccount)} index={index} proxied={proxiedAccount} /> */}
                 <Checkbox
                   checked={selectedProxied?.includes(proxiedAccount)}
                   disabled={isAvailable(proxiedAccount)}

--- a/packages/extension-polkagate/src/popup/import/importProxiedFullScreen/index.tsx
+++ b/packages/extension-polkagate/src/popup/import/importProxiedFullScreen/index.tsx
@@ -32,7 +32,7 @@ function ImportProxiedFS (): React.ReactElement {
 
   const allAddresses = useMemo(() =>
     accounts
-      .filter(({ isExternal, isHardware, isQR }) => !isExternal || isQR || isHardware)
+      // .filter(({ isExternal, isHardware, isQR }) => !isExternal || isQR || isHardware)
       .map(({ address, genesisHash, name }): [string, string | null, string | undefined] => [address, genesisHash || null, name])
   , [accounts]);
 


### PR DESCRIPTION
resolves #1303

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced the `ShowReservedDetails` component for displaying reserved details related to identity, proxy, social recovery, and referenda.

- **Enhancements**
  - Simplified the `DisplayBalance` component by using the `useTheme` hook from Material-UI.
  - Refactored the `TotalChart` component to remove unnecessary props and streamline functionality.
  - Improved state management in account details by adding `showReservedDetails` state and related logic.

- **Bug Fixes**
  - Adjusted the layout of the `ProxiedTable` component by removing a commented-out `<Select>` component.

- **Chores**
  - Commented out a filter condition in the `ImportProxiedFS` function to adjust the filtering logic for accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->