### PR TITLE
Refactor Proxy Type Filter to Use PROXY_TYPE Constants

### DIFF
--- a/packages/extension-polkagate/src/fullscreen/accountDetails/unlock/Review.tsx
+++ b/packages/extension-polkagate/src/fullscreen/accountDetails/unlock/Review.tsx
@@ -29,8 +29,8 @@ import { amountToHuman } from '../../../util/utils';
 import { DraggableModal } from '../../governance/components/DraggableModal';
 import SelectProxyModal2 from '../../governance/components/SelectProxyModal2';
 import WaitScreen from '../../governance/partials/WaitScreen';
-import { GOVERNANCE_PROXY } from '../../governance/utils/consts';
 import Confirmation from './Confirmation';
+import { PROXY_TYPE } from '../../../util/constants';
 
 interface Props {
   address: string;
@@ -174,7 +174,7 @@ export default function Review({ address, api, classToUnlock, setDisplayPopup, s
                 isPasswordError={isPasswordError}
                 onSecondaryClick={onClose}
                 primaryBtnText={t('Confirm')}
-                proxyTypeFilter={GOVERNANCE_PROXY}
+                proxyTypeFilter={PROXY_TYPE.GOVERNANCE}
                 secondaryBtnText={t('Back')}
                 selectedProxy={selectedProxy}
                 setIsPasswordError={setIsPasswordError}
@@ -192,7 +192,7 @@ export default function Review({ address, api, classToUnlock, setDisplayPopup, s
             closeSelectProxy={closeProxy}
             height={500}
             proxies={proxyItems}
-            proxyTypeFilter={['Any', 'NonTransfer']}
+            proxyTypeFilter={PROXY_TYPE.GOVERNANCE}
             selectedProxy={selectedProxy}
             setSelectedProxy={setSelectedProxy}
           />

--- a/packages/extension-polkagate/src/fullscreen/governance/delegate/Review.tsx
+++ b/packages/extension-polkagate/src/fullscreen/governance/delegate/Review.tsx
@@ -18,8 +18,8 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Identity, Motion, ShowValue, SignArea2, WrongPasswordAlert } from '../../../components';
 import { useIdentity, useInfo, useTracks, useTranslation } from '../../../hooks';
 import { ThroughProxy } from '../../../partials';
+import { PROXY_TYPE } from '../../../util/constants';
 import DisplayValue from '../post/castVote/partial/DisplayValue';
-import { GOVERNANCE_PROXY } from '../utils/consts';
 import TracksList from './partial/TracksList';
 import { DelegateInformation, STEPS } from '.';
 
@@ -152,7 +152,7 @@ export default function Review({ address, delegateInformation, estimatedFee, sel
           isPasswordError={isPasswordError}
           onSecondaryClick={onBackClick}
           primaryBtnText={t('Confirm')}
-          proxyTypeFilter={GOVERNANCE_PROXY}
+          proxyTypeFilter={PROXY_TYPE.GOVERNANCE}
           secondaryBtnText={t('Back')}
           selectedProxy={selectedProxy}
           setIsPasswordError={setIsPasswordError}

--- a/packages/extension-polkagate/src/fullscreen/governance/delegate/index.tsx
+++ b/packages/extension-polkagate/src/fullscreen/governance/delegate/index.tsx
@@ -18,10 +18,10 @@ import { BN, BN_ONE } from '@polkadot/util';
 import { cryptoWaitReady } from '@polkadot/util-crypto';
 
 import { useAccountLocks, useBalances, useInfo, useProxies, useTracks, useTranslation } from '../../../hooks';
+import { PROXY_TYPE } from '../../../util/constants';
 import { DraggableModal } from '../components/DraggableModal';
 import SelectProxyModal2 from '../components/SelectProxyModal2';
 import WaitScreen from '../partials/WaitScreen';
-import { GOVERNANCE_PROXY } from '../utils/consts';
 import { DelegationInfo } from '../utils/types';
 import { getMyDelegationInfo } from '../utils/util';
 import ChooseDelegator from './delegate/ChooseDelegator';
@@ -358,7 +358,7 @@ export function Delegate({ address, open, setOpen, showDelegationNote }: Props):
             closeSelectProxy={() => setStep(proxyStep)}
             height={modalHeight}
             proxies={proxyItems}
-            proxyTypeFilter={GOVERNANCE_PROXY}
+            proxyTypeFilter={PROXY_TYPE.GOVERNANCE}
             selectedProxy={selectedProxy}
             setSelectedProxy={setSelectedProxy}
           />

--- a/packages/extension-polkagate/src/fullscreen/governance/delegate/modify/ModifyDelegate.tsx
+++ b/packages/extension-polkagate/src/fullscreen/governance/delegate/modify/ModifyDelegate.tsx
@@ -23,9 +23,9 @@ import { Identity, Motion, ShowValue, SignArea2, WrongPasswordAlert } from '../.
 import { useCurrentBlockNumber, useIdentity, useInfo, useTracks, useTranslation } from '../../../../hooks';
 import { Lock } from '../../../../hooks/useAccountLocks';
 import { ThroughProxy } from '../../../../partials';
+import { PROXY_TYPE } from '../../../../util/constants';
 import { amountToHuman, amountToMachine } from '../../../../util/utils';
 import DisplayValue from '../../post/castVote/partial/DisplayValue';
-import { GOVERNANCE_PROXY } from '../../utils/consts';
 import TracksList from '../partial/TracksList';
 import { AlreadyDelegateInformation, DelegateInformation, STEPS } from '..';
 import Modify from './Modify';
@@ -324,7 +324,7 @@ export default function ModifyDelegate({ accountLocks, address, balances, classi
                 isPasswordError={isPasswordError}
                 onSecondaryClick={onBackClick}
                 primaryBtnText={t('Confirm')}
-                proxyTypeFilter={GOVERNANCE_PROXY}
+                proxyTypeFilter={PROXY_TYPE.GOVERNANCE}
                 secondaryBtnText={t('Back')}
                 selectedProxy={selectedProxy}
                 setIsPasswordError={setIsPasswordError}

--- a/packages/extension-polkagate/src/fullscreen/governance/delegate/remove/RemoveDelegate.tsx
+++ b/packages/extension-polkagate/src/fullscreen/governance/delegate/remove/RemoveDelegate.tsx
@@ -20,8 +20,8 @@ import { BN_ONE, BN_ZERO } from '@polkadot/util';
 import { Identity, Motion, ShowValue, SignArea2, WrongPasswordAlert } from '../../../../components';
 import { useIdentity, useInfo, useTracks, useTranslation } from '../../../../hooks';
 import { ThroughProxy } from '../../../../partials';
+import { PROXY_TYPE } from '../../../../util/constants';
 import DisplayValue from '../../post/castVote/partial/DisplayValue';
-import { GOVERNANCE_PROXY } from '../../utils/consts';
 import ReferendaTable from '../partial/ReferendaTable';
 import TracksList from '../partial/TracksList';
 import { AlreadyDelegateInformation, DelegateInformation, STEPS } from '..';
@@ -212,7 +212,7 @@ export default function RemoveDelegate({ address, classicDelegateInformation, fo
             isPasswordError={isPasswordError}
             onSecondaryClick={onBackClick}
             primaryBtnText={t('Confirm')}
-            proxyTypeFilter={GOVERNANCE_PROXY}
+            proxyTypeFilter={PROXY_TYPE.GOVERNANCE}
             secondaryBtnText={t('Back')}
             selectedProxy={selectedProxy}
             setIsPasswordError={setIsPasswordError}

--- a/packages/extension-polkagate/src/fullscreen/governance/post/castVote/Review.tsx
+++ b/packages/extension-polkagate/src/fullscreen/governance/post/castVote/Review.tsx
@@ -23,7 +23,8 @@ import { BN_ZERO } from '@polkadot/util';
 import { Identity, Motion, ShowBalance, ShowValue, SignArea2, Warning, WrongPasswordAlert } from '../../../../components';
 import { useInfo, useTranslation } from '../../../../hooks';
 import { ThroughProxy } from '../../../../partials';
-import { ENDED_STATUSES, GOVERNANCE_PROXY, STATUS_COLOR } from '../../utils/consts';
+import { ENDED_STATUSES, STATUS_COLOR } from '../../utils/consts';
+import { PROXY_TYPE } from '../../../../util/constants';
 import DisplayValue from './partial/DisplayValue';
 import { STEPS, VoteInformation } from '.';
 
@@ -184,7 +185,7 @@ export default function Review({ address, estimatedFee, selectedProxy, setModalH
             params={params}
             previousStep={txType === 'Vote' ? STEPS.REVIEW : STEPS.REMOVE}
             primaryBtnText={t('Confirm')}
-            proxyTypeFilter={GOVERNANCE_PROXY}
+            proxyTypeFilter={PROXY_TYPE.GOVERNANCE}
             secondaryBtnText={t('Back')}
             selectedProxy={selectedProxy}
             setIsPasswordError={setIsPasswordError}

--- a/packages/extension-polkagate/src/fullscreen/governance/post/castVote/index.tsx
+++ b/packages/extension-polkagate/src/fullscreen/governance/post/castVote/index.tsx
@@ -18,10 +18,10 @@ import { cryptoWaitReady } from '@polkadot/util-crypto';
 
 import { useInfo, useProxies, useTranslation } from '../../../../hooks';
 import { amountToHuman, amountToMachine } from '../../../../util/utils';
+import { PROXY_TYPE } from '../../../../util/constants';
 import { DraggableModal } from '../../components/DraggableModal';
 import SelectProxyModal2 from '../../components/SelectProxyModal2';
 import WaitScreen from '../../partials/WaitScreen';
-import { GOVERNANCE_PROXY } from '../../utils/consts';
 import { getVoteType } from '../../utils/util';
 import { getConviction, Vote } from '../myVote/util';
 import About from './About';
@@ -273,7 +273,7 @@ export default function Index({ address, cantModify, hasVoted, myVote, notVoted,
             closeSelectProxy={() => setStep(alterType === 'remove' ? STEPS.REMOVE : STEPS.REVIEW)}
             height={reviewModalHeight}
             proxies={proxyItems}
-            proxyTypeFilter={GOVERNANCE_PROXY}
+            proxyTypeFilter={PROXY_TYPE.GOVERNANCE}
             selectedProxy={selectedProxy}
             setSelectedProxy={setSelectedProxy}
           />

--- a/packages/extension-polkagate/src/fullscreen/governance/post/decisionDeposit/index.tsx
+++ b/packages/extension-polkagate/src/fullscreen/governance/post/decisionDeposit/index.tsx
@@ -18,11 +18,11 @@ import { cryptoWaitReady } from '@polkadot/util-crypto';
 import { Identity, ShowBalance, SignArea2, Warning } from '../../../../components';
 import { useAccountDisplay, useBalances, useInfo, useProxies, useTranslation } from '../../../../hooks';
 import { ThroughProxy } from '../../../../partials';
+import { PROXY_TYPE } from '../../../../util/constants';
 import type { Proxy, ProxyItem, TxInfo } from '../../../../util/types';
 import { DraggableModal } from '../../components/DraggableModal';
 import SelectProxyModal2 from '../../components/SelectProxyModal2';
 import WaitScreen from '../../partials/WaitScreen';
-import { GOVERNANCE_PROXY } from '../../utils/consts';
 import { type Track } from '../../utils/types';
 import DisplayValue from '../castVote/partial/DisplayValue';
 import Confirmation from './Confirmation';
@@ -200,7 +200,7 @@ export default function DecisionDeposit({ address, open, refIndex, setOpen, trac
                 params={[refIndex]}
                 previousStep={STEPS.REVIEW}
                 primaryBtnText={t('Confirm')}
-                proxyTypeFilter={GOVERNANCE_PROXY}
+                proxyTypeFilter={PROXY_TYPE.GOVERNANCE}
                 secondaryBtnText={t('Close')}
                 selectedProxy={selectedProxy}
                 setIsPasswordError={setIsPasswordError}
@@ -219,7 +219,7 @@ export default function DecisionDeposit({ address, open, refIndex, setOpen, trac
             closeSelectProxy={() => setStep(STEPS.REVIEW)}
             height={HEIGHT}
             proxies={proxyItems}
-            proxyTypeFilter={GOVERNANCE_PROXY}
+            proxyTypeFilter={PROXY_TYPE.GOVERNANCE}
             selectedProxy={selectedProxy}
             setSelectedProxy={setSelectedProxy}
           />

--- a/packages/extension-polkagate/src/fullscreen/governance/utils/consts.ts
+++ b/packages/extension-polkagate/src/fullscreen/governance/utils/consts.ts
@@ -10,7 +10,6 @@ export const TRACK_LIMIT_TO_LOAD_PER_REQUEST = LATEST_REFERENDA_LIMIT_TO_LOAD_PE
 export const REFERENDA_LIMIT_SAVED_LOCAL = 2 * LATEST_REFERENDA_LIMIT_TO_LOAD_PER_REQUEST;
 
 export const FINISHED_REFERENDUM_STATUSES = ['Cancelled', 'Confirmed', 'Executed', 'Rejected', 'TimedOut'];
-export const GOVERNANCE_PROXY = ['Any', 'NonTransfer', 'Governance'];
 
 export const REFERENDA_STATUS = [
   ['All'],

--- a/packages/extension-polkagate/src/fullscreen/manageIdentity/Review.tsx
+++ b/packages/extension-polkagate/src/fullscreen/manageIdentity/Review.tsx
@@ -16,7 +16,7 @@ import { ApiPromise } from '@polkadot/api';
 import type { DeriveAccountRegistration } from '@polkadot/api-derive/types';
 import type { Chain } from '@polkadot/extension-chains/types';
 
-import { PEOPLE_CHAINS } from '@polkadot/extension-polkagate/src/util/constants';
+import { PEOPLE_CHAINS, PROXY_TYPE } from '@polkadot/extension-polkagate/src/util/constants';
 import { BN, BN_ONE } from '@polkadot/util';
 
 import { CanPayErrorAlert, Identity, Motion, ShowBalance, SignArea2, Warning, WrongPasswordAlert } from '../../components';
@@ -359,7 +359,7 @@ export default function Review({ address, api, chain, depositToPay, depositValue
                 mayBeApi={api}
                 onSecondaryClick={handleClose}
                 primaryBtnText={t('Confirm')}
-                proxyTypeFilter={['Any', 'NonTransfer']}
+                proxyTypeFilter={PROXY_TYPE.GENERAL}
                 secondaryBtnText={t('Cancel')}
                 selectedProxy={selectedProxy}
                 setIsPasswordError={setIsPasswordError}
@@ -387,7 +387,7 @@ export default function Review({ address, api, chain, depositToPay, depositValue
                 closeSelectProxy={() => setStep(STEPS.REVIEW)}
                 height={500}
                 proxies={proxyItems}
-                proxyTypeFilter={['Any', 'NonTransfer']}
+                proxyTypeFilter={PROXY_TYPE.GENERAL}
                 selectedProxy={selectedProxy}
                 setSelectedProxy={setSelectedProxy}
               />

--- a/packages/extension-polkagate/src/fullscreen/manageProxies/Review.tsx
+++ b/packages/extension-polkagate/src/fullscreen/manageProxies/Review.tsx
@@ -21,6 +21,7 @@ import { BN, BN_ONE, BN_ZERO } from '@polkadot/util';
 import { CanPayErrorAlert, ShowBalance, SignArea2, WrongPasswordAlert } from '../../components';
 import { useCanPayFeeAndDeposit, useFormatted, useTranslation } from '../../hooks';
 import { ThroughProxy } from '../../partials';
+import { PROXY_TYPE } from '../../util/constants';
 import { pgBoxShadow } from '../../util/utils';
 import WaitScreen from '../governance/partials/WaitScreen';
 import DisplayValue from '../governance/post/castVote/partial/DisplayValue';
@@ -221,7 +222,7 @@ function Review({ address, api, chain, depositedValue, newDepositValue, proxyIte
               isPasswordError={isPasswordError}
               onSecondaryClick={backToManage}
               primaryBtnText={t('Confirm')}
-              proxyTypeFilter={['Any', 'NonTransfer']}
+              proxyTypeFilter={PROXY_TYPE.GENERAL}
               secondaryBtnText={t('Cancel')}
               selectedProxy={selectedProxy}
               setIsPasswordError={setIsPasswordError}

--- a/packages/extension-polkagate/src/fullscreen/sendFund/Review.tsx
+++ b/packages/extension-polkagate/src/fullscreen/sendFund/Review.tsx
@@ -13,6 +13,7 @@ import { ChainLogo, Identity, Motion, ShowBalance, SignArea2, WrongPasswordAlert
 import { useApi, useChain } from '../../hooks';
 import useTranslation from '../../hooks/useTranslation';
 import { ThroughProxy } from '../../partials';
+import { PROXY_TYPE } from '../../util/constants';
 import { amountToMachine, pgBoxShadow } from '../../util/utils';
 import DisplayValue from '../governance/post/castVote/partial/DisplayValue';
 import { STEPS } from '../stake/pool/stake';
@@ -137,7 +138,7 @@ export default function Review({ address, balances, inputs, setRefresh, setStep,
             onSecondaryClick={handleClose}
             params={inputs?.params}
             primaryBtnText={t('Confirm')}
-            proxyTypeFilter={['Any']}
+            proxyTypeFilter={PROXY_TYPE.SEND_FUND}
             secondaryBtnText={t('Cancel')}
             selectedProxy={selectedProxy}
             setIsPasswordError={setIsPasswordError}

--- a/packages/extension-polkagate/src/fullscreen/socialRecovery/Review.tsx
+++ b/packages/extension-polkagate/src/fullscreen/socialRecovery/Review.tsx
@@ -28,6 +28,7 @@ import type { ActiveRecoveryFor } from '../../hooks/useActiveRecoveries';
 import useTranslation from '../../hooks/useTranslation';
 import { ThroughProxy } from '../../partials';
 import blockToDate from '../../popup/crowdloans/partials/blockToDate';
+import { PROXY_TYPE } from '../../util/constants';
 import { pgBoxShadow } from '../../util/utils';
 import WaitScreen from '../governance/partials/WaitScreen';
 import DisplayValue from '../governance/post/castVote/partial/DisplayValue';
@@ -642,7 +643,7 @@ export default function Review({ activeLost, address, allActiveRecoveries, api, 
                   ? closeWindow
                   : handleClose}
                 primaryBtnText={t<string>('Confirm')}
-                proxyTypeFilter={['Any', 'NonTransfer']}
+                proxyTypeFilter={PROXY_TYPE.GENERAL}
                 secondaryBtnText={t<string>('Cancel')}
                 selectedProxy={selectedProxy}
                 setIsPasswordError={setIsPasswordError}

--- a/packages/extension-polkagate/src/fullscreen/stake/easyMode/Review.tsx
+++ b/packages/extension-polkagate/src/fullscreen/stake/easyMode/Review.tsx
@@ -19,7 +19,7 @@ import useTranslation from '../../../hooks/useTranslation';
 import { ThroughProxy } from '../../../partials';
 import ShowPool from '../../../popup/staking/partial/ShowPool';
 import RewardsDestination from '../../../popup/staking/solo/stake/partials/RewardDestination';
-import { SYSTEM_SUGGESTION_TEXT } from '../../../util/constants';
+import { PROXY_TYPE, SYSTEM_SUGGESTION_TEXT } from '../../../util/constants';
 import { amountToMachine, pgBoxShadow } from '../../../util/utils';
 import DisplayValue from '../../governance/post/castVote/partial/DisplayValue';
 import { STEPS } from '..';
@@ -160,7 +160,7 @@ export default function Review ({ address, balances, inputs, setRefresh, setStep
           onSecondaryClick={handleCancel}
           params={inputs?.params}
           primaryBtnText={t('Confirm')}
-          proxyTypeFilter={inputs?.pool ? ['Any', 'NonTransfer', 'Staking', 'NominationPools'] : ['Any', 'NonTransfer', 'Staking']} // TODO: nomination pools needs test
+          proxyTypeFilter={inputs?.pool ? PROXY_TYPE.NOMINATION_POOLS : PROXY_TYPE.STAKING}
           secondaryBtnText={t('Cancel')}
           selectedProxy={selectedProxy}
           setIsPasswordError={setIsPasswordError}

--- a/packages/extension-polkagate/src/fullscreen/stake/partials/Review.tsx
+++ b/packages/extension-polkagate/src/fullscreen/stake/partials/Review.tsx
@@ -20,6 +20,7 @@ import { BN, BN_ZERO } from '@polkadot/util';
 import { AccountHolderWithProxy, Identity, ShortAddress, ShowBalance, ShowValue, SignArea2, WrongPasswordAlert } from '../../../components';
 import { useEstimatedFee, useInfo, useProxies, useTranslation } from '../../../hooks';
 import { SubTitle } from '../../../partials';
+import { PROXY_TYPE } from '../../../util/constants';
 import type { MyPoolInfo, Payee, Proxy, ProxyItem, TxInfo } from '../../../util/types';
 import type { Inputs } from '../Entry';
 import { STEPS } from '../pool/stake';
@@ -95,8 +96,8 @@ export default function Review({ address, inputs, onClose, setRefresh, setStep, 
   const proxyTypeFilter = useMemo(
     () =>
       inputs?.extraInfo?.pool
-        ? ['Any', 'NonTransfer', 'NominationPools']
-        : ['Any', 'NonTransfer', 'Staking']
+        ? PROXY_TYPE.NOMINATION_POOLS
+        : PROXY_TYPE.STAKING
     , [inputs]);
 
   const closeProxy = useCallback(() => setStep(STEPS.REVIEW), [setStep]);

--- a/packages/extension-polkagate/src/fullscreen/stake/pool/commonTasks/editPool/Review.tsx
+++ b/packages/extension-polkagate/src/fullscreen/stake/pool/commonTasks/editPool/Review.tsx
@@ -14,6 +14,7 @@ import { SubmittableExtrinsicFunction } from '@polkadot/api/types/submittable';
 import type { Chain } from '@polkadot/extension-chains/types';
 
 import SelectProxyModal2 from '@polkadot/extension-polkagate/src/fullscreen/governance/components/SelectProxyModal2';
+import { PROXY_TYPE } from '@polkadot/extension-polkagate/src/util/constants';
 import type { Balance } from '@polkadot/types/interfaces';
 import { BN_ONE } from '@polkadot/util';
 
@@ -222,7 +223,7 @@ export default function Review({ address, api, chain, changes, formatted, pool, 
               onSecondaryClick={onBackClick}
               params={inputs?.params}
               primaryBtnText={t<string>('Confirm')}
-              proxyTypeFilter={['Any', 'NonTransfer', 'NominationPools']}
+              proxyTypeFilter={PROXY_TYPE.NOMINATION_POOLS}
               secondaryBtnText={t<string>('Back')}
               selectedProxy={selectedProxy}
               setIsPasswordError={setIsPasswordError}
@@ -243,7 +244,7 @@ export default function Review({ address, api, chain, changes, formatted, pool, 
           closeSelectProxy={closeProxy}
           height={500}
           proxies={proxyItems}
-          proxyTypeFilter={['Any', 'NonTransfer', 'NominationPools']}
+          proxyTypeFilter={PROXY_TYPE.NOMINATION_POOLS}
           selectedProxy={selectedProxy}
           setSelectedProxy={setSelectedProxy}
         />

--- a/packages/extension-polkagate/src/fullscreen/stake/pool/commonTasks/manageValidators/Review.tsx
+++ b/packages/extension-polkagate/src/fullscreen/stake/pool/commonTasks/manageValidators/Review.tsx
@@ -9,6 +9,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { DeriveAccountInfo } from '@polkadot/api-derive/types';
 import DisplayValue from '@polkadot/extension-polkagate/src/fullscreen/governance/post/castVote/partial/DisplayValue';
+import { PROXY_TYPE } from '@polkadot/extension-polkagate/src/util/constants';
 import type { Balance } from '@polkadot/types/interfaces';
 import { BN, BN_ZERO } from '@polkadot/util';
 
@@ -96,7 +97,7 @@ export default function Review({ address, allValidatorsIdentities, inputs, setSt
             onSecondaryClick={handleCancel}
             params={params}
             primaryBtnText={t('Confirm')}
-            proxyTypeFilter={['Any', 'NonTransfer', 'NominationPools']}
+            proxyTypeFilter={PROXY_TYPE.NOMINATION_POOLS}
             secondaryBtnText={t('Back')}
             selectedProxy={selectedProxy}
             setIsPasswordError={setIsPasswordError}

--- a/packages/extension-polkagate/src/fullscreen/stake/pool/commonTasks/removeAll/Review.tsx
+++ b/packages/extension-polkagate/src/fullscreen/stake/pool/commonTasks/removeAll/Review.tsx
@@ -14,6 +14,7 @@ import type { Chain } from '@polkadot/extension-chains/types';
 import SelectProxyModal2 from '@polkadot/extension-polkagate/src/fullscreen/governance/components/SelectProxyModal2';
 import DisplayValue from '@polkadot/extension-polkagate/src/fullscreen/governance/post/castVote/partial/DisplayValue';
 import ShowPool from '@polkadot/extension-polkagate/src/popup/staking/partial/ShowPool';
+import { PROXY_TYPE } from '@polkadot/extension-polkagate/src/util/constants';
 import { BN } from '@polkadot/util';
 
 import { AccountHolderWithProxy, Motion, ShowValue, SignArea2, WrongPasswordAlert } from '../../../../../components';
@@ -194,7 +195,7 @@ export default function Review({ address, api, chain, mode, pool, poolMembers, s
               onSecondaryClick={onBackClick}
               params={inputs?.params}
               primaryBtnText={t('Confirm')}
-              proxyTypeFilter={['Any', 'NonTransfer', 'NominationPools']}
+              proxyTypeFilter={PROXY_TYPE.NOMINATION_POOLS}
               secondaryBtnText={t('Back')}
               selectedProxy={selectedProxy}
               setIsPasswordError={setIsPasswordError}
@@ -214,7 +215,7 @@ export default function Review({ address, api, chain, mode, pool, poolMembers, s
           closeSelectProxy={closeProxy}
           height={500}
           proxies={proxyItems}
-          proxyTypeFilter={['Any', 'NonTransfer', 'NominationPools']}
+          proxyTypeFilter={PROXY_TYPE.NOMINATION_POOLS}
           selectedProxy={selectedProxy}
           setSelectedProxy={setSelectedProxy}
         />

--- a/packages/extension-polkagate/src/fullscreen/stake/solo/commonTasks/manageValidators/Review.tsx
+++ b/packages/extension-polkagate/src/fullscreen/stake/solo/commonTasks/manageValidators/Review.tsx
@@ -8,6 +8,7 @@ import { Grid, Typography } from '@mui/material';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import DisplayValue from '@polkadot/extension-polkagate/src/fullscreen/governance/post/castVote/partial/DisplayValue';
+import { PROXY_TYPE } from '@polkadot/extension-polkagate/src/util/constants';
 import type { Balance } from '@polkadot/types/interfaces';
 import { BN, BN_ZERO } from '@polkadot/util';
 
@@ -100,7 +101,7 @@ export default function Review({ address, inputs, setStep, setTxInfo, step }: Pr
             onSecondaryClick={handleCancel}
             params={params}
             primaryBtnText={t('Confirm')}
-            proxyTypeFilter={['Any', 'NonTransfer', 'Staking']}
+            proxyTypeFilter={PROXY_TYPE.STAKING}
             secondaryBtnText={t('Back')}
             selectedProxy={selectedProxy}
             setIsPasswordError={setIsPasswordError}

--- a/packages/extension-polkagate/src/popup/account/unlock/Review.tsx
+++ b/packages/extension-polkagate/src/popup/account/unlock/Review.tsx
@@ -25,6 +25,7 @@ import { useAccountDisplay, useChain, useDecimal, useFormatted, useProxies, useT
 import type { Lock } from '../../../hooks/useAccountLocks';
 import { HeaderBrand, SubTitle, WaitScreen } from '../../../partials';
 import { signAndSend } from '../../../util/api';
+import { PROXY_TYPE } from '../../../util/constants';
 import type { Proxy, ProxyItem, TxInfo } from '../../../util/types';
 import { amountToHuman, getSubstrateAddress, saveAsHistory } from '../../../util/utils';
 import Confirmation from './Confirmation';
@@ -213,7 +214,7 @@ export default function Review({ address, api, classToUnlock, setRefresh, setSho
           onConfirmClick={unlockRef}
           proxiedAddress={formatted}
           proxies={proxyItems}
-          proxyTypeFilter={['Any', 'NonTransfer', 'Staking']}
+          proxyTypeFilter={PROXY_TYPE.GOVERNANCE}
           selectedProxy={selectedProxy}
           setIsPasswordError={setIsPasswordError}
           setSelectedProxy={setSelectedProxy}

--- a/packages/extension-polkagate/src/popup/crowdloans/contribute/Review.tsx
+++ b/packages/extension-polkagate/src/popup/crowdloans/contribute/Review.tsx
@@ -23,6 +23,7 @@ import { AccountHolderWithProxy, ActionContext, ChainLogo, FormatBalance, Passwo
 import { useAccountDisplay, useChain, useProxies, useTranslation } from '../../../hooks';
 import { Confirmation, HeaderBrand, SubTitle, ThroughProxy, WaitScreen } from '../../../partials';
 import { broadcast } from '../../../util/api';
+import { PROXY_TYPE } from '../../../util/constants';
 import type { Crowdloan, Proxy, ProxyItem, TxInfo } from '../../../util/types';
 import { amountToHuman, getSubstrateAddress, saveAsHistory } from '../../../util/utils';
 import ParachainInfo from '../partials/ParachainInfo';
@@ -191,7 +192,7 @@ export default function Review({ api, contributionAmount, crowdloanToContribute,
           onConfirmClick={goContribute}
           proxiedAddress={formatted}
           proxies={proxyItems}
-          proxyTypeFilter={['Any', 'Auction', 'NonTransfer']}
+          proxyTypeFilter={PROXY_TYPE.CROWDLOAN}
           selectedProxy={selectedProxy}
           setIsPasswordError={setIsPasswordError}
           setSelectedProxy={setSelectedProxy}

--- a/packages/extension-polkagate/src/popup/manageProxies/Review.tsx
+++ b/packages/extension-polkagate/src/popup/manageProxies/Review.tsx
@@ -22,6 +22,7 @@ import useTranslation from '../../hooks/useTranslation';
 import { SubTitle, WaitScreen } from '../../partials';
 import Confirmation from '../../partials/Confirmation';
 import { signAndSend } from '../../util/api';
+import { PROXY_TYPE } from '../../util/constants';
 import type { Proxy, ProxyItem, TxInfo } from '../../util/types';
 import { getFormattedAddress, getSubstrateAddress, saveAsHistory } from '../../util/utils';
 import ManageProxiesTxDetail from './partials/ManageProxiesTxDetail';
@@ -212,7 +213,7 @@ export default function Review({ address, api, chain, depositToPay, depositValue
         onConfirmClick={onNext}
         proxiedAddress={address}
         proxies={proxies}
-        proxyTypeFilter={['Any', 'NonTransfer']}
+        proxyTypeFilter={PROXY_TYPE.GENERAL}
         selectedProxy={selectedProxy}
         setIsPasswordError={setIsPasswordError}
         setSelectedProxy={setSelectedProxy}

--- a/packages/extension-polkagate/src/popup/send/Review.tsx
+++ b/packages/extension-polkagate/src/popup/send/Review.tsx
@@ -27,6 +27,7 @@ import { HeaderBrand, WaitScreen } from '../../partials';
 import Confirmation from '../../partials/Confirmation';
 import SubTitle from '../../partials/SubTitle';
 import broadcast from '../../util/api/broadcast';
+import { PROXY_TYPE } from '../../util/constants';
 import type { Proxy, ProxyItem, TxInfo } from '../../util/types';
 import { amountToMachine, getSubstrateAddress, saveAsHistory } from '../../util/utils';
 import SendTxDetail from './partial/SendTxDetail';
@@ -210,7 +211,7 @@ export default function Review({ address, amount, api, chain, estimatedFee, reci
           onConfirmClick={send}
           proxiedAddress={formatted}
           proxies={proxyItems}
-          proxyTypeFilter={['Any']}
+          proxyTypeFilter={PROXY_TYPE.SEND_FUND}
           selectedProxy={selectedProxy}
           setIsPasswordError={setIsPasswordError}
           setSelectedProxy={setSelectedProxy}

--- a/packages/extension-polkagate/src/popup/staking/partial/SelectValidatorsReview.tsx
+++ b/packages/extension-polkagate/src/popup/staking/partial/SelectValidatorsReview.tsx
@@ -24,6 +24,7 @@ import { useAccountDisplay, useChain, useDecimal, useFormatted, useProxies, useT
 import { HeaderBrand, SubTitle, WaitScreen } from '../../../partials';
 import Confirmation from '../../../partials/Confirmation';
 import broadcast from '../../../util/api/broadcast';
+import { PROXY_TYPE } from '../../../util/constants';
 import type { Proxy, ProxyItem, StakingConsts, TxInfo, ValidatorInfo } from '../../../util/types';
 import { getSubstrateAddress, saveAsHistory } from '../../../util/utils';
 import TxDetail from './TxDetail';
@@ -193,7 +194,7 @@ export default function Review({ address, allValidatorsIdentities, api, newSelec
           onConfirmClick={nominate}
           proxiedAddress={formatted}
           proxies={proxyItems}
-          proxyTypeFilter={['Any', 'NonTransfer', poolId ? 'NominationPools' : 'Staking']}
+          proxyTypeFilter={poolId ? PROXY_TYPE.NOMINATION_POOLS : PROXY_TYPE.STAKING}
           selectedProxy={selectedProxy}
           setIsPasswordError={setIsPasswordError}
           setSelectedProxy={setSelectedProxy}

--- a/packages/extension-polkagate/src/popup/staking/pool/claimCommission/index.tsx
+++ b/packages/extension-polkagate/src/popup/staking/pool/claimCommission/index.tsx
@@ -21,6 +21,7 @@ import { useAccountDisplay, useInfo, useProxies, useTranslation } from '../../..
 import { HeaderBrand, SubTitle, WaitScreen } from '../../../../partials';
 import Confirmation from '../../../../partials/Confirmation';
 import broadcast from '../../../../util/api/broadcast';
+import { PROXY_TYPE } from '../../../../util/constants';
 import type { MyPoolInfo, Proxy, ProxyItem, TxInfo } from '../../../../util/types';
 import { amountToHuman, getSubstrateAddress, saveAsHistory } from '../../../../util/utils';
 import { To } from '../../../send/Review';
@@ -176,7 +177,7 @@ export default function ClaimCommission({ address, pool, setShow, show }: Props)
           onConfirmClick={submit}
           proxiedAddress={formatted}
           proxies={proxyItems}
-          proxyTypeFilter={['Any', 'NonTransfer', 'NominationPools']}
+          proxyTypeFilter={PROXY_TYPE.NOMINATION_POOLS}
           selectedProxy={selectedProxy}
           setIsPasswordError={setIsPasswordError}
           setSelectedProxy={setSelectedProxy}

--- a/packages/extension-polkagate/src/popup/staking/pool/myPool/SetState.tsx
+++ b/packages/extension-polkagate/src/popup/staking/pool/myPool/SetState.tsx
@@ -17,6 +17,7 @@ import { useAccountDisplay, useApi, useChain, useProxies, useTranslation } from 
 import { HeaderBrand, SubTitle, ThroughProxy, WaitScreen } from '../../../../partials';
 import Confirmation from '../../../../partials/Confirmation';
 import { signAndSend } from '../../../../util/api';
+import { PROXY_TYPE } from '../../../../util/constants';
 import type { MyPoolInfo, Proxy, ProxyItem, TxInfo } from '../../../../util/types';
 import { getSubstrateAddress, saveAsHistory } from '../../../../util/utils';
 import ShowPool from '../../partial/ShowPool';
@@ -193,7 +194,7 @@ export default function SetState({ address, formatted, headerText, helperText, p
           onConfirmClick={changeState}
           proxiedAddress={formatted}
           proxies={proxyItems}
-          proxyTypeFilter={['Any', 'NonTransfer', 'NominationPools']}
+          proxyTypeFilter={PROXY_TYPE.NOMINATION_POOLS}
           selectedProxy={selectedProxy}
           setIsPasswordError={setIsPasswordError}
           setSelectedProxy={setSelectedProxy}

--- a/packages/extension-polkagate/src/popup/staking/pool/myPool/editPool/Review.tsx
+++ b/packages/extension-polkagate/src/popup/staking/pool/myPool/editPool/Review.tsx
@@ -21,6 +21,7 @@ import { useAccountDisplay, useProxies, useTranslation } from '../../../../../ho
 import { HeaderBrand, SubTitle, WaitScreen } from '../../../../../partials';
 import Confirmation from '../../../../../partials/Confirmation';
 import { signAndSend } from '../../../../../util/api';
+import { PROXY_TYPE } from '../../../../../util/constants';
 import type { MyPoolInfo, Proxy, ProxyItem, TxInfo } from '../../../../../util/types';
 import { getSubstrateAddress, saveAsHistory } from '../../../../../util/utils';
 import ShowPoolRole from './ShowPoolRole';
@@ -263,7 +264,7 @@ export default function Review({ address, api, chain, changes, formatted, pool, 
         onConfirmClick={goEditPool}
         proxiedAddress={formatted}
         proxies={proxyItems}
-        proxyTypeFilter={['Any', 'NonTransfer', 'NominationPools']}
+        proxyTypeFilter={PROXY_TYPE.NOMINATION_POOLS}
         selectedProxy={selectedProxy}
         setIsPasswordError={setIsPasswordError}
         setSelectedProxy={setSelectedProxy}

--- a/packages/extension-polkagate/src/popup/staking/pool/myPool/removeAll/Review.tsx
+++ b/packages/extension-polkagate/src/popup/staking/pool/myPool/removeAll/Review.tsx
@@ -21,6 +21,7 @@ import { useAccountDisplay, useProxies, useTranslation } from '../../../../../ho
 import { HeaderBrand, SubTitle, ThroughProxy, WaitScreen } from '../../../../../partials';
 import Confirmation from '../../../../../partials/Confirmation';
 import { signAndSend } from '../../../../../util/api';
+import { PROXY_TYPE } from '../../../../../util/constants';
 import type { MemberPoints, MyPoolInfo, Proxy, ProxyItem, TxInfo } from '../../../../../util/types';
 import { getSubstrateAddress, saveAsHistory } from '../../../../../util/utils';
 import ShowPool from '../../../partial/ShowPool';
@@ -260,7 +261,7 @@ export default function Review({ address, api, chain, formatted, mode, pool, poo
           onConfirmClick={unstakeOrRemoveAll}
           proxiedAddress={formatted}
           proxies={proxyItems}
-          proxyTypeFilter={['Any', 'NonTransfer', 'NominationPools']}
+          proxyTypeFilter={PROXY_TYPE.NOMINATION_POOLS}
           selectedProxy={selectedProxy}
           setIsPasswordError={setIsPasswordError}
           setSelectedProxy={setSelectedProxy}

--- a/packages/extension-polkagate/src/popup/staking/pool/nominations/remove/index.tsx
+++ b/packages/extension-polkagate/src/popup/staking/pool/nominations/remove/index.tsx
@@ -24,6 +24,7 @@ import { useAccountDisplay, useProxies, useTranslation } from '../../../../../ho
 import { HeaderBrand, SubTitle, WaitScreen } from '../../../../../partials';
 import Confirmation from '../../../../../partials/Confirmation';
 import broadcast from '../../../../../util/api/broadcast';
+import { PROXY_TYPE } from '../../../../../util/constants';
 import type { Proxy, ProxyItem, TxInfo } from '../../../../../util/types';
 import { getSubstrateAddress, saveAsHistory } from '../../../../../util/utils';
 import TxDetail from '../../../partial/TxDetail';
@@ -175,7 +176,7 @@ export default function RemoveValidators({ address, api, chain, formatted, poolI
           onChange={setPassword}
           proxiedAddress={formatted}
           proxies={proxyItems}
-          proxyTypeFilter={['Any', 'NonTransfer', 'NominationPools']}
+          proxyTypeFilter={PROXY_TYPE.NOMINATION_POOLS}
           selectedProxy={selectedProxy}
           setIsPasswordError={setIsPasswordError}
           setSelectedProxy={setSelectedProxy}

--- a/packages/extension-polkagate/src/popup/staking/pool/redeem/index.tsx
+++ b/packages/extension-polkagate/src/popup/staking/pool/redeem/index.tsx
@@ -23,7 +23,7 @@ import { useAccountDisplay, useProxies, useTranslation, useUnSupportedNetwork } 
 import { HeaderBrand, SubTitle, WaitScreen } from '../../../../partials';
 import Confirmation from '../../../../partials/Confirmation';
 import broadcast from '../../../../util/api/broadcast';
-import { STAKING_CHAINS } from '../../../../util/constants';
+import { PROXY_TYPE, STAKING_CHAINS } from '../../../../util/constants';
 import type { Proxy, ProxyItem, TxInfo } from '../../../../util/types';
 import { amountToHuman, getSubstrateAddress, saveAsHistory } from '../../../../util/utils';
 import TxDetail from '../rewards/partials/TxDetail';
@@ -193,7 +193,7 @@ export default function RedeemableWithdrawReview({ address, amount, api, availab
           onConfirmClick={submit}
           proxiedAddress={formatted}
           proxies={proxyItems}
-          proxyTypeFilter={['Any', 'NonTransfer', 'NominationPools']}
+          proxyTypeFilter={PROXY_TYPE.NOMINATION_POOLS}
           selectedProxy={selectedProxy}
           setIsPasswordError={setIsPasswordError}
           setSelectedProxy={setSelectedProxy}

--- a/packages/extension-polkagate/src/popup/staking/pool/rewards/Stake.tsx
+++ b/packages/extension-polkagate/src/popup/staking/pool/rewards/Stake.tsx
@@ -25,6 +25,7 @@ import { useAccountDisplay, useProxies, useTranslation } from '../../../../hooks
 import { HeaderBrand, SubTitle, WaitScreen } from '../../../../partials';
 import Confirmation from '../../../../partials/Confirmation';
 import broadcast from '../../../../util/api/broadcast';
+import { PROXY_TYPE } from '../../../../util/constants';
 import type { Proxy, ProxyItem, TxInfo } from '../../../../util/types';
 import { amountToHuman, getSubstrateAddress, saveAsHistory } from '../../../../util/utils';
 import TxDetail from './partials/TxDetail';
@@ -176,7 +177,7 @@ export default function RewardsStakeReview({ address, amount, api, chain, format
           onConfirmClick={submit}
           proxiedAddress={formatted}
           proxies={proxyItems}
-          proxyTypeFilter={['Any', 'NonTransfer', 'NominationPools']}
+          proxyTypeFilter={PROXY_TYPE.NOMINATION_POOLS}
           selectedProxy={selectedProxy}
           setIsPasswordError={setIsPasswordError}
           setSelectedProxy={setSelectedProxy}

--- a/packages/extension-polkagate/src/popup/staking/pool/rewards/Withdraw.tsx
+++ b/packages/extension-polkagate/src/popup/staking/pool/rewards/Withdraw.tsx
@@ -25,6 +25,7 @@ import { useAccountDisplay, useProxies, useTranslation } from '../../../../hooks
 import { HeaderBrand, SubTitle, WaitScreen } from '../../../../partials';
 import Confirmation from '../../../../partials/Confirmation';
 import broadcast from '../../../../util/api/broadcast';
+import { PROXY_TYPE } from '../../../../util/constants';
 import type { Proxy, ProxyItem, TxInfo } from '../../../../util/types';
 import { amountToHuman, getSubstrateAddress, saveAsHistory } from '../../../../util/utils';
 import TxDetail from './partials/TxDetail';
@@ -176,7 +177,7 @@ export default function RewardsWithdrawReview({ address, amount, api, available,
           onConfirmClick={submit}
           proxiedAddress={formatted}
           proxies={proxyItems}
-          proxyTypeFilter={['Any', 'NonTransfer', 'NominationPools']}
+          proxyTypeFilter={PROXY_TYPE.NOMINATION_POOLS}
           selectedProxy={selectedProxy}
           setIsPasswordError={setIsPasswordError}
           setSelectedProxy={setSelectedProxy}

--- a/packages/extension-polkagate/src/popup/staking/pool/stake/bondExtra/Review.tsx
+++ b/packages/extension-polkagate/src/popup/staking/pool/stake/bondExtra/Review.tsx
@@ -22,6 +22,7 @@ import { AccountHolderWithProxy, ActionContext, AmountFee, PasswordUseProxyConfi
 import { useAccountDisplay, useChain, useFormatted, useProxies, useTranslation } from '../../../../../hooks';
 import { Confirmation, HeaderBrand, SubTitle, WaitScreen } from '../../../../../partials';
 import { broadcast } from '../../../../../util/api';
+import { PROXY_TYPE } from '../../../../../util/constants';
 import type { MyPoolInfo, Proxy, ProxyItem, TxInfo } from '../../../../../util/types';
 import { amountToHuman, getSubstrateAddress, saveAsHistory } from '../../../../../util/utils';
 import BondExtraTxDetail from './partial/BondExtraTxDetail';
@@ -169,7 +170,7 @@ export default function Review({ address, api, bondAmount, estimatedFee, pool, s
           onConfirmClick={BondExtra}
           proxiedAddress={formatted}
           proxies={proxyItems}
-          proxyTypeFilter={['Any', 'NonTransfer', 'NominationPools']}
+          proxyTypeFilter={PROXY_TYPE.NOMINATION_POOLS}
           selectedProxy={selectedProxy}
           setIsPasswordError={setIsPasswordError}
           setSelectedProxy={setSelectedProxy}

--- a/packages/extension-polkagate/src/popup/staking/pool/stake/createPool/Review.tsx
+++ b/packages/extension-polkagate/src/popup/staking/pool/stake/createPool/Review.tsx
@@ -22,6 +22,7 @@ import { AccountHolderWithProxy, ActionContext, FormatBalance, PasswordUseProxyC
 import { useAccountDisplay, useChain, useDecimal, useFormatted, useProxies, useTranslation } from '../../../../../hooks';
 import { Confirmation, HeaderBrand, SubTitle, WaitScreen } from '../../../../../partials';
 import { createPool } from '../../../../../util/api';
+import { PROXY_TYPE } from '../../../../../util/constants';
 import type { PoolInfo, Proxy, ProxyItem, TxInfo } from '../../../../../util/types';
 import { amountToHuman, getSubstrateAddress, saveAsHistory } from '../../../../../util/utils';
 import ShowPool from '../../../partial/ShowPool';
@@ -179,7 +180,7 @@ export default function Review({ address, api, createAmount, estimatedFee, poolT
           onConfirmClick={goCreatePool}
           proxiedAddress={formatted}
           proxies={proxyItems}
-          proxyTypeFilter={['Any', 'NonTransfer', 'NominationPools']}
+          proxyTypeFilter={PROXY_TYPE.NOMINATION_POOLS}
           selectedProxy={selectedProxy}
           setIsPasswordError={setIsPasswordError}
           setSelectedProxy={setSelectedProxy}

--- a/packages/extension-polkagate/src/popup/staking/pool/stake/joinPool/Review.tsx
+++ b/packages/extension-polkagate/src/popup/staking/pool/stake/joinPool/Review.tsx
@@ -22,6 +22,7 @@ import { AccountHolderWithProxy, ActionContext, ChainLogo, FormatBalance, Passwo
 import { useAccountDisplay, useChain, useFormatted, useProxies, useTranslation } from '../../../../../hooks';
 import { Confirmation, HeaderBrand, SubTitle, WaitScreen } from '../../../../../partials';
 import { broadcast } from '../../../../../util/api';
+import { PROXY_TYPE } from '../../../../../util/constants';
 import type { PoolInfo, Proxy, ProxyItem, TxInfo } from '../../../../../util/types';
 import { amountToHuman, getSubstrateAddress, saveAsHistory } from '../../../../../util/utils';
 import ShowPool from '../../../partial/ShowPool';
@@ -179,7 +180,7 @@ export default function Review({ address, api, estimatedFee, joinAmount, poolToJ
           onConfirmClick={joinPool}
           proxiedAddress={formatted}
           proxies={proxyItems}
-          proxyTypeFilter={['Any', 'NonTransfer', 'NominationPools']}
+          proxyTypeFilter={PROXY_TYPE.NOMINATION_POOLS}
           selectedProxy={selectedProxy}
           setIsPasswordError={setIsPasswordError}
           setSelectedProxy={setSelectedProxy}

--- a/packages/extension-polkagate/src/popup/staking/pool/unstake/Review.tsx
+++ b/packages/extension-polkagate/src/popup/staking/pool/unstake/Review.tsx
@@ -27,6 +27,7 @@ import { useAccountDisplay, useDecimal, useProxies, useToken, useTranslation } f
 import { HeaderBrand, SubTitle, WaitScreen } from '../../../../partials';
 import Confirmation from '../../../../partials/Confirmation';
 import { signAndSend } from '../../../../util/api';
+import { PROXY_TYPE } from '../../../../util/constants';
 import broadcast from '../../../../util/api/broadcast';
 import type { MyPoolInfo, Proxy, ProxyItem, TxInfo } from '../../../../util/types';
 import { amountToMachine, getSubstrateAddress, saveAsHistory } from '../../../../util/utils';
@@ -222,7 +223,7 @@ export default function Review({ address, amount, api, chain, estimatedFee, form
           onConfirmClick={unstake}
           proxiedAddress={formatted}
           proxies={proxyItems}
-          proxyTypeFilter={['Any', 'NonTransfer', 'NominationPools']}
+          proxyTypeFilter={PROXY_TYPE.NOMINATION_POOLS}
           selectedProxy={selectedProxy}
           setIsPasswordError={setIsPasswordError}
           setSelectedProxy={setSelectedProxy}

--- a/packages/extension-polkagate/src/popup/staking/solo/fastUnstake/Review.tsx
+++ b/packages/extension-polkagate/src/popup/staking/solo/fastUnstake/Review.tsx
@@ -25,6 +25,7 @@ import { useAccountDisplay, useDecimal, useProxies, useTranslation } from '../..
 import { HeaderBrand, SubTitle, WaitScreen } from '../../../../partials';
 import Confirmation from '../../../../partials/Confirmation';
 import broadcast from '../../../../util/api/broadcast';
+import { PROXY_TYPE } from '../../../../util/constants';
 import type { Proxy, ProxyItem, TxInfo } from '../../../../util/types';
 import { amountToHuman, getSubstrateAddress, saveAsHistory } from '../../../../util/utils';
 import TxDetail from '../partials/TxDetail';
@@ -185,7 +186,7 @@ export default function FastUnstakeReview({ address, amount, api, available, cha
           onConfirmClick={submit}
           proxiedAddress={formatted}
           proxies={proxyItems}
-          proxyTypeFilter={['Any', 'NonTransfer', 'Staking']}
+          proxyTypeFilter={PROXY_TYPE.STAKING}
           selectedProxy={selectedProxy}
           setIsPasswordError={setIsPasswordError}
           setSelectedProxy={setSelectedProxy}

--- a/packages/extension-polkagate/src/popup/staking/solo/nominations/remove/index.tsx
+++ b/packages/extension-polkagate/src/popup/staking/solo/nominations/remove/index.tsx
@@ -24,6 +24,7 @@ import { useAccountDisplay, useProxies, useTranslation } from '../../../../../ho
 import { HeaderBrand, SubTitle, WaitScreen } from '../../../../../partials';
 import Confirmation from '../../../../../partials/Confirmation';
 import broadcast from '../../../../../util/api/broadcast';
+import { PROXY_TYPE } from '../../../../../util/constants';
 import type { Proxy, ProxyItem, TxInfo } from '../../../../../util/types';
 import { getSubstrateAddress, saveAsHistory } from '../../../../../util/utils';
 import TxDetail from '../../../partial/TxDetail';
@@ -176,7 +177,7 @@ export default function RemoveValidators({ address, api, chain, formatted, setSh
           onConfirmClick={remove}
           proxiedAddress={formatted}
           proxies={proxyItems}
-          proxyTypeFilter={['Any', 'NonTransfer', 'Staking']}
+          proxyTypeFilter={PROXY_TYPE.STAKING}
           selectedProxy={selectedProxy}
           setIsPasswordError={setIsPasswordError}
           setSelectedProxy={setSelectedProxy}

--- a/packages/extension-polkagate/src/popup/staking/solo/redeem/index.tsx
+++ b/packages/extension-polkagate/src/popup/staking/solo/redeem/index.tsx
@@ -26,6 +26,7 @@ import { useAccountDisplay, useProxies, useTranslation } from '../../../../hooks
 import { HeaderBrand, SubTitle, WaitScreen } from '../../../../partials';
 import Confirmation from '../../../../partials/Confirmation';
 import broadcast from '../../../../util/api/broadcast';
+import { PROXY_TYPE } from '../../../../util/constants';
 import type { Proxy, ProxyItem, TxInfo } from '../../../../util/types';
 import { amountToHuman, getSubstrateAddress, saveAsHistory } from '../../../../util/utils';
 import TxDetail from '../partials/TxDetail';
@@ -183,7 +184,7 @@ export default function RedeemableWithdrawReview({ address, amount, api, availab
           onConfirmClick={submit}
           proxiedAddress={formatted}
           proxies={proxyItems}
-          proxyTypeFilter={['Any', 'NonTransfer', 'Staking']}
+          proxyTypeFilter={PROXY_TYPE.STAKING}
           selectedProxy={selectedProxy}
           setIsPasswordError={setIsPasswordError}
           setSelectedProxy={setSelectedProxy}

--- a/packages/extension-polkagate/src/popup/staking/solo/restake/Review.tsx
+++ b/packages/extension-polkagate/src/popup/staking/solo/restake/Review.tsx
@@ -27,6 +27,7 @@ import { useAccountDisplay, useDecimal, useProxies, useToken, useTranslation } f
 import { HeaderBrand, SubTitle, WaitScreen } from '../../../../partials';
 import Confirmation from '../../../../partials/Confirmation';
 import broadcast from '../../../../util/api/broadcast';
+import { PROXY_TYPE } from '../../../../util/constants';
 import type { Proxy, ProxyItem, TxInfo } from '../../../../util/types';
 import { amountToHuman, getSubstrateAddress, saveAsHistory } from '../../../../util/utils';
 import TxDetail from './partials/TxDetail';
@@ -179,7 +180,7 @@ export default function Review({ address, amount, api, chain, estimatedFee, form
           onConfirmClick={unstake}
           proxiedAddress={formatted}
           proxies={proxyItems}
-          proxyTypeFilter={['Any', 'NonTransfer', 'Staking']}
+          proxyTypeFilter={PROXY_TYPE.STAKING}
           selectedProxy={selectedProxy}
           setIsPasswordError={setIsPasswordError}
           setSelectedProxy={setSelectedProxy}

--- a/packages/extension-polkagate/src/popup/staking/solo/rewards/Review.tsx
+++ b/packages/extension-polkagate/src/popup/staking/solo/rewards/Review.tsx
@@ -24,6 +24,7 @@ import { useAccountDisplay, useInfo, useProxies, useTranslation } from '../../..
 import { HeaderBrand, SubTitle, WaitScreen } from '../../../../partials';
 import Confirmation from '../../../../partials/Confirmation';
 import { signAndSend } from '../../../../util/api';
+import { PROXY_TYPE } from '../../../../util/constants';
 import type { Proxy, ProxyItem, TxInfo } from '../../../../util/types';
 import { amountToHuman, getSubstrateAddress, saveAsHistory } from '../../../../util/utils';
 import TxDetail from './TxDetail';
@@ -202,7 +203,7 @@ export default function Review({ address, amount, selectedToPayout, setShow, sho
           onConfirmClick={unstake}
           proxiedAddress={formatted}
           proxies={proxyItems}
-          proxyTypeFilter={['Any', 'NonTransfer', 'Staking']}
+          proxyTypeFilter={PROXY_TYPE.STAKING}
           selectedProxy={selectedProxy}
           setIsPasswordError={setIsPasswordError}
           setSelectedProxy={setSelectedProxy}

--- a/packages/extension-polkagate/src/popup/staking/solo/settings/Review.tsx
+++ b/packages/extension-polkagate/src/popup/staking/solo/settings/Review.tsx
@@ -32,6 +32,7 @@ import { signAndSend } from '../../../../util/api';
 import type { Proxy, ProxyItem, SoloSettings, TxInfo } from '../../../../util/types';
 import { getSubstrateAddress, saveAsHistory } from '../../../../util/utils';
 import TxDetail from './partials/TxDetail';
+import { PROXY_TYPE } from '../../../../util/constants';
 
 interface Props {
   address: string;
@@ -248,7 +249,7 @@ export default function Review({ address, api, newSettings, setRefresh, setShow,
           onConfirmClick={applySettings}
           proxiedAddress={settings.stashId}
           proxies={proxyItems}
-          proxyTypeFilter={['Any', 'NonTransfer', 'Staking']}
+          proxyTypeFilter={PROXY_TYPE.STAKING}
           selectedProxy={selectedProxy}
           setIsPasswordError={setIsPasswordError}
           setSelectedProxy={setSelectedProxy}

--- a/packages/extension-polkagate/src/popup/staking/solo/stake/Review.tsx
+++ b/packages/extension-polkagate/src/popup/staking/solo/stake/Review.tsx
@@ -29,7 +29,7 @@ import { useAccountDisplay, useFormatted, useProxies, useToken, useTranslation }
 import { HeaderBrand, SubTitle, WaitScreen } from '../../../../partials';
 import Confirmation from '../../../../partials/Confirmation';
 import { signAndSend } from '../../../../util/api';
-import { SYSTEM_SUGGESTION_TEXT } from '../../../../util/constants';
+import { PROXY_TYPE, SYSTEM_SUGGESTION_TEXT } from '../../../../util/constants';
 import type { Proxy, ProxyItem, SoloSettings, TxInfo, ValidatorInfo } from '../../../../util/types';
 import { getSubstrateAddress, saveAsHistory } from '../../../../util/utils';
 import RewardsDestination from './partials/RewardDestination';
@@ -234,7 +234,7 @@ export default function Review({ address, amount, api, chain, estimatedFee, isFi
           onConfirmClick={stake}
           proxiedAddress={settings.stashId}
           proxies={proxyItems}
-          proxyTypeFilter={['Any', 'NonTransfer', 'Staking']}
+          proxyTypeFilter={PROXY_TYPE.STAKING}
           selectedProxy={selectedProxy}
           setIsPasswordError={setIsPasswordError}
           setSelectedProxy={setSelectedProxy}

--- a/packages/extension-polkagate/src/popup/staking/solo/tuneUp/index.tsx
+++ b/packages/extension-polkagate/src/popup/staking/solo/tuneUp/index.tsx
@@ -25,7 +25,7 @@ import { useAccountDisplay, useInfo, useNeedsPutInFrontOf, useNeedsRebag, usePro
 import { HeaderBrand, SubTitle, WaitScreen } from '../../../../partials';
 import Confirmation from '../../../../partials/Confirmation';
 import broadcast from '../../../../util/api/broadcast';
-import { STAKING_CHAINS } from '../../../../util/constants';
+import { PROXY_TYPE, STAKING_CHAINS } from '../../../../util/constants';
 import getLogo from '../../../../util/getLogo';
 import { getSubstrateAddress, saveAsHistory } from '../../../../util/utils';
 import TxDetail from './TxDetail';
@@ -216,7 +216,7 @@ export default function TuneUp(): React.ReactElement {
           onConfirmClick={submit}
           proxiedAddress={selectedProxyAddress}
           proxies={proxyItems}
-          proxyTypeFilter={['Any', 'NonTransfer', 'Staking']}
+          proxyTypeFilter={PROXY_TYPE.STAKING}
           selectedProxy={selectedProxy}
           setIsPasswordError={setIsPasswordError}
           setSelectedProxy={setSelectedProxy}

--- a/packages/extension-polkagate/src/popup/staking/solo/unstake/Review.tsx
+++ b/packages/extension-polkagate/src/popup/staking/solo/unstake/Review.tsx
@@ -24,6 +24,7 @@ import { useAccountDisplay, useInfo, useProxies, useTranslation } from '../../..
 import { HeaderBrand, SubTitle, WaitScreen } from '../../../../partials';
 import Confirmation from '../../../../partials/Confirmation';
 import { signAndSend } from '../../../../util/api';
+import { PROXY_TYPE } from '../../../../util/constants';
 import type { Proxy, ProxyItem, TxInfo } from '../../../../util/types';
 import { amountToHuman, amountToMachine, getSubstrateAddress, saveAsHistory } from '../../../../util/utils';
 import TxDetail from './partials/TxDetail';
@@ -199,7 +200,7 @@ export default function Review({ address, amount, chilled, estimatedFee, hasNomi
           onConfirmClick={unstake}
           proxiedAddress={formatted}
           proxies={proxyItems}
-          proxyTypeFilter={['Any', 'NonTransfer', 'Staking']}
+          proxyTypeFilter={PROXY_TYPE.STAKING}
           selectedProxy={selectedProxy}
           setIsPasswordError={setIsPasswordError}
           setSelectedProxy={setSelectedProxy}

--- a/packages/extension-polkagate/src/util/constants.tsx
+++ b/packages/extension-polkagate/src/util/constants.tsx
@@ -211,3 +211,12 @@ export const USD_CURRENCY = {
 
 export const FULLSCREEN_WIDTH = '900px';
 export const ALLOWED_URL_ON_RESET_PASSWORD = ['/account/restore-json', '/account/import-seed', '/account/import-raw-seed', '/forgot-password', '/reset-wallet'];
+
+export const PROXY_TYPE = {
+  STAKING: ['Any', 'NonTransfer', 'Staking'],
+  NOMINATION_POOLS: ['Any', 'NonTransfer', 'Staking', 'NominationPools'],
+  GOVERNANCE: ['Any', 'NonTransfer', 'Governance'],
+  SEND_FUND: ['Any'],
+  GENERAL: ['Any', 'NonTransfer'],
+  CROWDLOAN: ['Any', 'NonTransfer', 'Auction']
+};


### PR DESCRIPTION
## Works Done

1. Create PROXY_TYPE Constants.
2. Update all review pages.
3. remove unused `GOVERNANCE_PROXY` variable from `\fullscreen\governance\utils\consts.ts`

### Benefits

- [x] Readability.
- [x] Maintainability.
- [x] Consistency.

Close: #1376 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified proxy type management by replacing various array-based filters with a unified `PROXY_TYPE` constant across the application.

- **New Features**
  - Introduced `PROXY_TYPE` constants for better readability and maintainability. These constants include types such as `STAKING`, `NOMINATION_POOLS`, `GOVERNANCE`, `SEND_FUND`, `GENERAL`, and `CROWDLOAN`.

- **Bug Fixes**
  - Ensured consistent proxy type filtering throughout various components, reducing potential for errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->