### PR TITLE
Fix vadding-icon error

### DIFF
--- a/packages/extension-polkagate/src/components/AddressInput.tsx
+++ b/packages/extension-polkagate/src/components/AddressInput.tsx
@@ -5,10 +5,6 @@
 /* eslint-disable react/jsx-max-props-per-line */
 /* eslint-disable react/jsx-no-bind */
 
-// @ts-nocheck
-
-import '@vaadin/icons';
-
 import { faPaste, faXmarkCircle } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Autocomplete, Grid, IconButton, InputAdornment, type SxProps, TextField, type Theme, Typography, useTheme } from '@mui/material';
@@ -19,6 +15,7 @@ import type { Chain } from '@polkadot/extension-chains/types';
 import settings from '@polkadot/ui-settings';
 
 import { useTranslation } from '../hooks';
+import { VaadinIcon } from '../components';
 import QrScanner from '../popup/import/addWatchOnly/QrScanner';
 import isValidAddress from '../util/validateAddress';
 import Identicon from './Identicon';
@@ -162,7 +159,7 @@ export default function AddressInput({ addWithQr = false, allAddresses = [], cha
                             onClick={openQrScanner}
                             sx={{ p: '3px' }}
                           >
-                            <vaadin-icon icon='vaadin:qrcode' style={{ height: '16px', width: '16px', color: `${settings.camera === 'on' ? theme.palette.primary.main : theme.palette.text.disabled}` }} />
+                            <VaadinIcon icon='vaadin:qrcode' style={{ height: '16px', width: '16px', color: `${settings.camera === 'on' ? theme.palette.primary.main : theme.palette.text.disabled}` }} />
                           </IconButton>
                         }
                       </InputAdornment>

--- a/packages/extension-polkagate/src/components/AddressInput2.tsx
+++ b/packages/extension-polkagate/src/components/AddressInput2.tsx
@@ -5,8 +5,6 @@
 /* eslint-disable react/jsx-max-props-per-line */
 /* eslint-disable react/jsx-no-bind */
 
-import '@vaadin/icons';
-
 import { faPaste, faXmarkCircle } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Autocomplete, Grid, IconButton, InputAdornment, SxProps, TextField, Theme, Typography, useTheme } from '@mui/material';
@@ -17,6 +15,7 @@ import type { Chain } from '@polkadot/extension-chains/types';
 import settings from '@polkadot/ui-settings';
 
 import { useTranslation } from '../hooks';
+import { VaadinIcon } from '../components';
 import QrScanner from '../popup/import/addWatchOnly/QrScanner';
 import isValidAddress from '../util/validateAddress';
 import Identicon from './Identicon';
@@ -161,7 +160,7 @@ export default function AddressInput2({ addWithQr = false, allAddresses = [], ch
                             onClick={openQrScanner}
                             sx={{ p: '3px' }}
                           >
-                            <vaadin-icon icon='vaadin:qrcode' style={{ height: '16px', width: '16px', color: `${settings.camera === 'on' ? theme.palette.primary.main : theme.palette.text.disabled}` }} />
+                            <VaadinIcon icon='vaadin:qrcode' style={{ height: '16px', width: '16px', color: `${settings.camera === 'on' ? theme.palette.primary.main : theme.palette.text.disabled}` }} />
                           </IconButton>
                         }
                       </InputAdornment>

--- a/packages/extension-polkagate/src/components/CopyAddressButton.tsx
+++ b/packages/extension-polkagate/src/components/CopyAddressButton.tsx
@@ -2,13 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // @ts-nocheck
 
-import '@vaadin/icons';
-
 import { Grid, IconButton, Tooltip, useTheme } from '@mui/material';
 import React, { useCallback, useState } from 'react';
 import CopyToClipboard from 'react-copy-to-clipboard';
 
 import { useTranslation } from '../hooks';
+import { VaadinIcon } from '../components';
 
 interface Props {
   address: string | null | undefined;
@@ -75,7 +74,7 @@ function CopyAddressButton({ address, showAddress = false, size = 20 }: Props): 
           }}
         >
           <CopyToClipboard text={String(address)}>
-            <vaadin-icon icon='vaadin:copy-o' style={{ color: `${theme.palette.secondary.light}`, width: `${size}px` }} />
+            <VaadinIcon icon='vaadin:copy-o' style={{ color: `${theme.palette.secondary.light}`, width: `${size}px` }} />
           </CopyToClipboard>
         </IconButton>
       </Tooltip>

--- a/packages/extension-polkagate/src/components/InputWithLabelAndIdenticon.tsx
+++ b/packages/extension-polkagate/src/components/InputWithLabelAndIdenticon.tsx
@@ -4,8 +4,6 @@
 
 /* eslint-disable react/jsx-max-props-per-line */
 
-import '@vaadin/icons';
-
 import { faPaste, faXmarkCircle } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Grid, IconButton, type SxProps, type Theme, Typography, useTheme } from '@mui/material';
@@ -16,6 +14,7 @@ import type { Chain } from '@polkadot/extension-chains/types';
 import settings from '@polkadot/ui-settings';
 
 import { useOutsideClick, useTranslation } from '../hooks';
+import { VaadinIcon } from '../components';
 import QrScanner from '../popup/import/addWatchOnly/QrScanner';
 import isValidAddress from '../util/validateAddress';
 import Identicon from './Identicon';
@@ -155,7 +154,7 @@ export default function InputWithLabelAndIdenticon({ addWithQr = false, allAddre
                     right: '25px'
                   }}
                 >
-                  <vaadin-icon icon='vaadin:qrcode' style={{ height: '16px', width: '16px', color: `${settings.camera === 'on' ? theme.palette.primary.main : theme.palette.text.disabled}` }} />
+                  <VaadinIcon icon='vaadin:qrcode' style={{ height: '16px', width: '16px', color: `${settings.camera === 'on' ? theme.palette.primary.main : theme.palette.text.disabled}` }} />
                 </IconButton>
               }
             </>

--- a/packages/extension-polkagate/src/components/OnActionToolTip.tsx
+++ b/packages/extension-polkagate/src/components/OnActionToolTip.tsx
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // @ts-nocheck
 
-import '@vaadin/icons';
-
 import { Tooltip } from '@mui/material';
 import React, { useCallback } from 'react';
 

--- a/packages/extension-polkagate/src/components/OptionalCopyButton.tsx
+++ b/packages/extension-polkagate/src/components/OptionalCopyButton.tsx
@@ -4,12 +4,11 @@
 
 /* eslint-disable react/jsx-max-props-per-line */
 
-import '@vaadin/icons';
-
 import { Grid, Popover, useTheme } from '@mui/material';
 import React, { useCallback, useMemo, useState } from 'react';
 
 import OptionalCopyPopup from '../partials/OptionalCopyPopup';
+import { VaadinIcon } from '../components';
 
 interface Props {
   address: string | undefined;
@@ -36,7 +35,7 @@ function OptionalCopyButton({ address }: Props): React.ReactElement {
   return (
     <>
       <Grid alignItems='center' aria-describedby={id} component='button' container direction='column' item justifyContent='center' onClick={onCopyIconClick} sx={{ bgcolor: 'transparent', border: 'none', cursor: 'pointer', p: '2px 6px', position: 'relative', width: '35px' }}>
-        <vaadin-icon icon='vaadin:copy-o' style={{ color: `${theme.palette.secondary.light}`, width: '20px' }} />
+        <VaadinIcon icon='vaadin:copy-o' style={{ color: `${theme.palette.secondary.light}`, width: '20px' }} />
       </Grid>
       <Popover
         PaperProps={{

--- a/packages/extension-polkagate/src/components/Password.tsx
+++ b/packages/extension-polkagate/src/components/Password.tsx
@@ -7,6 +7,7 @@ import '@vaadin/icons';
 import { IconButton, useTheme } from '@mui/material';
 import React, { useCallback, useState } from 'react';
 
+import VaadinIcon from './VaadinIcon';
 import Label from './Label';
 import { Input } from './TextInputs';
 
@@ -95,7 +96,7 @@ export default function Password({ defaultValue, disabled, isError, isFocused, i
         }}
         tabIndex={-1}
       >
-        <vaadin-icon icon={showPass ? 'vaadin:eye' : 'vaadin:eye-slash'} style={{ height: '20px', color: `${theme.palette.secondary.light}` }} />
+        <VaadinIcon icon={showPass ? 'vaadin:eye' : 'vaadin:eye-slash'} style={{ height: '20px', color: `${theme.palette.secondary.light}` }} />
       </IconButton>
     </Label>
   );

--- a/packages/extension-polkagate/src/components/Password.tsx
+++ b/packages/extension-polkagate/src/components/Password.tsx
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // @ts-nocheck
 
-import '@vaadin/icons';
-
 import { IconButton, useTheme } from '@mui/material';
 import React, { useCallback, useState } from 'react';
 

--- a/packages/extension-polkagate/src/components/VaadinIcon.tsx
+++ b/packages/extension-polkagate/src/components/VaadinIcon.tsx
@@ -10,7 +10,7 @@ interface VaadinIconProps extends React.HTMLAttributes<HTMLElement> {
 }
 
 const VaadinIcon: React.FC<VaadinIconProps> = ({ icon, ...props }) => {
-  return <vaadin-icon icon={icon} {...props}></vaadin-icon>;
+  return <vaadin-icon icon={icon} {...props} />;
 };
 
 export default VaadinIcon;

--- a/packages/extension-polkagate/src/components/VaadinIcon.tsx
+++ b/packages/extension-polkagate/src/components/VaadinIcon.tsx
@@ -1,0 +1,16 @@
+// Copyright 2019-2024 @polkadot/extension-polkagate authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+// @ts-nocheck
+
+import React from 'react';
+import '@vaadin/icons';
+
+interface VaadinIconProps extends React.HTMLAttributes<HTMLElement> {
+  icon: string;
+}
+
+const VaadinIcon: React.FC<VaadinIconProps> = ({ icon, ...props }) => {
+  return <vaadin-icon icon={icon} {...props}></vaadin-icon>;
+};
+
+export default VaadinIcon;

--- a/packages/extension-polkagate/src/components/index.ts
+++ b/packages/extension-polkagate/src/components/index.ts
@@ -94,5 +94,6 @@ export { default as DisplayLogo } from './DisplayLogo';
 export { default as FullScreenIcon } from './FullScreenIcon';
 export { default as OptionalCopyButton } from './OptionalCopyButton';
 export { default as Waiting } from './Waiting';
+export { default as VaadinIcon } from './VaadinIcon';
 
 export * from './contexts';

--- a/packages/extension-polkagate/src/fullscreen/accountDetails/components/AccountInformationForDetails.tsx
+++ b/packages/extension-polkagate/src/fullscreen/accountDetails/components/AccountInformationForDetails.tsx
@@ -9,7 +9,7 @@ import React, { useCallback, useEffect, useMemo } from 'react';
 
 import { BN } from '@polkadot/util';
 
-import { DisplayLogo, FormatBalance2, FormatPrice, Identicon, Identity, Infotip, Infotip2, OptionalCopyButton, ShortAddress2 } from '../../../components';
+import { DisplayLogo, FormatBalance2, FormatPrice, Identicon, Identity, Infotip, Infotip2, OptionalCopyButton, ShortAddress2, VaadinIcon } from '../../../components';
 import { useIdentity, useInfo, useTranslation } from '../../../hooks';
 import { FetchedBalance } from '../../../hooks/useAssetsBalances';
 import { showAccount, tieAccount } from '../../../messaging';
@@ -219,7 +219,7 @@ export default function AccountInformationForDetails({ accountAssets, address, l
               <Grid item width='40px'>
                 <Infotip text={account?.isHidden && t('This account is hidden from websites')}>
                   <IconButton onClick={toggleVisibility} sx={{ height: '20px', ml: '7px', mt: '13px', p: 0, width: '28px' }}>
-                    <vaadin-icon icon={account?.isHidden ? 'vaadin:eye-slash' : 'vaadin:eye'} style={{ color: `${theme.palette.secondary.light}`, height: '20px' }} />
+                    <VaadinIcon icon={account?.isHidden ? 'vaadin:eye-slash' : 'vaadin:eye'} style={{ color: `${theme.palette.secondary.light}`, height: '20px' }} />
                   </IconButton>
                 </Infotip>
               </Grid>

--- a/packages/extension-polkagate/src/fullscreen/accountDetails/components/AccountSetting.tsx
+++ b/packages/extension-polkagate/src/fullscreen/accountDetails/components/AccountSetting.tsx
@@ -4,15 +4,13 @@
 
 /* eslint-disable react/jsx-max-props-per-line */
 
-import '@vaadin/icons';
-
 import { faAddressCard } from '@fortawesome/free-regular-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { ArrowForwardIosRounded as ArrowForwardIosRoundedIcon } from '@mui/icons-material';
 import { Collapse, Divider, Grid, Typography, useTheme } from '@mui/material';
 import React, { useCallback, useContext, useMemo, useState } from 'react';
 
-import { ActionContext, SocialRecoveryIcon } from '../../../components';
+import { ActionContext, SocialRecoveryIcon, VaadinIcon } from '../../../components';
 import { useInfo, useTranslation } from '../../../hooks';
 import { IDENTITY_CHAINS, PROXY_CHAINS, SOCIAL_RECOVERY_CHAINS } from '../../../util/constants';
 import { popupNumbers } from '..';
@@ -96,7 +94,7 @@ export default function AccountSetting({ address, setDisplayPopup }: Props): Rea
           />
           <TaskButton
             disabled={proxyDisable}
-            icon={<vaadin-icon icon='vaadin:sitemap' style={{ height: '30px', color: `${proxyDisable ? theme.palette.text.disabled : theme.palette.text.primary}` }} />}
+            icon={<VaadinIcon icon='vaadin:sitemap' style={{ height: '30px', color: `${proxyDisable ? theme.palette.text.disabled : theme.palette.text.primary}` }} />}
             onClick={onManageProxies}
             secondaryIconType='page'
             text={t('Manage proxies')}
@@ -119,26 +117,26 @@ export default function AccountSetting({ address, setDisplayPopup }: Props): Rea
           />
           <TaskButton
             disabled={hardwareOrExternalAccount}
-            icon={<vaadin-icon icon='vaadin:download-alt' style={{ height: '30px', color: `${hardwareOrExternalAccount ? theme.palette.text.disabled : theme.palette.text.primary}` }} />}
+            icon={<VaadinIcon icon='vaadin:download-alt' style={{ height: '30px', color: `${hardwareOrExternalAccount ? theme.palette.text.disabled : theme.palette.text.primary}` }} />}
             onClick={onExportAccount}
             secondaryIconType='popup'
             text={t('Export account')}
           />
           <TaskButton
             disabled={hardwareOrExternalAccount}
-            icon={<vaadin-icon icon='vaadin:road-branch' style={{ height: '30px', color: `${hardwareOrExternalAccount ? theme.palette.text.disabled : theme.palette.text.primary}` }} />}
+            icon={<VaadinIcon icon='vaadin:road-branch' style={{ height: '30px', color: `${hardwareOrExternalAccount ? theme.palette.text.disabled : theme.palette.text.primary}` }} />}
             onClick={goToDeriveAcc}
             secondaryIconType='popup'
             text={t('Derive new account')}
           />
           <TaskButton
-            icon={<vaadin-icon icon='vaadin:edit' style={{ height: '30px', color: `${theme.palette.text.primary}` }} />}
+            icon={<VaadinIcon icon='vaadin:edit' style={{ height: '30px', color: `${theme.palette.text.primary}` }} />}
             onClick={onRenameAccount}
             secondaryIconType='popup'
             text={t('Rename')}
           />
           <TaskButton
-            icon={<vaadin-icon icon='vaadin:file-remove' style={{ height: '30px', color: `${theme.palette.text.primary}` }} />}
+            icon={<VaadinIcon icon='vaadin:file-remove' style={{ height: '30px', color: `${theme.palette.text.primary}` }} />}
             noBorderButton
             onClick={onForgetAccount}
             secondaryIconType='popup'

--- a/packages/extension-polkagate/src/fullscreen/governance/SearchBox.tsx
+++ b/packages/extension-polkagate/src/fullscreen/governance/SearchBox.tsx
@@ -5,8 +5,6 @@
 /* eslint-disable react/jsx-max-props-per-line */
 /* eslint-disable react/jsx-first-prop-new-line */
 
-import '@vaadin/icons';
-
 import { ArrowForwardIos as ArrowForwardIosIcon } from '@mui/icons-material';
 import { Grid, useTheme } from '@mui/material';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';

--- a/packages/extension-polkagate/src/fullscreen/governance/index.tsx
+++ b/packages/extension-polkagate/src/fullscreen/governance/index.tsx
@@ -4,8 +4,6 @@
 
 /* eslint-disable react/jsx-max-props-per-line */
 
-import '@vaadin/icons';
-
 import { Container, Grid, Typography, useTheme } from '@mui/material';
 import { CubeGrid } from 'better-react-spinkit';
 import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';

--- a/packages/extension-polkagate/src/fullscreen/governance/post/allVote/Delegators.tsx
+++ b/packages/extension-polkagate/src/fullscreen/governance/post/allVote/Delegators.tsx
@@ -4,15 +4,13 @@
 
 /* eslint-disable react/jsx-max-props-per-line */
 
-import '@vaadin/icons';
-
 import { ArrowBackIos as ArrowBackIosIcon, Check as CheckIcon, Close as CloseIcon, RemoveCircle as AbstainIcon } from '@mui/icons-material';
 import { Divider, Grid, Pagination, SxProps, Typography, useTheme } from '@mui/material';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { BN, BN_ZERO } from '@polkadot/util';
 
-import { Identity, ShowBalance } from '../../../../components';
+import { Identity, ShowBalance, VaadinIcon } from '../../../../components';
 import { useApi, useChain, useDecimal, useToken, useTranslation } from '../../../../hooks';
 import { DraggableModal } from '../../components/DraggableModal';
 import { AbstainVoteType, VoteType } from '../../utils/helpers';
@@ -249,7 +247,7 @@ export default function Delegators({ address, closeDelegators, handleCloseStanda
               {t('Delegators ({{count}})', { replace: { count: delegatorList?.length } })}
             </Grid>
             <Grid item width='22%'>
-              <vaadin-icon icon='vaadin:sort' onClick={onSortVotes} style={{ height: '20px', color: `${theme.palette.primary.main}`, cursor: 'pointer' }} />
+              <VaadinIcon icon='vaadin:sort' onClick={onSortVotes} style={{ height: '20px', color: `${theme.palette.primary.main}`, cursor: 'pointer' }} />
               {t('Amount')}
             </Grid>
             <Grid item width='15%'>

--- a/packages/extension-polkagate/src/fullscreen/governance/post/allVote/FellowshipVotes.tsx
+++ b/packages/extension-polkagate/src/fullscreen/governance/post/allVote/FellowshipVotes.tsx
@@ -4,8 +4,6 @@
 
 /* eslint-disable react/jsx-max-props-per-line */
 
-import '@vaadin/icons';
-
 import { Check as CheckIcon, Close as CloseIcon } from '@mui/icons-material';
 import SearchIcon from '@mui/icons-material/Search';
 import { Box, Divider, Grid, Pagination, Tab, Tabs, Typography, useTheme } from '@mui/material';

--- a/packages/extension-polkagate/src/fullscreen/governance/post/allVote/Standards.tsx
+++ b/packages/extension-polkagate/src/fullscreen/governance/post/allVote/Standards.tsx
@@ -4,8 +4,6 @@
 
 /* eslint-disable react/jsx-max-props-per-line */
 
-import '@vaadin/icons';
-
 import { Check as CheckIcon, Close as CloseIcon, RemoveCircle as AbstainIcon } from '@mui/icons-material';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import SearchIcon from '@mui/icons-material/Search';
@@ -15,7 +13,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { noop } from '@polkadot/extension-polkagate/src/util/utils';
 import { BN } from '@polkadot/util';
 
-import { Identity, InputFilter, Progress, ShowBalance } from '../../../../components';
+import { Identity, InputFilter, Progress, ShowBalance, VaadinIcon } from '../../../../components';
 import { useApi, useChain, useDecimal, useToken, useTranslation } from '../../../../hooks';
 import { DraggableModal } from '../../components/DraggableModal';
 import { AbstainVoteType, AllVotesType, FilteredVotes, VoteType } from '../../utils/helpers';
@@ -236,7 +234,7 @@ export default function Standards({ address, allVotes, filteredVotes, handleClos
               </Grid>
               <Grid container item justifyContent='space-around' xs={12} fontSize='16px'>
                 <Grid item>
-                  <vaadin-icon icon='vaadin:sort' onClick={onSortVotes} style={{ height: '25px', color: `${theme.palette.primary.main}`, cursor: 'pointer' }} />
+                  <VaadinIcon icon='vaadin:sort' onClick={onSortVotes} style={{ height: '25px', color: `${theme.palette.primary.main}`, cursor: 'pointer' }} />
                   {t('Value')}
                 </Grid>
                 {voteTypeStr !== 'abstain' &&

--- a/packages/extension-polkagate/src/fullscreen/homeFullScreen/partials/AccountInformationForHome.tsx
+++ b/packages/extension-polkagate/src/fullscreen/homeFullScreen/partials/AccountInformationForHome.tsx
@@ -13,7 +13,7 @@ import { getValue } from '@polkadot/extension-polkagate/src/popup/account/util';
 import { BN } from '@polkadot/util';
 
 import { stars6Black, stars6White } from '../../../assets/icons';
-import { ActionContext, Identicon, Identity, Infotip, OptionalCopyButton, ShortAddress2 } from '../../../components';
+import { ActionContext, Identicon, Identity, Infotip, OptionalCopyButton, ShortAddress2, VaadinIcon } from '../../../components';
 import { nFormatter } from '../../../components/FormatPrice';
 import { useCurrency, useIdentity, useInfo, usePrices, useTranslation } from '../../../hooks';
 import { FetchedBalance } from '../../../hooks/useAssetsBalances';
@@ -166,7 +166,7 @@ export default function AccountInformationForHome({ accountAssets, address, hide
               <Grid item width='40px'>
                 <Infotip text={account?.isHidden && t('This account is hidden from websites')}>
                   <IconButton onClick={toggleVisibility} sx={{ height: '20px', ml: '7px', mt: '13px', p: 0, width: '28px' }}>
-                    <vaadin-icon icon={account?.isHidden ? 'vaadin:eye-slash' : 'vaadin:eye'} style={{ color: `${theme.palette.secondary.light}`, height: '20px' }} />
+                    <VaadinIcon icon={account?.isHidden ? 'vaadin:eye-slash' : 'vaadin:eye'} style={{ color: `${theme.palette.secondary.light}`, height: '20px' }} />
                   </IconButton>
                 </Infotip>
               </Grid>

--- a/packages/extension-polkagate/src/fullscreen/homeFullScreen/partials/ExportAllModal.tsx
+++ b/packages/extension-polkagate/src/fullscreen/homeFullScreen/partials/ExportAllModal.tsx
@@ -4,14 +4,12 @@
 
 /* eslint-disable react/jsx-max-props-per-line */
 
-import '@vaadin/icons';
-
 import { Close as CloseIcon } from '@mui/icons-material';
 import { Grid, Typography, useTheme } from '@mui/material';
 import { saveAs } from 'file-saver';
 import React, { useCallback, useContext, useState } from 'react';
 
-import { AccountContext, TwoButtons } from '../../../components';
+import { AccountContext, TwoButtons, VaadinIcon } from '../../../components';
 import { useTranslation } from '../../../hooks';
 import { exportAccounts } from '../../../messaging';
 import { Passwords } from '../../../partials';
@@ -65,7 +63,7 @@ export default function ExportAllModal({ open, setDisplayPopup }: Props): React.
         <Grid alignItems='center' container justifyContent='space-between' pt='5px'>
           <Grid alignItems='flex-start' container justifyContent='flex-start' sx={{ width: 'fit-content' }}>
             <Grid item>
-              <vaadin-icon icon='vaadin:download' style={{ height: '25px', color: `${theme.palette.text.primary}`, width: '25px' }} />
+              <VaadinIcon icon='vaadin:download' style={{ height: '25px', color: `${theme.palette.text.primary}`, width: '25px' }} />
             </Grid>
             <Grid item sx={{ pl: '10px' }}>
               <Typography fontSize='22px' fontWeight={700}>

--- a/packages/extension-polkagate/src/fullscreen/homeFullScreen/partials/FullScreenAccountMenu.tsx
+++ b/packages/extension-polkagate/src/fullscreen/homeFullScreen/partials/FullScreenAccountMenu.tsx
@@ -4,14 +4,12 @@
 
 /* eslint-disable react/jsx-max-props-per-line */
 
-import '@vaadin/icons';
-
 import { faAddressCard } from '@fortawesome/free-regular-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Divider, Grid, Popover, useTheme } from '@mui/material';
 import React, { useCallback, useContext } from 'react';
 
-import { ActionContext, MenuItem, SocialRecoveryIcon } from '../../../components';
+import { ActionContext, MenuItem, SocialRecoveryIcon, VaadinIcon } from '../../../components';
 import { useInfo, useTranslation } from '../../../hooks';
 import { IDENTITY_CHAINS, PROXY_CHAINS, SOCIAL_RECOVERY_CHAINS } from '../../../util/constants';
 import { POPUPS_NUMBER } from './AccountInformationForHome';
@@ -98,7 +96,7 @@ function FullScreenAccountMenu({ address, baseButton, setDisplayPopup }: Props):
       <MenuItem
         disabled={isDisable(PROXY_CHAINS)}
         iconComponent={
-          <vaadin-icon icon='vaadin:sitemap' style={{ height: '20px', color: `${isDisable(PROXY_CHAINS) ? theme.palette.text.disabled : theme.palette.text.primary}` }} />
+          <VaadinIcon icon='vaadin:sitemap' style={{ height: '20px', color: `${isDisable(PROXY_CHAINS) ? theme.palette.text.disabled : theme.palette.text.primary}` }} />
         }
         onClick={onManageProxies}
         text={t<string>('Manage proxies')}
@@ -124,7 +122,7 @@ function FullScreenAccountMenu({ address, baseButton, setDisplayPopup }: Props):
       {hasPrivateKey &&
         <MenuItem
           iconComponent={
-            <vaadin-icon icon='vaadin:download-alt' style={{ height: '20px', color: `${theme.palette.text.primary}` }} />
+            <VaadinIcon icon='vaadin:download-alt' style={{ height: '20px', color: `${theme.palette.text.primary}` }} />
           }
           onClick={onExportAccount}
           text={t('Export account')}
@@ -134,7 +132,7 @@ function FullScreenAccountMenu({ address, baseButton, setDisplayPopup }: Props):
       {hasPrivateKey &&
         <MenuItem
           iconComponent={
-            <vaadin-icon icon='vaadin:road-branch' style={{ height: '20px', color: `${theme.palette.text.primary}` }} />
+            <VaadinIcon icon='vaadin:road-branch' style={{ height: '20px', color: `${theme.palette.text.primary}` }} />
           }
           onClick={goToDeriveAcc}
           text={t('Derive new account')}
@@ -143,7 +141,7 @@ function FullScreenAccountMenu({ address, baseButton, setDisplayPopup }: Props):
       }
       <MenuItem
         iconComponent={
-          <vaadin-icon icon='vaadin:edit' style={{ height: '20px', color: `${theme.palette.text.primary}` }} />
+          <VaadinIcon icon='vaadin:edit' style={{ height: '20px', color: `${theme.palette.text.primary}` }} />
         }
         onClick={onRenameAccount}
         text={t('Rename')}
@@ -151,7 +149,7 @@ function FullScreenAccountMenu({ address, baseButton, setDisplayPopup }: Props):
       />
       <MenuItem
         iconComponent={
-          <vaadin-icon icon='vaadin:file-remove' style={{ color: `${theme.palette.text.primary}`, height: '20px' }} />
+          <VaadinIcon icon='vaadin:file-remove' style={{ color: `${theme.palette.text.primary}`, height: '20px' }} />
         }
         onClick={onForgetAccount}
         text={t('Forget account')}

--- a/packages/extension-polkagate/src/fullscreen/homeFullScreen/partials/HomeMenu.tsx
+++ b/packages/extension-polkagate/src/fullscreen/homeFullScreen/partials/HomeMenu.tsx
@@ -4,13 +4,11 @@
 
 /* eslint-disable react/jsx-max-props-per-line */
 
-import '@vaadin/icons';
-
 import { ArrowForwardIosRounded as ArrowForwardIosRoundedIcon } from '@mui/icons-material';
 import { Divider, Grid, Typography, useTheme } from '@mui/material';
 import React, { useCallback, useContext, useMemo, useState } from 'react';
 
-import { AccountContext } from '../../../components';
+import { AccountContext, VaadinIcon } from '../../../components';
 import { useTranslation } from '../../../hooks';
 import VersionSocial from '../../../partials/VersionSocial';
 import { openOrFocusTab } from '../../accountDetails/components/CommonTasks';
@@ -102,7 +100,7 @@ export default function HomeMenu(): React.ReactElement {
       <Grid alignItems='center' container direction='column' display='block' item justifyContent='center' sx={{ pb: '40px' }}>
         <TaskButton
           icon={
-            <vaadin-icon icon='vaadin:plus-circle' style={{ height: '30px', color: `${theme.palette.text.primary}`, width: '30px' }} />
+            <VaadinIcon icon='vaadin:plus-circle' style={{ height: '30px', color: `${theme.palette.text.primary}`, width: '30px' }} />
           }
           onClick={onCreate}
           secondaryIconType='page'
@@ -111,7 +109,7 @@ export default function HomeMenu(): React.ReactElement {
         <TaskButton
           disabled={areAllExternalAccounts}
           icon={
-            <vaadin-icon icon='vaadin:road-branch' style={{ height: '30px', color: `${theme.palette.text.primary}`, width: '30px' }} />
+            <VaadinIcon icon='vaadin:road-branch' style={{ height: '30px', color: `${theme.palette.text.primary}`, width: '30px' }} />
           }
           onClick={onDeriveFromAccounts}
           secondaryIconType='page'
@@ -120,7 +118,7 @@ export default function HomeMenu(): React.ReactElement {
         <TaskButton
           hasChildren
           icon={
-            <vaadin-icon icon='vaadin:upload-alt' style={{ height: '30px', color: `${theme.palette.text.primary}`, width: '30px' }} />
+            <VaadinIcon icon='vaadin:upload-alt' style={{ height: '30px', color: `${theme.palette.text.primary}`, width: '30px' }} />
           }
           onClick={onImportClick}
           secondaryIconType='page'
@@ -132,7 +130,7 @@ export default function HomeMenu(): React.ReactElement {
         <TaskButton
           disabled={areAllExternalAccounts}
           icon={
-            <vaadin-icon icon='vaadin:download' style={{ height: '30px', color: `${theme.palette.text.primary}`, width: '30px' }} />
+            <VaadinIcon icon='vaadin:download' style={{ height: '30px', color: `${theme.palette.text.primary}`, width: '30px' }} />
           }
           onClick={onExportAll}
           secondaryIconType='popup'
@@ -141,7 +139,7 @@ export default function HomeMenu(): React.ReactElement {
         <TaskButton
           hasChildren
           icon={
-            <vaadin-icon icon='vaadin:cog' style={{ height: '30px', color: `${theme.palette.text.primary}`, width: '30px' }} />
+            <VaadinIcon icon='vaadin:cog' style={{ height: '30px', color: `${theme.palette.text.primary}`, width: '30px' }} />
           }
           noBorderButton
           onClick={onSettingClick}

--- a/packages/extension-polkagate/src/fullscreen/homeFullScreen/partials/ImportAccSubMenuFullScreen.tsx
+++ b/packages/extension-polkagate/src/fullscreen/homeFullScreen/partials/ImportAccSubMenuFullScreen.tsx
@@ -4,8 +4,6 @@
 
 /* eslint-disable react/jsx-max-props-per-line */
 
-import '@vaadin/icons';
-
 import { faSitemap } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { ArrowForwardIos as ArrowForwardIosIcon } from '@mui/icons-material';
@@ -15,6 +13,7 @@ import React, { useCallback } from 'react';
 import settings from '@polkadot/ui-settings';
 
 import { useTranslation } from '../../../hooks';
+import { VaadinIcon } from '../../../components';
 import { openOrFocusTab } from '../../accountDetails/components/CommonTasks';
 import { TaskButton } from './HomeMenu';
 
@@ -61,7 +60,7 @@ function ImportAccSubMenuFullScreen({ show, toggleSettingSubMenu }: Props): Reac
         <Grid container direction='column' display='block' item sx={{ p: '0 0 15px 40px' }}>
           <TaskButton
             icon={
-              <vaadin-icon icon='vaadin:file-text' style={{ height: '25px', color: `${theme.palette.text.primary}`, width: '25px' }} />
+              <VaadinIcon icon='vaadin:file-text' style={{ height: '25px', color: `${theme.palette.text.primary}`, width: '25px' }} />
             }
             isSubMenu
             onClick={onRestoreFromJson}
@@ -69,7 +68,7 @@ function ImportAccSubMenuFullScreen({ show, toggleSettingSubMenu }: Props): Reac
           />
           <TaskButton
             icon={
-              <vaadin-icon icon='vaadin:book' style={{ height: '25px', color: `${theme.palette.text.primary}`, width: '25px' }} />
+              <VaadinIcon icon='vaadin:book' style={{ height: '25px', color: `${theme.palette.text.primary}`, width: '25px' }} />
             }
             isSubMenu
             onClick={onImportFromSeed}
@@ -77,7 +76,7 @@ function ImportAccSubMenuFullScreen({ show, toggleSettingSubMenu }: Props): Reac
           />
           <TaskButton
             icon={
-              <vaadin-icon icon='vaadin:book-dollar' style={{ height: '25px', color: `${theme.palette.text.primary}`, width: '25px' }} />
+              <VaadinIcon icon='vaadin:book-dollar' style={{ height: '25px', color: `${theme.palette.text.primary}`, width: '25px' }} />
             }
             isSubMenu
             onClick={onImportFromRawSeed}
@@ -85,7 +84,7 @@ function ImportAccSubMenuFullScreen({ show, toggleSettingSubMenu }: Props): Reac
           />
           <TaskButton
             icon={
-              <vaadin-icon icon='vaadin:sitemap' style={{ height: '25px', color: `${theme.palette.text.primary}`, width: '25px', transform: 'rotate(180deg)' }} />
+              <VaadinIcon icon='vaadin:sitemap' style={{ height: '25px', color: `${theme.palette.text.primary}`, width: '25px', transform: 'rotate(180deg)' }} />
             }
             isSubMenu
             onClick={onImportProxiedFullScreen}
@@ -93,7 +92,7 @@ function ImportAccSubMenuFullScreen({ show, toggleSettingSubMenu }: Props): Reac
           />
           <TaskButton
             icon={
-              <vaadin-icon icon='vaadin:tag' style={{ height: '25px', color: `${theme.palette.text.primary}`, width: '25px' }} />
+              <VaadinIcon icon='vaadin:tag' style={{ height: '25px', color: `${theme.palette.text.primary}`, width: '25px' }} />
             }
             isSubMenu
             onClick={onAddWatchOnlyFullScreen}
@@ -109,7 +108,7 @@ function ImportAccSubMenuFullScreen({ show, toggleSettingSubMenu }: Props): Reac
               : undefined
             }
             icon={
-              <vaadin-icon icon='vaadin:qrcode' style={{ height: '25px', color: `${theme.palette.text.primary}`, width: '25px' }} />
+              <VaadinIcon icon='vaadin:qrcode' style={{ height: '25px', color: `${theme.palette.text.primary}`, width: '25px' }} />
             }
             isSubMenu
             onClick={onAttachQrFullScreen}
@@ -117,7 +116,7 @@ function ImportAccSubMenuFullScreen({ show, toggleSettingSubMenu }: Props): Reac
           />
           <TaskButton
             icon={
-              <vaadin-icon icon='vaadin:wallet' style={{ height: '25px', color: `${theme.palette.text.primary}`, width: '25px' }} />
+              <VaadinIcon icon='vaadin:wallet' style={{ height: '25px', color: `${theme.palette.text.primary}`, width: '25px' }} />
             }
             isSubMenu
             onClick={onImportLedger}

--- a/packages/extension-polkagate/src/fullscreen/homeFullScreen/partials/ManageLoginPassword.tsx
+++ b/packages/extension-polkagate/src/fullscreen/homeFullScreen/partials/ManageLoginPassword.tsx
@@ -4,13 +4,11 @@
 
 /* eslint-disable react/jsx-max-props-per-line */
 
-import '@vaadin/icons';
-
 import { Close as CloseIcon } from '@mui/icons-material';
 import { Grid, Typography, useTheme } from '@mui/material';
 import React, { useCallback, useEffect, useState } from 'react';
 
-import { WrongPasswordAlert } from '../../../components';
+import { VaadinIcon, WrongPasswordAlert } from '../../../components';
 import { getStorage, LoginInfo } from '../../../components/Loading';
 import { useTranslation } from '../../../hooks';
 import Confirmation from '../../../popup/passwordManagement/Confirmation';
@@ -58,7 +56,7 @@ export default function ManageLoginPassword({ open, setDisplayPopup }: Props): R
         <Grid alignItems='center' container justifyContent='space-between' pt='5px'>
           <Grid alignItems='flex-start' container justifyContent='flex-start' sx={{ width: 'fit-content' }}>
             <Grid item>
-              <vaadin-icon icon='vaadin:key' style={{ height: '25px', color: `${theme.palette.text.primary}`, width: '25px' }} />
+              <VaadinIcon icon='vaadin:key' style={{ height: '25px', color: `${theme.palette.text.primary}`, width: '25px' }} />
             </Grid>
             <Grid item sx={{ pl: '10px' }}>
               <Typography fontSize='22px' fontWeight={700}>

--- a/packages/extension-polkagate/src/fullscreen/homeFullScreen/partials/ManageWebAccess.tsx
+++ b/packages/extension-polkagate/src/fullscreen/homeFullScreen/partials/ManageWebAccess.tsx
@@ -4,15 +4,13 @@
 
 /* eslint-disable react/jsx-max-props-per-line */
 
-import '@vaadin/icons';
-
 import { Close as CloseIcon } from '@mui/icons-material';
 import { Grid, Typography, useTheme } from '@mui/material';
 import React, { useCallback, useEffect, useState } from 'react';
 
 import { AuthUrlInfo, AuthUrls } from '@polkadot/extension-base/background/handlers/State';
 
-import { InputFilter, Label, PButton } from '../../../components';
+import { InputFilter, Label, PButton, VaadinIcon } from '../../../components';
 import { useTranslation } from '../../../hooks';
 import { getAuthList, removeAuthorization, toggleAuthorization } from '../../../messaging';
 import WebsiteEntry from '../../../popup/authManagement/WebsiteEntry';
@@ -59,7 +57,7 @@ export default function ManageWebAccess({ open, setDisplayPopup }: Props): React
         <Grid alignItems='center' container justifyContent='space-between' pt='5px'>
           <Grid alignItems='flex-start' container justifyContent='flex-start' sx={{ width: 'fit-content' }}>
             <Grid item>
-              <vaadin-icon icon='vaadin:lines-list' style={{ height: '25px', color: `${theme.palette.text.primary}`, width: '25px' }} />
+              <VaadinIcon icon='vaadin:lines-list' style={{ height: '25px', color: `${theme.palette.text.primary}`, width: '25px' }} />
             </Grid>
             <Grid item sx={{ pl: '10px' }}>
               <Typography fontSize='22px' fontWeight={700}>

--- a/packages/extension-polkagate/src/fullscreen/homeFullScreen/partials/SettingSubMenuFullScreen.tsx
+++ b/packages/extension-polkagate/src/fullscreen/homeFullScreen/partials/SettingSubMenuFullScreen.tsx
@@ -4,15 +4,13 @@
 
 /* eslint-disable react/jsx-max-props-per-line */
 
-import '@vaadin/icons';
-
 import { Box, Collapse, Divider, Grid, useTheme } from '@mui/material';
 import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 
 import settings from '@polkadot/ui-settings';
 
 import { checkBox, checkedBox } from '../../../assets/icons';
-import { AccountContext, Select } from '../../../components';
+import { AccountContext, Select, VaadinIcon } from '../../../components';
 import { getStorage, setStorage } from '../../../components/Loading';
 import { useIsTestnetEnabled, useTranslation } from '../../../hooks';
 import { setNotification, tieAccount } from '../../../messaging';
@@ -123,7 +121,7 @@ export default function SettingSubMenuFullScreen({ show }: Props): React.ReactEl
             />
             <TaskButton
               icon={
-                <vaadin-icon icon='vaadin:lines-list' style={{ height: '25px', color: `${theme.palette.text.primary}`, width: '25px' }} />
+                <VaadinIcon icon='vaadin:lines-list' style={{ height: '25px', color: `${theme.palette.text.primary}`, width: '25px' }} />
               }
               isSubMenu
               onClick={onAuthManagement}
@@ -131,7 +129,7 @@ export default function SettingSubMenuFullScreen({ show }: Props): React.ReactEl
             />
             <TaskButton
               icon={
-                <vaadin-icon icon='vaadin:key' style={{ height: '25px', color: `${theme.palette.text.primary}`, width: '25px' }} />
+                <VaadinIcon icon='vaadin:key' style={{ height: '25px', color: `${theme.palette.text.primary}`, width: '25px' }} />
               }
               isSubMenu
               onClick={onManageLoginPassword}

--- a/packages/extension-polkagate/src/fullscreen/manageProxies/AddProxy.tsx
+++ b/packages/extension-polkagate/src/fullscreen/manageProxies/AddProxy.tsx
@@ -4,8 +4,6 @@
 
 /* eslint-disable react/jsx-max-props-per-line */
 
-import '@vaadin/icons';
-
 import { AddRounded as AddRoundedIcon } from '@mui/icons-material';
 import { Grid, Typography, useTheme } from '@mui/material';
 import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';

--- a/packages/extension-polkagate/src/fullscreen/manageProxies/Manage.tsx
+++ b/packages/extension-polkagate/src/fullscreen/manageProxies/Manage.tsx
@@ -4,8 +4,6 @@
 
 /* eslint-disable react/jsx-max-props-per-line */
 
-import '@vaadin/icons';
-
 import type { ProxyItem } from '../../util/types';
 
 import { AddRounded as AddRoundedIcon } from '@mui/icons-material';
@@ -17,7 +15,7 @@ import type { Chain } from '@polkadot/extension-chains/types';
 
 import { BN, BN_ZERO } from '@polkadot/util';
 
-import { ActionContext, ShowBalance, TwoButtons } from '../../components';
+import { ActionContext, ShowBalance, TwoButtons, VaadinIcon } from '../../components';
 import { useTranslation } from '../../hooks';
 import { noop } from '../../util/utils';
 import Bread from '../partials/Bread';
@@ -122,7 +120,7 @@ export default function Manage({ api, chain, decimal, depositedValue, isDisabled
       <Bread />
       <Title
         height='100px'
-        logo={<vaadin-icon icon='vaadin:sitemap' style={{ fontSize: '23px', color: `${theme.palette.text.primary}` }} />}
+        logo={<VaadinIcon icon='vaadin:sitemap' style={{ fontSize: '23px', color: `${theme.palette.text.primary}` }} />}
         text={t('Proxy Management')}
       />
       <Typography fontSize='14px' fontWeight={400}>

--- a/packages/extension-polkagate/src/fullscreen/manageProxies/Review.tsx
+++ b/packages/extension-polkagate/src/fullscreen/manageProxies/Review.tsx
@@ -4,8 +4,6 @@
 
 /* eslint-disable react/jsx-max-props-per-line */
 
-import '@vaadin/icons';
-
 import type { SubmittableExtrinsic } from '@polkadot/api/types';
 import type { Balance } from '@polkadot/types/interfaces';
 import type { Proxy, ProxyItem, TxInfo } from '../../util/types';
@@ -18,7 +16,7 @@ import type { Chain } from '@polkadot/extension-chains/types';
 
 import { BN, BN_ONE, BN_ZERO } from '@polkadot/util';
 
-import { CanPayErrorAlert, ShowBalance, SignArea2, WrongPasswordAlert } from '../../components';
+import { CanPayErrorAlert, ShowBalance, SignArea2, WrongPasswordAlert, VaadinIcon } from '../../components';
 import { useCanPayFeeAndDeposit, useFormatted, useTranslation } from '../../hooks';
 import { ThroughProxy } from '../../partials';
 import { PROXY_TYPE } from '../../util/constants';
@@ -154,7 +152,7 @@ function Review({ address, api, chain, depositedValue, newDepositValue, proxyIte
     <Grid container item>
       <Title
         logo={
-          <vaadin-icon icon='vaadin:sitemap' style={{ fontSize: '25px', color: `${theme.palette.text.primary}` }} />
+          <VaadinIcon icon='vaadin:sitemap' style={{ fontSize: '25px', color: `${theme.palette.text.primary}` }} />
         }
         text={
           [STEPS.REVIEW, STEPS.PROXY, STEPS.SIGN_QR].includes(step)

--- a/packages/extension-polkagate/src/fullscreen/manageProxies/index.tsx
+++ b/packages/extension-polkagate/src/fullscreen/manageProxies/index.tsx
@@ -4,8 +4,6 @@
 
 /* eslint-disable react/jsx-max-props-per-line */
 
-import '@vaadin/icons';
-
 import type { Proxy, ProxyItem } from '../../util/types';
 
 import { Grid, Typography, useTheme } from '@mui/material';

--- a/packages/extension-polkagate/src/fullscreen/onboarding/index.tsx
+++ b/packages/extension-polkagate/src/fullscreen/onboarding/index.tsx
@@ -3,8 +3,6 @@
 // @ts-nocheck
 
 /* eslint-disable react/jsx-max-props-per-line */
-//@ts-nocheck
-import '@vaadin/icons';
 
 import { faHome } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -13,7 +11,7 @@ import React, { useCallback, useContext, useEffect, useState } from 'react';
 
 import { FULLSCREEN_WIDTH } from '@polkadot/extension-polkagate/src/util/constants';
 
-import { AccountContext, ActionContext, PButton } from '../../components';
+import { AccountContext, ActionContext, PButton, VaadinIcon } from '../../components';
 import { useFullscreen, useTranslation } from '../../hooks';
 import { createAccountExternal, windowOpen } from '../../messaging';
 import Privacy from '../../popup/welcome/Privacy';
@@ -127,7 +125,7 @@ function Onboarding(): React.ReactElement {
               _mt='20px'
               _onClick={onCreate}
               _variant={'contained'}
-              startIcon={<vaadin-icon icon='vaadin:plus-circle' style={{ height: '18px', color: `${theme.palette.text.main}` }} />}
+              startIcon={<VaadinIcon icon='vaadin:plus-circle' style={{ height: '18px', color: `${theme.palette.text.main}` }} />}
               text={t('Create a new account')}
             />
             <Divider sx={{ fontSize: '20px', fontWeight: 400, my: '25px', width: '88%' }}>

--- a/packages/extension-polkagate/src/fullscreen/socialRecovery/components/SelectTrustedFriend.tsx
+++ b/packages/extension-polkagate/src/fullscreen/socialRecovery/components/SelectTrustedFriend.tsx
@@ -5,8 +5,6 @@
 /* eslint-disable react/jsx-max-props-per-line */
 /* eslint-disable react/jsx-first-prop-new-line */
 
-import '@vaadin/icons';
-
 import type { DeriveAccountInfo } from '@polkadot/api-derive/types';
 
 import { faPaste, faXmarkCircle } from '@fortawesome/free-solid-svg-icons';

--- a/packages/extension-polkagate/src/fullscreen/stake/pool/PoolStaked.tsx
+++ b/packages/extension-polkagate/src/fullscreen/stake/pool/PoolStaked.tsx
@@ -4,8 +4,6 @@
 
 /* eslint-disable react/jsx-max-props-per-line */
 
-import '@vaadin/icons';
-
 import type { BalancesInfo, MyPoolInfo } from '../../../util/types';
 
 import { faSquarePlus } from '@fortawesome/free-regular-svg-icons';

--- a/packages/extension-polkagate/src/fullscreen/stake/pool/index.tsx
+++ b/packages/extension-polkagate/src/fullscreen/stake/pool/index.tsx
@@ -4,8 +4,6 @@
 
 /* eslint-disable react/jsx-max-props-per-line */
 
-import '@vaadin/icons';
-
 import type { TxInfo } from '../../../util/types';
 
 import { Grid, useTheme } from '@mui/material';

--- a/packages/extension-polkagate/src/fullscreen/stake/solo/partials/ValidatorsTable.tsx
+++ b/packages/extension-polkagate/src/fullscreen/stake/solo/partials/ValidatorsTable.tsx
@@ -4,8 +4,6 @@
 
 /* eslint-disable react/jsx-max-props-per-line */
 
-import '@vaadin/icons';
-
 import type { AccountId } from '@polkadot/types/interfaces';
 
 import { alpha, Grid, type SxProps, type Theme, useTheme } from '@mui/material';
@@ -17,6 +15,7 @@ import { useInfo } from '@polkadot/extension-polkagate/src/hooks';
 import ValidatorInfoPage from '@polkadot/extension-polkagate/src/popup/staking/partial/ValidatorInfo';
 import { BN, hexToBn, isHex } from '@polkadot/util';
 
+import { VaadinIcon } from '../../../../components';
 import type { StakingConsts, ValidatorInfo } from '../../../../util/types';
 import ShowValidator from './ShowValidator';
 
@@ -119,7 +118,7 @@ export default function ValidatorsTable({ activeValidators, address, allValidato
                     v={v}
                   />
                   <Grid alignItems='center' container item justifyContent='center' onClick={() => openValidatorInfo(v)} sx={{ cursor: 'pointer' }} width='6%'>
-                    <vaadin-icon icon='vaadin:ellipsis-dots-v' style={{ color: `${theme.palette.secondary.light}`, width: '33px' }} />
+                    <VaadinIcon icon='vaadin:ellipsis-dots-v' style={{ color: `${theme.palette.secondary.light}`, width: '33px' }} />
                   </Grid>
                 </Grid>
               );

--- a/packages/extension-polkagate/src/partials/AccountMenu.tsx
+++ b/packages/extension-polkagate/src/partials/AccountMenu.tsx
@@ -4,15 +4,13 @@
 
 /* eslint-disable react/jsx-max-props-per-line */
 
-import '@vaadin/icons';
-
 import { faAddressCard } from '@fortawesome/free-regular-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Close as CloseIcon } from '@mui/icons-material';
 import { Divider, Grid, IconButton, Slide, useTheme } from '@mui/material';
 import React, { useCallback, useContext, useState } from 'react';
 
-import { ActionContext, Identity, MenuItem, RemoteNodeSelector, SelectChain, SocialRecoveryIcon } from '../components';
+import { ActionContext, Identity, MenuItem, RemoteNodeSelector, SelectChain, SocialRecoveryIcon, VaadinIcon } from '../components';
 import { useGenesisHashOptions, useInfo, useTranslation } from '../hooks';
 import { tieAccount, windowOpen } from '../messaging';
 import { IDENTITY_CHAINS, PROXY_CHAINS, SOCIAL_RECOVERY_CHAINS } from '../util/constants';
@@ -107,7 +105,7 @@ function AccountMenu({ address, isMenuOpen, noMargin, setShowMenu }: Props): Rea
       <MenuItem
         disabled={isDisabled(PROXY_CHAINS)}
         iconComponent={
-          <vaadin-icon icon='vaadin:sitemap' style={{ height: '18px', color: `${isDisabled(PROXY_CHAINS) ? theme.palette.text.disabled : theme.palette.text.primary}` }} />
+          <VaadinIcon icon='vaadin:sitemap' style={{ height: '18px', color: `${isDisabled(PROXY_CHAINS) ? theme.palette.text.disabled : theme.palette.text.primary}` }} />
         }
         onClick={onManageProxies}
         text={t('Manage proxies')}
@@ -133,7 +131,7 @@ function AccountMenu({ address, isMenuOpen, noMargin, setShowMenu }: Props): Rea
       {hasPrivateKey &&
         <MenuItem
           iconComponent={
-            <vaadin-icon icon='vaadin:download-alt' style={{ height: '18px', color: `${theme.palette.text.primary}` }} />
+            <VaadinIcon icon='vaadin:download-alt' style={{ height: '18px', color: `${theme.palette.text.primary}` }} />
           }
           onClick={onExportAccount}
           text={t('Export account')}
@@ -142,7 +140,7 @@ function AccountMenu({ address, isMenuOpen, noMargin, setShowMenu }: Props): Rea
       {hasPrivateKey &&
         <MenuItem
           iconComponent={
-            <vaadin-icon icon='vaadin:road-branch' style={{ height: '18px', color: `${theme.palette.text.primary}` }} />
+            <VaadinIcon icon='vaadin:road-branch' style={{ height: '18px', color: `${theme.palette.text.primary}` }} />
           }
           onClick={goToDeriveAcc}
           text={t('Derive new account')}
@@ -151,7 +149,7 @@ function AccountMenu({ address, isMenuOpen, noMargin, setShowMenu }: Props): Rea
       }
       <MenuItem
         iconComponent={
-          <vaadin-icon icon='vaadin:edit' style={{ height: '18px', color: `${theme.palette.text.primary}` }} />
+          <VaadinIcon icon='vaadin:edit' style={{ height: '18px', color: `${theme.palette.text.primary}` }} />
         }
         onClick={onRenameAccount}
         text={t('Rename')}
@@ -159,7 +157,7 @@ function AccountMenu({ address, isMenuOpen, noMargin, setShowMenu }: Props): Rea
       />
       <MenuItem
         iconComponent={
-          <vaadin-icon icon='vaadin:file-remove' style={{ height: '18px', color: `${theme.palette.text.primary}` }} />
+          <VaadinIcon icon='vaadin:file-remove' style={{ height: '18px', color: `${theme.palette.text.primary}` }} />
         }
         onClick={onForgetAccount}
         text={t('Forget account')}

--- a/packages/extension-polkagate/src/partials/AddNewAccountButton.tsx
+++ b/packages/extension-polkagate/src/partials/AddNewAccountButton.tsx
@@ -4,13 +4,11 @@
 
 /* eslint-disable react/jsx-max-props-per-line */
 
-import '@vaadin/icons';
-
 import { ArrowForwardIosRounded as ArrowForwardIosRoundedIcon } from '@mui/icons-material';
 import { Grid, IconButton, Typography, useTheme } from '@mui/material';
 import React, { useCallback, useContext } from 'react';
 
-import { ActionContext } from '../components';
+import { ActionContext, VaadinIcon } from '../components';
 import { useTranslation } from '../hooks';
 import useIsExtensionPopup from '../hooks/useIsExtensionPopup';
 import { windowOpen } from '../messaging';
@@ -31,7 +29,7 @@ export default function AddNewAccountButton(): React.ReactElement {
     <Grid alignItems='center' container justifyContent='space-between' onClick={onCreate} sx={{ '&:hover': { opacity: 1 }, backgroundColor: 'background.paper', borderColor: 'secondary.main', borderRadius: '10px', borderStyle: 'solid', borderWidth: '0.5px', bottom: '20px', cursor: 'pointer', my: isExtensionMode ? '10px' : '20px', opacity: '0.7', padding: 'min(3%, 20px) min(5%, 40px)', position: isExtensionMode ? 'absolute' : 'relative', transition: 'opacity 0.3s ease', width: 'inherit', zIndex: 1 }}>
       <Grid container item width='fit-content'>
         <Grid item width='fit-content'>
-          <vaadin-icon icon='vaadin:plus-circle' style={{ height: '36px', color: `${theme.palette.secondary.light}`, width: '36px' }} />
+          <VaadinIcon icon='vaadin:plus-circle' style={{ height: '36px', color: `${theme.palette.secondary.light}`, width: '36px' }} />
         </Grid>
         <Grid alignItems='center' container item textAlign='left' width='fit-content'>
           <Typography fontSize='18px' fontWeight={500} pl='8px'>

--- a/packages/extension-polkagate/src/partials/HeaderBrand.tsx
+++ b/packages/extension-polkagate/src/partials/HeaderBrand.tsx
@@ -4,8 +4,6 @@
 
 /* eslint-disable react/jsx-max-props-per-line */
 
-import '@vaadin/icons';
-
 import { faRefresh } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { ArrowBackIos as ArrowBackIosIcon, Close as CloseIcon, Menu as MenuIcon, MoreVert as MoreVertIcon } from '@mui/icons-material';
@@ -13,7 +11,7 @@ import { Box, Container, Divider, Grid, IconButton, type SxProps, type Theme, Ty
 import React, { useCallback, useContext, useRef, useState } from 'react';
 
 import { logoBlack, logoWhite } from '../assets/logos';
-import { ActionContext, FullScreenIcon, Steps } from '../components';
+import { ActionContext, FullScreenIcon, Steps, VaadinIcon } from '../components';
 import useOutsideClick from '../hooks/useOutsideClick';
 import type { Step } from '../util/types';
 import Menu from './Menu';
@@ -141,7 +139,7 @@ function HeaderBrand({ _centerItem, address, backgroundDefault, fullScreenURL = 
         <IconButton aria-label='menu' color='inherit' edge='start' onClick={onClose || _onClose} size='small' sx={{ p: 0 }}>
           {showCloseX
             ? <CloseIcon sx={{ fontSize: 40 }} />
-            : <vaadin-icon icon={`vaadin:home${theme.palette.mode === 'light' ? '-o' : ''}`} style={{ height: '22px', width: '22px', color: `${theme.palette.secondary.light}` }} />
+            : <VaadinIcon icon={`vaadin:home${theme.palette.mode === 'light' ? '-o' : ''}`} style={{ height: '22px', width: '22px', color: `${theme.palette.secondary.light}` }} />
           }
         </IconButton>
       }

--- a/packages/extension-polkagate/src/partials/ImportAccSubMenu.tsx
+++ b/packages/extension-polkagate/src/partials/ImportAccSubMenu.tsx
@@ -4,15 +4,13 @@
 
 /* eslint-disable react/jsx-max-props-per-line */
 
-import '@vaadin/icons';
-
 import { ArrowForwardIos as ArrowForwardIosIcon } from '@mui/icons-material';
 import { Collapse, Divider, Grid, useTheme } from '@mui/material';
 import React, { useCallback, useContext } from 'react';
 
 import settings from '@polkadot/ui-settings';
 
-import { ActionContext, MenuItem } from '../components';
+import { ActionContext, MenuItem, VaadinIcon } from '../components';
 import { useTranslation } from '../hooks';
 import { windowOpen } from '../messaging';
 
@@ -62,7 +60,7 @@ function ImportAccSubMenu({ show, toggleSettingSubMenu }: Props): React.ReactEle
           <MenuItem
             fontSize='17px'
             iconComponent={
-              <vaadin-icon icon='vaadin:file-text' style={{ height: '18px', color: `${theme.palette.text.primary}` }} />
+              <VaadinIcon icon='vaadin:file-text' style={{ height: '18px', color: `${theme.palette.text.primary}` }} />
             }
             onClick={onRestoreFromJson}
             py='4px'
@@ -72,7 +70,7 @@ function ImportAccSubMenu({ show, toggleSettingSubMenu }: Props): React.ReactEle
           <MenuItem
             fontSize='17px'
             iconComponent={
-              <vaadin-icon icon='vaadin:book' style={{ height: '18px', color: `${theme.palette.text.primary}` }} />
+              <VaadinIcon icon='vaadin:book' style={{ height: '18px', color: `${theme.palette.text.primary}` }} />
             }
             onClick={onImportAcc}
             py='4px'
@@ -82,7 +80,7 @@ function ImportAccSubMenu({ show, toggleSettingSubMenu }: Props): React.ReactEle
           <MenuItem
             fontSize='17px'
             iconComponent={
-              <vaadin-icon icon='vaadin:book-dollar' style={{ height: '18px', color: `${theme.palette.text.primary}` }} />
+              <VaadinIcon icon='vaadin:book-dollar' style={{ height: '18px', color: `${theme.palette.text.primary}` }} />
             }
             onClick={onImportRawSeed}
             py='4px'
@@ -92,7 +90,7 @@ function ImportAccSubMenu({ show, toggleSettingSubMenu }: Props): React.ReactEle
           <MenuItem
             fontSize='17px'
             iconComponent={
-              <vaadin-icon icon='vaadin:sitemap' style={{ height: '18px', color: `${theme.palette.text.primary}`, transform: 'rotate(180deg)' }} />
+              <VaadinIcon icon='vaadin:sitemap' style={{ height: '18px', color: `${theme.palette.text.primary}`, transform: 'rotate(180deg)' }} />
             }
             onClick={onImportProxied}
             py='4px'
@@ -102,7 +100,7 @@ function ImportAccSubMenu({ show, toggleSettingSubMenu }: Props): React.ReactEle
           <MenuItem
             fontSize='17px'
             iconComponent={
-              <vaadin-icon icon='vaadin:tag' style={{ height: '18px', color: `${theme.palette.text.primary}` }} />
+              <VaadinIcon icon='vaadin:tag' style={{ height: '18px', color: `${theme.palette.text.primary}` }} />
             }
             onClick={onAddWatchOnly}
             py='4px'
@@ -113,7 +111,7 @@ function ImportAccSubMenu({ show, toggleSettingSubMenu }: Props): React.ReactEle
             disabled={settings.camera !== 'on'}
             fontSize='17px'
             iconComponent={
-              <vaadin-icon icon='vaadin:qrcode' style={{ height: '18px', color: `${settings.camera === 'on' ? 'theme.palette.text.primary' : 'theme.palette.text.disabled'}` }} />
+              <VaadinIcon icon='vaadin:qrcode' style={{ height: '18px', color: `${settings.camera === 'on' ? 'theme.palette.text.primary' : 'theme.palette.text.disabled'}` }} />
             }
             onClick={onAttachQR}
             py='4px'
@@ -129,7 +127,7 @@ function ImportAccSubMenu({ show, toggleSettingSubMenu }: Props): React.ReactEle
           <MenuItem
             fontSize='17px'
             iconComponent={
-              <vaadin-icon icon='vaadin:wallet' style={{ height: '18px', color: `${theme.palette.text.primary}` }} />
+              <VaadinIcon icon='vaadin:wallet' style={{ height: '18px', color: `${theme.palette.text.primary}` }} />
             }
             onClick={onImportLedger}
             py='4px'

--- a/packages/extension-polkagate/src/partials/Menu.tsx
+++ b/packages/extension-polkagate/src/partials/Menu.tsx
@@ -4,14 +4,12 @@
 
 /* eslint-disable react/jsx-max-props-per-line */
 
-import '@vaadin/icons';
-
 import { Close as CloseIcon } from '@mui/icons-material';
 import { Divider, Grid, IconButton, Typography } from '@mui/material';
 import { keyframes, Theme } from '@mui/material/styles';
 import React, { useCallback, useContext, useState } from 'react';
 
-import { AccountContext, ActionContext, MenuItem, TwoButtons, Warning } from '../components';
+import { AccountContext, ActionContext, MenuItem, TwoButtons, VaadinIcon,Warning } from '../components';
 import { setStorage } from '../components/Loading';
 import { useTranslation } from '../hooks';
 import { tieAccount } from '../messaging';
@@ -119,7 +117,7 @@ function Menu({ setShowMenu, theme }: Props): React.ReactElement<Props> {
           ? <>
             <MenuItem
               iconComponent={
-                <vaadin-icon icon='vaadin:plus-circle' style={{ height: '18px', color: `${theme.palette.text.primary}` }} />
+                <VaadinIcon icon='vaadin:plus-circle' style={{ height: '18px', color: `${theme.palette.text.primary}` }} />
               }
               onClick={toggleNewAccountSubMenu}
               showSubMenu={collapsedMenu === COLLAPSIBLE_MENUS.NEW_ACCOUNT}
@@ -131,7 +129,7 @@ function Menu({ setShowMenu, theme }: Props): React.ReactElement<Props> {
             <Divider sx={{ bgcolor: 'secondary.light', height: '1px' }} />
             <MenuItem
               iconComponent={
-                <vaadin-icon icon='vaadin:upload-alt' style={{ height: '18px', color: `${theme.palette.text.primary}` }} />
+                <VaadinIcon icon='vaadin:upload-alt' style={{ height: '18px', color: `${theme.palette.text.primary}` }} />
               }
               onClick={toggleImportSubMenu}
               showSubMenu={collapsedMenu === COLLAPSIBLE_MENUS.IMPORT_ACCOUNT}
@@ -143,7 +141,7 @@ function Menu({ setShowMenu, theme }: Props): React.ReactElement<Props> {
             <Divider sx={{ bgcolor: 'secondary.light', height: '1px' }} />
             <MenuItem
               iconComponent={
-                <vaadin-icon icon='vaadin:download' style={{ height: '18px', color: `${theme.palette.text.primary}` }} />
+                <VaadinIcon icon='vaadin:download' style={{ height: '18px', color: `${theme.palette.text.primary}` }} />
               }
               onClick={_goToExportAll}
               text={t('Export all accounts')}
@@ -152,7 +150,7 @@ function Menu({ setShowMenu, theme }: Props): React.ReactElement<Props> {
             <Divider sx={{ bgcolor: 'secondary.light', height: '1px' }} />
             <MenuItem
               iconComponent={
-                <vaadin-icon icon='vaadin:cog' style={{ height: '18px', color: `${theme.palette.text.primary}` }} />
+                <VaadinIcon icon='vaadin:cog' style={{ height: '18px', color: `${theme.palette.text.primary}` }} />
               }
               onClick={toggleSettingSubMenu}
               showSubMenu={collapsedMenu === COLLAPSIBLE_MENUS.SETTING}

--- a/packages/extension-polkagate/src/partials/NewAccountSubMenu.tsx
+++ b/packages/extension-polkagate/src/partials/NewAccountSubMenu.tsx
@@ -4,12 +4,10 @@
 
 /* eslint-disable react/jsx-max-props-per-line */
 
-import '@vaadin/icons';
-
 import { Collapse, Divider, Grid, useTheme } from '@mui/material';
 import React, { useCallback, useContext } from 'react';
 
-import { AccountContext, ActionContext, MenuItem } from '../components';
+import { AccountContext, ActionContext, MenuItem, VaadinIcon } from '../components';
 import { useTranslation } from '../hooks';
 import { windowOpen } from '../messaging';
 
@@ -39,7 +37,7 @@ function NewAccountSubMenu({ show }: Props): React.ReactElement<Props> {
           <MenuItem
             fontSize='17px'
             iconComponent={
-              <vaadin-icon icon='vaadin:plus-circle-o' style={{ height: '18px', color: `${theme.palette.text.primary}` }} />
+              <VaadinIcon icon='vaadin:plus-circle-o' style={{ height: '18px', color: `${theme.palette.text.primary}` }} />
             }
             onClick={goToCreateAcc}
             py='4px'
@@ -49,7 +47,7 @@ function NewAccountSubMenu({ show }: Props): React.ReactElement<Props> {
           <MenuItem
             fontSize='17px'
             iconComponent={
-              <vaadin-icon icon='vaadin:road-branch' style={{ height: '18px', color: `${theme.palette.text.primary}` }} />
+              <VaadinIcon icon='vaadin:road-branch' style={{ height: '18px', color: `${theme.palette.text.primary}` }} />
             }
             onClick={goToDeriveAcc}
             text={t('Derive from accounts')}

--- a/packages/extension-polkagate/src/partials/OptionalCopyPopup.tsx
+++ b/packages/extension-polkagate/src/partials/OptionalCopyPopup.tsx
@@ -4,8 +4,6 @@
 
 /* eslint-disable react/jsx-max-props-per-line */
 
-import '@vaadin/icons';
-
 import { Grid, Typography } from '@mui/material';
 import React, { useCallback, useLayoutEffect, useState } from 'react';
 

--- a/packages/extension-polkagate/src/partials/QuickAction.tsx
+++ b/packages/extension-polkagate/src/partials/QuickAction.tsx
@@ -4,8 +4,6 @@
 
 /* eslint-disable react/jsx-max-props-per-line */
 
-import '@vaadin/icons';
-
 import { faHistory, faPaperPlane, faVoteYea } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { ArrowForwardIos as ArrowForwardIosIcon, Boy as BoyIcon } from '@mui/icons-material';

--- a/packages/extension-polkagate/src/partials/QuickAction.tsx
+++ b/packages/extension-polkagate/src/partials/QuickAction.tsx
@@ -15,7 +15,7 @@ import { useHistory } from 'react-router-dom';
 
 import type { AccountId } from '@polkadot/types/interfaces/runtime';
 
-import { HorizontalMenuItem, PoolStakingIcon } from '../components';
+import { HorizontalMenuItem, PoolStakingIcon, VaadinIcon } from '../components';
 import { useInfo, useTranslation } from '../hooks';
 import { windowOpen } from '../messaging';
 import { CROWDLOANS_CHAINS, GOVERNANCE_CHAINS, STAKING_CHAINS } from '../util/constants';
@@ -156,7 +156,7 @@ export default function QuickAction({ address, quickActionOpen, setQuickActionOp
         divider
         dividerHeight={20}
         icon={
-          <vaadin-icon icon='vaadin:piggy-bank-coin' style={{ height: '23px', color: `${CROWDLOANS_CHAINS.includes(account?.genesisHash) ? theme.palette.text.primary : theme.palette.action.disabledBackground}` }} />
+          <VaadinIcon icon='vaadin:piggy-bank-coin' style={{ height: '23px', color: `${CROWDLOANS_CHAINS.includes(account?.genesisHash) ? theme.palette.text.primary : theme.palette.action.disabledBackground}` }} />
         }
         onClick={goToCrowdLoans}
         textDisabled={!CROWDLOANS_CHAINS.includes(account?.genesisHash)}

--- a/packages/extension-polkagate/src/partials/QuickActionFullScreen.tsx
+++ b/packages/extension-polkagate/src/partials/QuickActionFullScreen.tsx
@@ -4,8 +4,6 @@
 
 /* eslint-disable react/jsx-max-props-per-line */
 
-import '@vaadin/icons';
-
 import { faHistory, faPaperPlane, faVoteYea } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { ArrowForwardIos as ArrowForwardIosIcon, Boy as BoyIcon } from '@mui/icons-material';

--- a/packages/extension-polkagate/src/partials/SettingSubMenu.tsx
+++ b/packages/extension-polkagate/src/partials/SettingSubMenu.tsx
@@ -4,8 +4,6 @@
 
 /* eslint-disable react/jsx-max-props-per-line */
 
-import '@vaadin/icons';
-
 import { faListCheck } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import LockIcon from '@mui/icons-material/Lock';
@@ -14,7 +12,7 @@ import React, { useCallback, useContext, useEffect, useMemo, useState } from 're
 
 import settings from '@polkadot/ui-settings';
 
-import { ActionContext, Checkbox2, ColorContext, FullScreenIcon, Infotip2, MenuItem, Select, Switch } from '../components';
+import { ActionContext, Checkbox2, ColorContext, FullScreenIcon, Infotip2, MenuItem, Select, Switch, VaadinIcon } from '../components';
 import { getStorage, updateStorage } from '../components/Loading';
 import { useExtensionLockContext } from '../context/ExtensionLockContext';
 import { useIsLoginEnabled, useIsPopup, useTranslation } from '../hooks';
@@ -179,7 +177,7 @@ export default function SettingSubMenu({ isTestnetEnabledChecked, onChange, setT
             <MenuItem
               fontSize='17px'
               iconComponent={
-                <vaadin-icon icon='vaadin:key' style={{ height: '18px', color: `${theme.palette.text.primary}` }} />
+                <VaadinIcon icon='vaadin:key' style={{ height: '18px', color: `${theme.palette.text.primary}` }} />
               }
               onClick={onManageLoginPassword}
               py='2px'

--- a/packages/extension-polkagate/src/partials/VersionSocial.tsx
+++ b/packages/extension-polkagate/src/partials/VersionSocial.tsx
@@ -4,8 +4,6 @@
 
 /* eslint-disable react/jsx-max-props-per-line */
 
-import '@vaadin/icons';
-
 import { Email as EmailIcon, Language as LanguageIcon, X as XIcon } from '@mui/icons-material';
 import { Box, Grid, Link, useTheme } from '@mui/material';
 import React from 'react';

--- a/packages/extension-polkagate/src/popup/account/AccountBrief.tsx
+++ b/packages/extension-polkagate/src/popup/account/AccountBrief.tsx
@@ -9,8 +9,6 @@
  * this component show a brief of an account on home pages like staking/crowdloans homepages
  * */
 
-import '@vaadin/icons';
-
 import type { DeriveAccountRegistration } from '@polkadot/api-derive/types';
 
 import { QrCode2 } from '@mui/icons-material';

--- a/packages/extension-polkagate/src/popup/crowdloans/index.tsx
+++ b/packages/extension-polkagate/src/popup/crowdloans/index.tsx
@@ -4,10 +4,6 @@
 
 /* eslint-disable react/jsx-max-props-per-line */
 
-// @ts-nocheck
-
-import '@vaadin/icons';
-
 import type { ApiPromise } from '@polkadot/api';
 import type { DeriveOwnContributions } from '@polkadot/api-derive/types';
 import type { Balance } from '@polkadot/types/interfaces';
@@ -25,7 +21,7 @@ import type { SettingsStruct } from '@polkadot/ui-settings/types';
 import { decodeAddress, encodeAddress } from '@polkadot/util-crypto';
 
 import { auctionBlack, auctionRed, auctionWhite, crowdloanHomeBlack, crowdloanHomeRed, crowdloanHomeWhite, pastCrowdloanBlack, pastCrowdloanRed, pastCrowdloanWhite } from '../../assets/icons';
-import { ActionContext, HorizontalMenuItem, Identicon, Identity, Progress, ShowBalance, Warning } from '../../components';
+import { ActionContext, HorizontalMenuItem, Identicon, Identity, Progress, ShowBalance, VaadinIcon, Warning } from '../../components';
 import { SettingsContext } from '../../components/contexts';
 import { useAuction, useCurrentBlockNumber, useInfo, useMyAccountIdentity, useTranslation } from '../../hooks';
 import useIsExtensionPopup from '../../hooks/useIsExtensionPopup';
@@ -457,7 +453,7 @@ export default function CrowdLoans(): React.ReactElement {
           divider
           exceptionWidth={33}
           icon={
-            <vaadin-icon
+            <VaadinIcon
               icon='vaadin:piggy-bank-coin'
               style={{
                 height: '32px',

--- a/packages/extension-polkagate/src/popup/home/AccountDetail.tsx
+++ b/packages/extension-polkagate/src/popup/home/AccountDetail.tsx
@@ -4,8 +4,6 @@
 
 /* eslint-disable react/jsx-max-props-per-line */
 
-import '@vaadin/icons';
-
 import type { DeriveAccountRegistration } from '@polkadot/api-derive/types';
 
 import { ArrowForwardIos as ArrowForwardIosIcon } from '@mui/icons-material';
@@ -16,7 +14,7 @@ import type { Chain } from '@polkadot/extension-chains/types';
 
 
 import { stars5Black, stars5White } from '../../assets/icons';
-import { FormatBalance2, FormatPrice, Infotip, OptionalCopyButton } from '../../components';
+import { FormatBalance2, FormatPrice, Infotip, OptionalCopyButton, VaadinIcon } from '../../components';
 import { useBalances, useChainName, useTokenPrice, useTranslation } from '../../hooks/';
 import RecentChains from '../../partials/RecentChains';
 import { BALANCES_VALIDITY_PERIOD } from '../../util/constants';
@@ -48,7 +46,7 @@ const EyeButton = ({ isHidden, toggleVisibility }: EyeProps) => {
   return (
     <Infotip text={isHidden && t('This account is hidden from websites')}>
       <IconButton onClick={toggleVisibility} sx={{ height: '15px', ml: '7px', mt: '13px', p: 0, width: '24px' }}>
-        <vaadin-icon icon={isHidden ? 'vaadin:eye-slash' : 'vaadin:eye'} style={{ color: `${theme.palette.secondary.light}`, height: '20px' }} />
+        <VaadinIcon icon={isHidden ? 'vaadin:eye-slash' : 'vaadin:eye'} style={{ color: `${theme.palette.secondary.light}`, height: '20px' }} />
       </IconButton>
     </Infotip>
   );

--- a/packages/extension-polkagate/src/popup/home/index.tsx
+++ b/packages/extension-polkagate/src/popup/home/index.tsx
@@ -5,8 +5,6 @@
 /* eslint-disable react/jsx-max-props-per-line */
 /* eslint-disable react/jsx-first-prop-new-line */
 
-import '@vaadin/icons';
-
 import { Container, Grid, useTheme } from '@mui/material';
 import React, { useContext, useEffect, useState } from 'react';
 

--- a/packages/extension-polkagate/src/popup/import/addWatchOnlyFullScreen/index.tsx
+++ b/packages/extension-polkagate/src/popup/import/addWatchOnlyFullScreen/index.tsx
@@ -3,8 +3,6 @@
 // @ts-nocheck
 
 /* eslint-disable react/jsx-max-props-per-line */
-// @ts-nocheck
-import '@vaadin/icons';
 
 import { Grid, Typography, useTheme } from '@mui/material';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
@@ -17,7 +15,7 @@ import { FULLSCREEN_WIDTH } from '@polkadot/extension-polkagate/src/util/constan
 import keyring from '@polkadot/ui-keyring';
 import { cryptoWaitReady } from '@polkadot/util-crypto';
 
-import { AddressInput, ProxyTable, SelectChain, TwoButtons } from '../../../components';
+import { AddressInput, ProxyTable, SelectChain, TwoButtons, VaadinIcon } from '../../../components';
 import { FullScreenHeader } from '../../../fullscreen/governance/FullScreenHeader';
 import { useApiWithChain, useFullscreen, useGenesisHashOptions, useTranslation } from '../../../hooks';
 import { createAccountExternal, getMetadata } from '../../../messaging';
@@ -99,7 +97,7 @@ export default function AddWatchOnlyFullScreen(): React.ReactElement {
         <Grid container item sx={{ display: 'block', px: '10%' }}>
           <Grid alignContent='center' alignItems='center' container item>
             <Grid item sx={{ mr: '20px' }}>
-              <vaadin-icon icon='vaadin:tag' style={{ height: '40px', color: `${theme.palette.text.primary}`, width: '40px' }} />
+              <VaadinIcon icon='vaadin:tag' style={{ height: '40px', color: `${theme.palette.text.primary}`, width: '40px' }} />
             </Grid>
             <Grid item>
               <Typography fontSize='30px' fontWeight={700} py='20px' width='100%'>

--- a/packages/extension-polkagate/src/popup/import/attachQrFullScreen/index.tsx
+++ b/packages/extension-polkagate/src/popup/import/attachQrFullScreen/index.tsx
@@ -3,8 +3,6 @@
 // @ts-nocheck
 
 /* eslint-disable react/jsx-max-props-per-line */
-// @ts-nocheck
-import '@vaadin/icons';
 
 import { Button, Grid, Typography, useTheme } from '@mui/material';
 import React, { useCallback, useContext, useEffect, useState } from 'react';
@@ -12,7 +10,7 @@ import React, { useCallback, useContext, useEffect, useState } from 'react';
 import { FULLSCREEN_WIDTH } from '@polkadot/extension-polkagate/src/util/constants';
 import { QrScanAddress } from '@polkadot/react-qr';
 
-import { AccountContext, AccountNamePasswordCreation, ActionContext, Address, PButton, TwoButtons, Warning } from '../../../components';
+import { AccountContext, AccountNamePasswordCreation, ActionContext, Address, PButton, TwoButtons, VaadinIcon, Warning } from '../../../components';
 import { FullScreenHeader } from '../../../fullscreen/governance/FullScreenHeader';
 import { useFullscreen, useTranslation } from '../../../hooks';
 import { createAccountExternal, createAccountSuri, createSeed, updateMeta } from '../../../messaging';
@@ -123,7 +121,7 @@ export default function AttachQrFullScreen(): React.ReactElement {
         <Grid container item sx={{ display: 'block', px: '10%' }}>
           <Grid alignContent='center' alignItems='center' container item>
             <Grid item sx={{ mr: '20px' }}>
-              <vaadin-icon icon='vaadin:qrcode' style={{ height: '40px', color: `${theme.palette.text.primary}`, width: '40px' }} />
+              <VaadinIcon icon='vaadin:qrcode' style={{ height: '40px', color: `${theme.palette.text.primary}`, width: '40px' }} />
             </Grid>
             <Grid item>
               <Typography fontSize='30px' fontWeight={700} py='20px' width='100%'>

--- a/packages/extension-polkagate/src/popup/import/importLedger/index.tsx
+++ b/packages/extension-polkagate/src/popup/import/importLedger/index.tsx
@@ -3,8 +3,6 @@
 // @ts-nocheck
 
 /* eslint-disable react/jsx-max-props-per-line */
-// @ts-nocheck
-import '@vaadin/icons';
 
 import { ArrowForwardIos as ArrowForwardIosIcon } from '@mui/icons-material';
 import { Grid, keyframes, Typography, useTheme } from '@mui/material';
@@ -15,7 +13,7 @@ import type { Chain } from '@polkadot/extension-chains/types';
 import { FULLSCREEN_WIDTH } from '@polkadot/extension-polkagate/src/util/constants';
 import settings from '@polkadot/ui-settings';
 
-import { AccountContext, ActionContext, Address, Select, SelectChain, TwoButtons, Warning } from '../../../components';
+import { AccountContext, ActionContext, Address, Select, SelectChain, TwoButtons, VaadinIcon, Warning } from '../../../components';
 import { FullScreenHeader } from '../../../fullscreen/governance/FullScreenHeader';
 import { useFullscreen, useLedger, useTranslation } from '../../../hooks';
 import { createAccountHardware, getMetadata } from '../../../messaging';
@@ -148,7 +146,7 @@ export default function ImportLedger(): React.ReactElement {
         <Grid container item sx={{ display: 'block', px: '10%' }}>
           <Grid alignContent='center' alignItems='center' container item>
             <Grid item sx={{ mr: '20px' }}>
-              <vaadin-icon icon='vaadin:wallet' style={{ height: '40px', color: `${theme.palette.text.primary}`, width: '40px' }} />
+              <VaadinIcon icon='vaadin:wallet' style={{ height: '40px', color: `${theme.palette.text.primary}`, width: '40px' }} />
             </Grid>
             <Grid item>
               <Typography fontSize='30px' fontWeight={700} py='20px' width='100%'>

--- a/packages/extension-polkagate/src/popup/import/importProxiedFullScreen/index.tsx
+++ b/packages/extension-polkagate/src/popup/import/importProxiedFullScreen/index.tsx
@@ -3,7 +3,6 @@
 // @ts-nocheck
 
 /* eslint-disable react/jsx-max-props-per-line */
-//@ts-nocheck
 
 import { Grid, Typography, useTheme } from '@mui/material';
 import Chance from 'chance';
@@ -14,7 +13,7 @@ import type { Chain } from '@polkadot/extension-chains/types';
 import Bread from '@polkadot/extension-polkagate/src/fullscreen/partials/Bread';
 import { Title } from '@polkadot/extension-polkagate/src/fullscreen/sendFund/InputPage';
 
-import { AccountContext, Label, SelectChain, TwoButtons } from '../../../components';
+import { AccountContext, Label, SelectChain, TwoButtons, VaadinIcon } from '../../../components';
 import { FullScreenHeader } from '../../../fullscreen/governance/FullScreenHeader';
 import { useFullscreen, useGenesisHashOptions, useInfo, useProxiedAccounts, useTranslation } from '../../../hooks';
 import { createAccountExternal, getMetadata, tieAccount } from '../../../messaging';
@@ -106,7 +105,7 @@ function ImportProxiedFS(): React.ReactElement {
           <Title
             height='85px'
             logo={
-              <vaadin-icon icon='vaadin:sitemap' style={{ height: '40px', color: `${theme.palette.text.primary}`, width: '40px', transform: 'rotate(180deg)' }} />
+              <VaadinIcon icon='vaadin:sitemap' style={{ height: '40px', color: `${theme.palette.text.primary}`, width: '40px', transform: 'rotate(180deg)' }} />
             }
             text={t('Import proxied accounts')}
           />

--- a/packages/extension-polkagate/src/popup/import/importRawSeedFullScreen/index.tsx
+++ b/packages/extension-polkagate/src/popup/import/importRawSeedFullScreen/index.tsx
@@ -3,9 +3,6 @@
 // @ts-nocheck
 
 /* eslint-disable react/jsx-max-props-per-line */
-//@ts-nocheck
-
-import '@vaadin/icons';
 
 import ContentPasteIcon from '@mui/icons-material/ContentPaste';
 import { Collapse, Grid, IconButton, Typography, useTheme } from '@mui/material';
@@ -17,7 +14,7 @@ import { keyring } from '@polkadot/ui-keyring';
 import { objectSpread } from '@polkadot/util';
 import { cryptoWaitReady } from '@polkadot/util-crypto';
 
-import { ActionContext, Address, InputWithLabel, TextAreaWithLabel, TwoButtons, Warning } from '../../../components';
+import { ActionContext, Address, InputWithLabel, TextAreaWithLabel, TwoButtons, VaadinIcon, Warning } from '../../../components';
 import { FullScreenHeader } from '../../../fullscreen/governance/FullScreenHeader';
 import { useFullscreen, useGenesisHashOptions, useMetadata, useTranslation } from '../../../hooks';
 import { createAccountSuri } from '../../../messaging';
@@ -149,7 +146,7 @@ export default function ImportRawSeed(): React.ReactElement {
         <Grid container item sx={{ display: 'block', position: 'relative', px: '10%' }}>
           <Grid alignContent='center' alignItems='center' container item>
             <Grid item sx={{ mr: '20px' }}>
-              <vaadin-icon icon='vaadin:book-dollar' style={{ height: '40px', color: `${theme.palette.text.primary}`, width: '40px' }} />
+              <VaadinIcon icon='vaadin:book-dollar' style={{ height: '40px', color: `${theme.palette.text.primary}`, width: '40px' }} />
             </Grid>
             <Grid item>
               <Typography fontSize='30px' fontWeight={700} py='20px' width='100%'>

--- a/packages/extension-polkagate/src/popup/import/importSeedFullScreen/index.tsx
+++ b/packages/extension-polkagate/src/popup/import/importSeedFullScreen/index.tsx
@@ -3,8 +3,6 @@
 // @ts-nocheck
 
 /* eslint-disable react/jsx-max-props-per-line */
-//@ts-nocheck
-import '@vaadin/icons';
 
 import { ArrowForwardIos as ArrowForwardIosIcon } from '@mui/icons-material';
 import ContentPasteIcon from '@mui/icons-material/ContentPaste';
@@ -16,7 +14,7 @@ import type { Chain } from '@polkadot/extension-chains/types';
 import { FULLSCREEN_WIDTH } from '@polkadot/extension-polkagate/src/util/constants';
 import { objectSpread } from '@polkadot/util';
 
-import { ActionContext, Address, InputWithLabel, SelectChain, TextAreaWithLabel, TwoButtons, Warning } from '../../../components';
+import { ActionContext, Address, InputWithLabel, SelectChain, TextAreaWithLabel, TwoButtons, VaadinIcon, Warning } from '../../../components';
 import { FullScreenHeader } from '../../../fullscreen/governance/FullScreenHeader';
 import { useFullscreen, useGenesisHashOptions, useMetadata, useTranslation } from '../../../hooks';
 import { createAccountSuri, getMetadata, validateSeed } from '../../../messaging';
@@ -146,7 +144,7 @@ export default function ImportSeed(): React.ReactElement {
         <Grid container item sx={{ display: 'block', position: 'relative', px: '10%' }}>
           <Grid alignContent='center' alignItems='center' container item>
             <Grid item sx={{ mr: '20px' }}>
-              <vaadin-icon icon='vaadin:book' style={{ height: '40px', color: `${theme.palette.text.primary}`, width: '40px' }} />
+              <VaadinIcon icon='vaadin:book' style={{ height: '40px', color: `${theme.palette.text.primary}`, width: '40px' }} />
             </Grid>
             <Grid item>
               <Typography fontSize='30px' fontWeight={700} py='20px' width='100%'>

--- a/packages/extension-polkagate/src/popup/import/restoreJSONFullScreen/index.tsx
+++ b/packages/extension-polkagate/src/popup/import/restoreJSONFullScreen/index.tsx
@@ -3,8 +3,6 @@
 // @ts-nocheck
 
 /* eslint-disable react/jsx-max-props-per-line */
-//@ts-nocheck
-import '@vaadin/icons';
 
 import type { ResponseJsonGetAccountInfo } from '@polkadot/extension-base/background/types';
 import type { KeyringPair$Json } from '@polkadot/keyring/types';
@@ -17,7 +15,7 @@ import { openOrFocusTab } from '@polkadot/extension-polkagate/src/fullscreen/acc
 import { FULLSCREEN_WIDTH } from '@polkadot/extension-polkagate/src/util/constants';
 import { u8aToString } from '@polkadot/util';
 
-import { Address, InputFileWithLabel, Label, Password, TwoButtons, Warning, WrongPasswordAlert } from '../../../components';
+import { Address, InputFileWithLabel, Label, Password, TwoButtons, VaadinIcon, Warning, WrongPasswordAlert } from '../../../components';
 import { FullScreenHeader } from '../../../fullscreen/governance/FullScreenHeader';
 import { useFullscreen, useTranslation } from '../../../hooks';
 import { batchRestore, jsonGetAccountInfo, jsonRestore } from '../../../messaging';
@@ -131,7 +129,7 @@ export default function RestoreJson(): React.ReactElement {
         <Grid container item sx={{ display: 'block', px: '10%' }}>
           <Grid alignContent='center' alignItems='center' container item>
             <Grid item sx={{ mr: '20px' }}>
-              <vaadin-icon icon='vaadin:file-text' style={{ height: '40px', color: `${theme.palette.text.primary}`, width: '40px' }} />
+              <VaadinIcon icon='vaadin:file-text' style={{ height: '40px', color: `${theme.palette.text.primary}`, width: '40px' }} />
             </Grid>
             <Grid item>
               <Typography fontSize='30px' fontWeight={700} py='20px' width='100%'>

--- a/packages/extension-polkagate/src/popup/newAccount/createAccountFullScreen/index.tsx
+++ b/packages/extension-polkagate/src/popup/newAccount/createAccountFullScreen/index.tsx
@@ -3,9 +3,6 @@
 // @ts-nocheck
 
 /* eslint-disable react/jsx-max-props-per-line */
-// @ts-nocheck
-
-import '@vaadin/icons';
 
 import { Grid, type SxProps, type Theme, Typography, useTheme } from '@mui/material';
 import React, { useCallback, useEffect, useState } from 'react';
@@ -14,7 +11,7 @@ import { openOrFocusTab } from '@polkadot/extension-polkagate/src/fullscreen/acc
 import { FULLSCREEN_WIDTH, POLKADOT_GENESIS_HASH } from '@polkadot/extension-polkagate/src/util/constants';
 import { DEFAULT_TYPE } from '@polkadot/extension-polkagate/src/util/defaultType';
 
-import { Checkbox2, InputWithLabel, TwoButtons } from '../../../components';
+import { Checkbox2, InputWithLabel, TwoButtons, VaadinIcon } from '../../../components';
 import { FullScreenHeader } from '../../../fullscreen/governance/FullScreenHeader';
 import { useFullscreen, useTranslation } from '../../../hooks';
 import { createAccountSuri, createSeed } from '../../../messaging';
@@ -110,7 +107,7 @@ function CreateAccount(): React.ReactElement {
         <Grid container item sx={{ display: 'block', position: 'relative', px: '10%' }}>
           <Grid alignContent='center' alignItems='center' container item>
             <Grid item sx={{ mr: '20px' }}>
-              <vaadin-icon icon='vaadin:plus-circle' style={{ height: '40px', color: `${theme.palette.text.primary}`, width: '40px' }} />
+              <VaadinIcon icon='vaadin:plus-circle' style={{ height: '40px', color: `${theme.palette.text.primary}`, width: '40px' }} />
             </Grid>
             <Grid item>
               <Typography fontSize='30px' fontWeight={700} py='20px' width='100%'>

--- a/packages/extension-polkagate/src/popup/newAccount/deriveFromAccountsFullscreen/index.tsx
+++ b/packages/extension-polkagate/src/popup/newAccount/deriveFromAccountsFullscreen/index.tsx
@@ -3,8 +3,6 @@
 // @ts-nocheck
 
 /* eslint-disable react/jsx-max-props-per-line */
-//@ts-nocheck
-import '@vaadin/icons';
 
 import { Grid, Typography, useTheme } from '@mui/material';
 import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
@@ -16,7 +14,7 @@ import Bread from '@polkadot/extension-polkagate/src/fullscreen/partials/Bread';
 import { Title } from '@polkadot/extension-polkagate/src/fullscreen/sendFund/InputPage';
 import { FULLSCREEN_WIDTH } from '@polkadot/extension-polkagate/src/util/constants';
 
-import { AccountContext, AccountNamePasswordCreation, ActionContext, Label, Password, Warning } from '../../../components';
+import { AccountContext, AccountNamePasswordCreation, ActionContext, Label, Password, VaadinIcon, Warning } from '../../../components';
 import { FullScreenHeader } from '../../../fullscreen/governance/FullScreenHeader';
 import { useFullscreen, useTranslation } from '../../../hooks';
 import { deriveAccount, validateAccount, validateDerivationPath } from '../../../messaging';
@@ -144,7 +142,7 @@ function DeriveFromAccounts(): React.ReactElement {
           <Title
             height='70px'
             logo={
-              <vaadin-icon icon='vaadin:road-branch' style={{ height: '40px', color: `${theme.palette.text.primary}`, width: '40px' }} />
+              <VaadinIcon icon='vaadin:road-branch' style={{ height: '40px', color: `${theme.palette.text.primary}`, width: '40px' }} />
             }
             padding='0px'
             text={t('Derive from accounts')}

--- a/packages/extension-polkagate/src/popup/passwordManagement/Reset.tsx
+++ b/packages/extension-polkagate/src/popup/passwordManagement/Reset.tsx
@@ -3,13 +3,11 @@
 // @ts-nocheck
 
 /* eslint-disable react/jsx-max-props-per-line */
-// @ts-nocheck
-import '@vaadin/icons';
 
 import { Grid, Typography, useTheme } from '@mui/material';
 import React, { useCallback } from 'react';
 
-import { PButton } from '../../components';
+import { PButton, VaadinIcon } from '../../components';
 import { useTranslation } from '../../hooks';
 import { windowOpen } from '../../messaging';
 import HeaderBrand from '../../partials/HeaderBrand';
@@ -48,7 +46,7 @@ function Reset(): React.ReactElement {
           _onClick={_goToRestoreFromJson}
           _variant={'contained'}
           startIcon={
-            <vaadin-icon icon='vaadin:file-text' style={{ height: '18px', color: `${theme.palette.text.main}` }} />
+            <VaadinIcon icon='vaadin:file-text' style={{ height: '18px', color: `${theme.palette.text.main}` }} />
           }
           text={t<string>('Restore from JSON File')}
         />
@@ -62,7 +60,7 @@ function Reset(): React.ReactElement {
           _onClick={_goToImport}
           _variant={'contained'}
           startIcon={
-            <vaadin-icon icon='vaadin:book' style={{ height: '18px', color: `${theme.palette.text.main}` }} />
+            <VaadinIcon icon='vaadin:book' style={{ height: '18px', color: `${theme.palette.text.main}` }} />
           }
           text={t<string>('Import from Recovery Phrase')}
         />

--- a/packages/extension-polkagate/src/popup/passwordManagement/ResetFS.tsx
+++ b/packages/extension-polkagate/src/popup/passwordManagement/ResetFS.tsx
@@ -3,8 +3,6 @@
 // @ts-nocheck
 
 /* eslint-disable react/jsx-max-props-per-line */
-//@ts-nocheck
-import '@vaadin/icons';
 
 import { faWallet } from '@fortawesome/free-solid-svg-icons';
 import { Grid, Typography, useTheme } from '@mui/material';
@@ -14,7 +12,7 @@ import { FullScreenHeader } from '@polkadot/extension-polkagate/src/fullscreen/g
 import { Title } from '@polkadot/extension-polkagate/src/fullscreen/sendFund/InputPage';
 import { FULLSCREEN_WIDTH } from '@polkadot/extension-polkagate/src/util/constants';
 
-import { PButton } from '../../components';
+import { PButton, VaadinIcon } from '../../components';
 import { useFullscreen, useTranslation } from '../../hooks';
 import { windowOpen } from '../../messaging';
 
@@ -52,7 +50,7 @@ function ResetFS(): React.ReactElement {
             _onClick={_goToRestoreFromJson}
             _variant={'contained'}
             startIcon={
-              <vaadin-icon icon='vaadin:file-text' style={{ height: '18px', color: `${theme.palette.text.main}` }} />
+              <VaadinIcon icon='vaadin:file-text' style={{ height: '18px', color: `${theme.palette.text.main}` }} />
             }
             text={t<string>('Restore from JSON File')}
           />
@@ -66,7 +64,7 @@ function ResetFS(): React.ReactElement {
             _onClick={_goToImport}
             _variant={'contained'}
             startIcon={
-              <vaadin-icon icon='vaadin:book' style={{ height: '18px', color: `${theme.palette.text.main}` }} />
+              <VaadinIcon icon='vaadin:book' style={{ height: '18px', color: `${theme.palette.text.main}` }} />
             }
             text={t<string>('Import from Recovery Phrase')}
           />

--- a/packages/extension-polkagate/src/popup/staking/partial/ShowPool.tsx
+++ b/packages/extension-polkagate/src/popup/staking/partial/ShowPool.tsx
@@ -4,8 +4,6 @@
 
 /* eslint-disable react/jsx-max-props-per-line */
 
-import '@vaadin/icons';
-
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import { Grid, type SxProps, type Theme, Typography, useTheme } from '@mui/material';
 // @ts-ignore
@@ -16,7 +14,7 @@ import { ApiPromise } from '@polkadot/api';
 import type { Chain } from '@polkadot/extension-chains/types';
 
 
-import { Identity, Infotip, ShowBalance } from '../../../components';
+import { Identity, Infotip, ShowBalance, VaadinIcon } from '../../../components';
 import { useTranslation } from '../../../hooks';
 import getPoolAccounts from '../../../util/getPoolAccounts';
 import type { MyPoolInfo } from '../../../util/types';
@@ -141,7 +139,7 @@ export default function ShowPool({ api, chain, label, labelPosition = 'left', mo
                   {mode === 'Default' ? poolStatus : mode}
                 </Grid>
                 <Grid alignItems='center' item justifyContent='center' onClick={onRewardsChart} width='16%' sx={{ cursor: 'pointer' }}>
-                  <vaadin-icon icon='vaadin:bar-chart-h' style={{ height: '16px', width: '16px', color: `${mode === 'Creating' ? theme.palette.text.disabled : theme.palette.secondary.main}` }} />
+                  <VaadinIcon icon='vaadin:bar-chart-h' style={{ height: '16px', width: '16px', color: `${mode === 'Creating' ? theme.palette.text.disabled : theme.palette.secondary.main}` }} />
                 </Grid>
               </Grid>
             </>

--- a/packages/extension-polkagate/src/popup/staking/partial/ValidatorsTable.tsx
+++ b/packages/extension-polkagate/src/popup/staking/partial/ValidatorsTable.tsx
@@ -4,8 +4,6 @@
 
 /* eslint-disable react/jsx-max-props-per-line */
 
-import '@vaadin/icons';
-
 import type { AccountId } from '@polkadot/types/interfaces';
 
 import { alpha, Grid, type SxProps, type Theme, useTheme } from '@mui/material';
@@ -15,6 +13,7 @@ import { FixedSizeList as List } from 'react-window';
 import { ApiPromise } from '@polkadot/api';
 import { DeriveAccountInfo } from '@polkadot/api-derive/types';
 import type { Chain } from '@polkadot/extension-chains/types';
+import { VaadinIcon } from '@polkadot/extension-polkagate/src/components';
 import { useIsExtensionPopup } from '@polkadot/extension-polkagate/src/hooks';
 import { BN, hexToBn, isHex } from '@polkadot/util';
 
@@ -124,7 +123,7 @@ export default function ValidatorsTable({ activeValidators, allValidatorsIdentit
                     v={v}
                   />
                   <Grid alignItems='center' container item justifyContent='center' onClick={() => openValidatorInfo(v)} sx={{ cursor: 'pointer' }} width='6%'>
-                    <vaadin-icon icon='vaadin:ellipsis-dots-v' style={{ color: `${theme.palette.secondary.light}`, width: '33px' }} />
+                    <VaadinIcon icon='vaadin:ellipsis-dots-v' style={{ color: `${theme.palette.secondary.light}`, width: '33px' }} />
                   </Grid>
                 </Grid>
               );

--- a/packages/extension-polkagate/src/popup/staking/pool/index.tsx
+++ b/packages/extension-polkagate/src/popup/staking/pool/index.tsx
@@ -4,8 +4,6 @@
 
 /* eslint-disable react/jsx-max-props-per-line */
 
-import '@vaadin/icons';
-
 import type { ApiPromise } from '@polkadot/api';
 import type { PoolStakingConsts, StakingConsts } from '../../../util/types';
 
@@ -19,7 +17,7 @@ import { useHistory, useLocation } from 'react-router-dom';
 
 import { BN, BN_ZERO } from '@polkadot/util';
 
-import { ActionContext, FormatBalance, FormatBalance2, HorizontalMenuItem, Identicon, ShowBalance } from '../../../components';
+import { ActionContext, FormatBalance, FormatBalance2, HorizontalMenuItem, Identicon, ShowBalance, VaadinIcon } from '../../../components';
 import { useApi, useBalances, useChain, useDecimal, useFormatted, useMyAccountIdentity, usePool, usePoolConsts, useStakingConsts, useToken, useTranslation, useUnSupportedNetwork } from '../../../hooks';
 import useIsExtensionPopup from '../../../hooks/useIsExtensionPopup';
 import { ChainSwitch, HeaderBrand } from '../../../partials';
@@ -370,13 +368,13 @@ export default function Index(): React.ReactElement {
         <HorizontalMenuItem
           divider
           // @ts-ignore
-          icon={<vaadin-icon icon='vaadin:grid-small' style={{ height: '28px', color: `${theme.palette.text.primary}` }} />}
+          icon={<VaadinIcon icon='vaadin:grid-small' style={{ height: '28px', color: `${theme.palette.text.primary}` }} />}
           onClick={goToPool}
           title={t<string>('Pool')}
         />
         <HorizontalMenuItem
           // @ts-ignore
-          icon={<vaadin-icon icon='vaadin:info-circle' style={{ height: '28px', color: `${theme.palette.text.primary}` }} />}
+          icon={<VaadinIcon icon='vaadin:info-circle' style={{ height: '28px', color: `${theme.palette.text.primary}` }} />}
           onClick={goToInfo}
           title={t<string>('Info')}
         />

--- a/packages/extension-polkagate/src/popup/welcome/index.tsx
+++ b/packages/extension-polkagate/src/popup/welcome/index.tsx
@@ -3,13 +3,11 @@
 // @ts-nocheck
 
 /* eslint-disable react/jsx-max-props-per-line */
-// @ts-nocheck
-import '@vaadin/icons';
 
 import { Divider, Grid, Typography, useTheme } from '@mui/material';
 import React, { useCallback, useState } from 'react';
 
-import { PButton } from '../../components';
+import { PButton, VaadinIcon } from '../../components';
 import { useTranslation } from '../../hooks';
 import { windowOpen } from '../../messaging';
 import HeaderBrand from '../../partials/HeaderBrand';
@@ -81,7 +79,7 @@ function Welcome(): React.ReactElement {
         _mt='20px'
         _onClick={onCreate}
         _variant={'contained'}
-        startIcon={<vaadin-icon icon='vaadin:plus-circle' style={{ height: '18px', color: `${theme.palette.text.main}` }} />}
+        startIcon={<VaadinIcon icon='vaadin:plus-circle' style={{ height: '18px', color: `${theme.palette.text.main}` }} />}
         text={t<string>('Create a new account')}
       />
       <Divider sx={{ fontSize: '18px', fontWeight: 300, my: '10px', px: '20px' }}>


### PR DESCRIPTION
## Works Done
Create a Custom Wrapper Component called VaadinIcon, and use it instead of vaadin-icon.

Close: #1381 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Replaced `<vaadin-icon>` with a custom `<VaadinIcon>` component across various files.
  - Removed dependency on `@vaadin/icons`.
  - Improved consistency and maintainability of icon usage by centralizing icon rendering logic in a new `VaadinIcon` component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->