### PR TITLE
Refactor and Standardize Route paths

### DIFF
--- a/packages/extension-base/src/defaults.ts
+++ b/packages/extension-base/src/defaults.ts
@@ -1,7 +1,7 @@
 // Copyright 2019-2024 @polkadot/extension-base authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-const ALLOWED_PATH = ['/', '/account/import-ledger', '/account/restore-json'] as const;
+const ALLOWED_PATH = ['/', '/create-account-full-screen'] as const;
 // Added for Polkagate
 const START_WITH_PATH = [
   '/account/',

--- a/packages/extension-polkagate/src/fullscreen/homeFullScreen/partials/HomeMenu.tsx
+++ b/packages/extension-polkagate/src/fullscreen/homeFullScreen/partials/HomeMenu.tsx
@@ -73,7 +73,7 @@ export default function HomeMenu (): React.ReactElement {
   const areAllExternalAccounts = useMemo(() => accounts.every(({ isExternal }) => isExternal), [accounts]);
 
   const onCreate = useCallback(() => {
-    openOrFocusTab('/account/create');
+    openOrFocusTab('/create-account-full-screen');
   }, []);
 
   const onExportAll = useCallback(() => {

--- a/packages/extension-polkagate/src/fullscreen/homeFullScreen/partials/ImportAccSubMenuFullScreen.tsx
+++ b/packages/extension-polkagate/src/fullscreen/homeFullScreen/partials/ImportAccSubMenuFullScreen.tsx
@@ -27,15 +27,15 @@ function ImportAccSubMenuFullScreen ({ show, toggleSettingSubMenu }: Props): Rea
   const theme = useTheme();
 
   const onRestoreFromJson = useCallback((): void => {
-    openOrFocusTab('/account/restore-json');
+    openOrFocusTab('/import/restore-json-full-screen');
   }, []);
 
   const onImportFromSeed = useCallback(() => {
-    openOrFocusTab('/account/import-seed');
+    openOrFocusTab('/import/seed-full-screen');
   }, []);
 
   const onImportFromRawSeed = useCallback(() => {
-    openOrFocusTab('/account/import-raw-seed');
+    openOrFocusTab('/import/raw-seed-full-screen');
   }, []);
 
   const onAddWatchOnlyFullScreen = useCallback(() => {
@@ -51,7 +51,7 @@ function ImportAccSubMenuFullScreen ({ show, toggleSettingSubMenu }: Props): Rea
   }, []);
 
   const onImportLedger = useCallback((): void => {
-    openOrFocusTab('/account/import-ledger');
+    openOrFocusTab('/import/ledger-full-screen');
   }, []);
 
   return (

--- a/packages/extension-polkagate/src/fullscreen/onboarding/index.tsx
+++ b/packages/extension-polkagate/src/fullscreen/onboarding/index.tsx
@@ -40,13 +40,13 @@ function Onboarding (): React.ReactElement {
 
   const onRestoreFromJson = useCallback(
     (): void => {
-      windowOpen('/account/restore-json').catch(console.error);
+      windowOpen('/import/restore-json-full-screen').catch(console.error);
     }, []
   );
 
   const onImportLedger = useCallback(
     (): void => {
-      windowOpen('/account/import-ledger').catch(console.error);
+      windowOpen('/import/ledger-full-screen').catch(console.error);
     }, []
   );
 
@@ -63,7 +63,7 @@ function Onboarding (): React.ReactElement {
 
   const onCreate = useCallback(
     (): void => {
-      windowOpen('/account/create').catch(console.error);
+      windowOpen('/create-account-full-screen').catch(console.error);
     }, []
   );
 
@@ -75,13 +75,13 @@ function Onboarding (): React.ReactElement {
 
   const onImport = useCallback(
     (): void => {
-      windowOpen('/account/import-seed').catch(console.error);
+      windowOpen('/import/seed-full-screen').catch(console.error);
     }, []
   );
 
   const onImportRawSeed = useCallback(
     (): void => {
-      windowOpen('/account/import-raw-seed').catch(console.error);
+      windowOpen('/import/raw-seed-full-screen').catch(console.error);
     }, []
   );
 

--- a/packages/extension-polkagate/src/partials/AddNewAccountButton.tsx
+++ b/packages/extension-polkagate/src/partials/AddNewAccountButton.tsx
@@ -22,8 +22,8 @@ export default function AddNewAccountButton (): React.ReactElement {
 
   const onCreate = useCallback((): void => {
     isExtensionMode
-      ? windowOpen('/account/create').catch(console.error)
-      : onAction('/account/create');
+      ? windowOpen('/create-account-full-screen').catch(console.error)
+      : onAction('/create-account-full-screen');
   }, [isExtensionMode, onAction]);
 
   return (

--- a/packages/extension-polkagate/src/partials/ImportAccSubMenu.tsx
+++ b/packages/extension-polkagate/src/partials/ImportAccSubMenu.tsx
@@ -26,15 +26,15 @@ function ImportAccSubMenu ({ show, toggleSettingSubMenu }: Props): React.ReactEl
   const onAction = useContext(ActionContext);
 
   const onRestoreFromJson = useCallback((): void => {
-    windowOpen('/account/restore-json').catch(console.error);
+    windowOpen('/import/restore-json-full-screen').catch(console.error);
   }, []);
 
   const onImportAcc = useCallback(() => {
-    windowOpen('/account/import-seed').catch(console.error);
+    windowOpen('/import/seed-full-screen').catch(console.error);
   }, []);
 
   const onImportRawSeed = useCallback(() => {
-    windowOpen('/account/import-raw-seed').catch(console.error);
+    windowOpen('/import/raw-seed-full-screen').catch(console.error);
   }, []);
 
   const onAddWatchOnly = useCallback(() => {
@@ -46,7 +46,7 @@ function ImportAccSubMenu ({ show, toggleSettingSubMenu }: Props): React.ReactEl
   }, [onAction]);
 
   const onImportLedger = useCallback((): void => {
-    windowOpen('/account/import-ledger').catch(console.error);
+    windowOpen('/import/ledger-full-screen').catch(console.error);
   }, []);
 
   const onImportProxied = useCallback((): void => {

--- a/packages/extension-polkagate/src/partials/Menu.tsx
+++ b/packages/extension-polkagate/src/partials/Menu.tsx
@@ -65,7 +65,7 @@ function Menu ({ setShowMenu, theme }: Props): React.ReactElement<Props> {
   }, [setShowMenu]);
 
   const _goToExportAll = useCallback(() => {
-    onAction('/account/export-all');
+    onAction('/export/all');
   }, [onAction]);
 
   const onEnableTestnetConfirm = useCallback(() => {

--- a/packages/extension-polkagate/src/partials/NewAccountSubMenu.tsx
+++ b/packages/extension-polkagate/src/partials/NewAccountSubMenu.tsx
@@ -27,7 +27,7 @@ function NewAccountSubMenu({ show }: Props): React.ReactElement<Props> {
   }, [master, onAction]);
 
   const goToCreateAcc = useCallback(() => {
-    windowOpen('/account/create').catch(console.error);
+    windowOpen('/create-account-full-screen').catch(console.error);
   }, []);
 
   return (

--- a/packages/extension-polkagate/src/popup/passwordManagement/Reset.tsx
+++ b/packages/extension-polkagate/src/popup/passwordManagement/Reset.tsx
@@ -19,11 +19,11 @@ function Reset (): React.ReactElement {
   const theme = useTheme();
 
   const _goToRestoreFromJson = useCallback((): void => {
-    windowOpen('/account/restore-json').catch(console.error);
+    windowOpen('/import/restore-json-full-screen').catch(console.error);
   }, []);
 
   const _goToImport = useCallback((): void => {
-    windowOpen('/account/import-seed').catch(console.error);
+    windowOpen('/import/seed-full-screen').catch(console.error);
   }, []);
 
   return (

--- a/packages/extension-polkagate/src/popup/passwordManagement/ResetFS.tsx
+++ b/packages/extension-polkagate/src/popup/passwordManagement/ResetFS.tsx
@@ -24,11 +24,11 @@ function ResetFS (): React.ReactElement {
   useFullscreen();
 
   const _goToRestoreFromJson = useCallback((): void => {
-    windowOpen('/account/restore-json').catch(console.error);
+    windowOpen('/import/restore-json-full-screen').catch(console.error);
   }, []);
 
   const _goToImport = useCallback((): void => {
-    windowOpen('/account/import-seed').catch(console.error);
+    windowOpen('/import/seed-full-screen').catch(console.error);
   }, []);
 
   return (

--- a/packages/extension-polkagate/src/popup/welcome/index.tsx
+++ b/packages/extension-polkagate/src/popup/welcome/index.tsx
@@ -23,19 +23,19 @@ function Welcome(): React.ReactElement {
 
   const onRestoreFromJson = useCallback(
     (): void => {
-      windowOpen('/account/restore-json').catch(console.error);
+      windowOpen('/import/restore-json-full-screen').catch(console.error);
     }, []
   );
 
   const onImportLedger = useCallback(
     (): void => {
-      windowOpen('/account/import-ledger').catch(console.error);
+      windowOpen('/import/ledger-full-screen').catch(console.error);
     }, []
   );
 
   const onCreate = useCallback(
     (): void => {
-      windowOpen('/account/create').catch(console.error);
+      windowOpen('/create-account-full-screen').catch(console.error);
     }, []
   );
 
@@ -47,13 +47,13 @@ function Welcome(): React.ReactElement {
 
   const onImport = useCallback(
     (): void => {
-      windowOpen('/account/import-seed').catch(console.error);
+      windowOpen('/import/seed-full-screen').catch(console.error);
     }, []
   );
 
   const onImportRawSeed = useCallback(
     (): void => {
-      windowOpen('/account/import-raw-seed').catch(console.error);
+      windowOpen('/import/raw-seed-full-screen').catch(console.error);
     }, []
   );
 

--- a/packages/extension-polkagate/src/util/constants.tsx
+++ b/packages/extension-polkagate/src/util/constants.tsx
@@ -209,4 +209,4 @@ export const USD_CURRENCY = {
 };
 
 export const FULLSCREEN_WIDTH = '900px';
-export const ALLOWED_URL_ON_RESET_PASSWORD = ['/account/restore-json', '/account/import-seed', '/account/import-raw-seed', '/forgot-password', '/reset-wallet'];
+export const ALLOWED_URL_ON_RESET_PASSWORD = ['/import/restore-json-full-screen', '/import/seed-full-screen', '/import/raw-seed-full-screen', '/forgot-password', '/reset-wallet'];

--- a/packages/extension-ui/src/Popup/index.tsx
+++ b/packages/extension-ui/src/Popup/index.tsx
@@ -282,17 +282,13 @@ export default function Popup (): React.ReactElement {
                                 <SigningReqContext.Provider value={signRequests}>
                                   <Switch>
                                     <Route path='/account/:genesisHash/:address/'>{wrapWithErrorBoundary(<AccountEx />, 'account')}</Route>
-                                    <Route path='/account/create'>{wrapWithErrorBoundary(<CreateAccount />, 'account-creation')}</Route>
-                                    <Route path='/account/export-all'>{wrapWithErrorBoundary(<ExportAll />, 'export-all-address')}</Route>
-                                    <Route path='/account/import-ledger'>{wrapWithErrorBoundary(<ImportLedger />, 'import-ledger')}</Route>
-                                    <Route path='/account/import-seed'>{wrapWithErrorBoundary(<ImportSeed />, 'import-seed')}</Route>
-                                    <Route path='/account/import-raw-seed'>{wrapWithErrorBoundary(<ImportRawSeed />, 'import-raw-seed')}</Route>
-                                    <Route path='/account/restore-json'>{wrapWithErrorBoundary(<RestoreJson />, 'restore-json')}</Route>
                                     <Route path='/accountfs/:address/:paramAssetId'>{wrapWithErrorBoundary(<AccountFS />, 'account')}</Route>
                                     <Route path='/auth-list'>{wrapWithErrorBoundary(<AuthList />, 'auth-list')}</Route>
+                                    <Route path='/create-account-full-screen'>{wrapWithErrorBoundary(<CreateAccount />, 'account-creation')}</Route>
                                     <Route path='/crowdloans/:address'>{wrapWithErrorBoundary(<CrowdLoans />, 'crowdloans')}</Route>
                                     <Route path='/derive/:address/locked'>{wrapWithErrorBoundary(<Derive isLocked />, 'derived-address-locked')}</Route>
                                     <Route path='/derive/:address'>{wrapWithErrorBoundary(<Derive />, 'derive-address')}</Route>
+                                    <Route path='/export/all'>{wrapWithErrorBoundary(<ExportAll />, 'export-all-address')}</Route>
                                     <Route path='/export/:address'>{wrapWithErrorBoundary(<Export />, 'export-address')}</Route>
                                     <Route path='/forget/:address/:isExternal'>{wrapWithErrorBoundary(<ForgetAccount />, 'forget-address')}</Route>
                                     <Route path='/forgot-password'>{wrapWithErrorBoundary(<ForgotPassword />, 'forgot-password')}</Route>
@@ -306,8 +302,12 @@ export default function Popup (): React.ReactElement {
                                     <Route path='/import/add-watch-only-full-screen'>{wrapWithErrorBoundary(<AddWatchOnlyFullScreen />, 'import-add-watch-only-full-screen')}</Route>
                                     <Route path='/import/attach-qr'>{wrapWithErrorBoundary(<AttachQR />, 'attach-qr')}</Route>
                                     <Route path='/import/attach-qr-full-screen'>{wrapWithErrorBoundary(<AttachQrFullScreen />, 'attach-qr-full-screen')}</Route>
+                                    <Route path='/import/ledger-full-screen'>{wrapWithErrorBoundary(<ImportLedger />, 'import-ledger-full-screen')}</Route>
                                     <Route path='/import/proxied'>{wrapWithErrorBoundary(<ImportProxied />, 'import-proxied')}</Route>
                                     <Route path='/import/proxied-full-screen'>{wrapWithErrorBoundary(<ImportProxiedFullScreen />, 'import-add-watch-only-full-screen')}</Route>
+                                    <Route path='/import/raw-seed-full-screen'>{wrapWithErrorBoundary(<ImportRawSeed />, 'import-raw-seed-full-screen')}</Route>
+                                    <Route path='/import/restore-json-full-screen'>{wrapWithErrorBoundary(<RestoreJson />, 'restore-json-full-screen')}</Route>
+                                    <Route path='/import/seed-full-screen'>{wrapWithErrorBoundary(<ImportSeed />, 'import-seed-full-screen')}</Route>
                                     <Route path='/login-password'>{wrapWithErrorBoundary(<LoginPassword />, 'manage-login-password')}</Route>
                                     <Route path='/manageProxies/:address'>{wrapWithErrorBoundary(<ManageProxies />, 'manageProxies')}</Route>
                                     <Route path='/manageIdentity/:address'>{wrapWithErrorBoundary(<ManageIdentity />, 'manage-identity')}</Route>


### PR DESCRIPTION
## Works Done

1. Paths changed:

      - `/account/import-ledger`        -->> `/import/ledger-full-screen`
      - `/account/create`                     -->> `/create-account-full-screen`
      - `/account/restore-json`           -->> `/import/restore-json-full-screen`
      - `/account/import-seed`           -->> `/import/seed-full-screen`
      - `/account/import-raw-seed`    -->> `/import/raw-seed-full-screen`
      - `/account/export-all`               -->> `/export/all`

2. `ALLOWED_URL_ON_RESET_PASSWORD` updated.
3. `packages/extension-ui/src/Popup/index.tsx` routes updated.

Close #1361.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced full-screen views for account creation, importing, and restoring actions.

- **Updates**
  - Updated navigation paths across the app for a more consistent user experience, including new paths for creating accounts and importing data.
  - Adjusted allowed URLs on the reset password page to match the new full-screen paths.

- **Bug Fixes**
  - Fixed navigation issues by updating outdated paths to the new full-screen URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->