### PR TITLE
address the issue of handling CheckMetadataHash extension  by ignoring it atm

### DIFF
--- a/packages/extension-polkagate/src/components/SignArea2.tsx
+++ b/packages/extension-polkagate/src/components/SignArea2.tsx
@@ -4,8 +4,6 @@
 
 /* eslint-disable react/jsx-max-props-per-line */
 
-//@ts-nocheck
-
 import type { Header } from '@polkadot/types/interfaces';
 import type { AnyTuple } from '@polkadot/types/types';
 import type { HexString } from '@polkadot/util/types';
@@ -139,8 +137,12 @@ export default function SignArea({ address, call, disabled, extraInfo, isPasswor
         genesisHash: api.genesisHash.toHex(),
         method: api.createType('Call', ptx).toHex(), // TODO: DOES SUPPORT nested calls, batches , ...
         nonce: api.registry.createType('Compact<Index>', rawNonce).toHex(),
+        mode: 0,  // default value to ignore CheckMetadataHash
+        assetId: null,
+        metadataHash: null, //api.runtimeMetadata.hash.toHex(),
         signedExtensions: [
           'CheckNonZeroSender',
+          'CheckMetadataHash',
           'CheckSpecVersion',
           'CheckTxVersion',
           'CheckGenesis',


### PR DESCRIPTION
ignore by setting mode = 0

However, more work is needed when it is enabled on-chain.

related #1378

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the signing process by adding default values for `mode`, `assetId`, and `metadataHash`.

- **Improvements**
  - Updated the signing extensions to include `CheckMetadataHash` for better security and verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->