### PR TITLE
Support Proxy on AssetHubs

### DIFF
--- a/packages/extension-polkagate/src/fullscreen/manageProxies/AddProxy.tsx
+++ b/packages/extension-polkagate/src/fullscreen/manageProxies/AddProxy.tsx
@@ -43,10 +43,10 @@ export default function AddProxy({ chain, proxiedAddress, proxyItems, setProxyIt
   const proxyAccountIdentity = useIdentity(chain?.genesisHash, proxyAddress ?? undefined);
 
   const myselfAsProxy = useMemo(() => formatted === proxyAddress, [formatted, proxyAddress]);
-  const chainName = sanitizeChainName(chain?.name)?.toLowerCase()?.includes('assethub')
-    ? 'AssetHubs'
-    : sanitizeChainName(chain?.name);
-  const PROXY_TYPE = CHAIN_PROXY_TYPES[chainName as keyof typeof CHAIN_PROXY_TYPES];
+
+  const chainName = sanitizeChainName(chain?.name);
+  const proxyTypeIndex = chainName?.toLowerCase()?.includes('assethub') ? 'AssetHubs' : chainName;
+  const PROXY_TYPE = CHAIN_PROXY_TYPES[proxyTypeIndex as keyof typeof CHAIN_PROXY_TYPES];
 
   const proxyTypeOptions = PROXY_TYPE.map((type: string): DropdownOption => ({
     text: type,
@@ -168,7 +168,7 @@ export default function AddProxy({ chain, proxiedAddress, proxyItems, setProxyIt
       </Grid>
       {proxyAddress &&
         <ShowIdentity
-          accountIdentity={proxyAccountIdentity?.accountId?.toString() === proxyAddress ? proxyAccountIdentity?.identity : undefined}
+          accountIdentity={proxyAccountIdentity !== undefined && proxyAccountIdentity?.accountId?.toString() === proxyAddress ? proxyAccountIdentity?.identity : null}
           style={{ '> div:last-child div div p': { fontSize: '14px' }, '> div:last-child div div:last-child p': { fontSize: '16px', fontWeight: 400 }, m: '25px auto 0', width: '100%' }}
         />}
       <Grid container item justifyContent='flex-end' sx={{ borderColor: 'divider', borderTop: 1, bottom: '25px', height: '50px', left: 0, mx: '7%', position: 'absolute', width: '85%' }}>

--- a/packages/extension-polkagate/src/fullscreen/manageProxies/AddProxy.tsx
+++ b/packages/extension-polkagate/src/fullscreen/manageProxies/AddProxy.tsx
@@ -12,7 +12,6 @@ import React, { useCallback, useContext, useEffect, useMemo, useState } from 're
 
 import type { Chain } from '@polkadot/extension-chains/types';
 
-
 import { AccountContext, AddressInput, InputWithLabel, Select, TwoButtons, Warning } from '../../components';
 import { useAccountDisplay, useFormatted, useIdentity, useTranslation } from '../../hooks';
 import ShowIdentity from '../../popup/manageProxies/partials/ShowIdentity';
@@ -44,7 +43,10 @@ export default function AddProxy({ chain, proxiedAddress, proxyItems, setProxyIt
   const proxyAccountIdentity = useIdentity(chain?.genesisHash, proxyAddress ?? undefined);
 
   const myselfAsProxy = useMemo(() => formatted === proxyAddress, [formatted, proxyAddress]);
-  const PROXY_TYPE = CHAIN_PROXY_TYPES[sanitizeChainName(chain?.name) as keyof typeof CHAIN_PROXY_TYPES];
+  const chainName = sanitizeChainName(chain?.name)?.toLowerCase()?.includes('assethub')
+    ? 'AssetHubs'
+    : sanitizeChainName(chain?.name);
+  const PROXY_TYPE = CHAIN_PROXY_TYPES[chainName as keyof typeof CHAIN_PROXY_TYPES];
 
   const proxyTypeOptions = PROXY_TYPE.map((type: string): DropdownOption => ({
     text: type,

--- a/packages/extension-polkagate/src/hooks/useIdentity.ts
+++ b/packages/extension-polkagate/src/hooks/useIdentity.ts
@@ -1,5 +1,6 @@
 // Copyright 2019-2024 @polkadot/extension-polkagate authors & contributors
 // SPDX-License-Identifier: Apache-2.0
+
 // @ts-nocheck
 
 import type { DeriveAccountInfo } from '@polkadot/api-derive/types';
@@ -16,19 +17,19 @@ interface SubIdentity {
   display: string
 }
 
-export default function useIdentity(genesisHash: string | undefined, formatted: string | undefined, accountInfo?: DeriveAccountInfo): DeriveAccountInfo | undefined {
-  const [info, setInfo] = useState<DeriveAccountInfo | undefined>();
+export default function useIdentity(genesisHash: string | undefined, formatted: string | undefined, accountInfo?: DeriveAccountInfo): DeriveAccountInfo | undefined | null {
+  const [info, setInfo] = useState<DeriveAccountInfo | null>();
 
   const { peopleChain } = usePeopleChain(undefined, genesisHash);
   const api = useApiWithChain2(peopleChain);
 
   const getIdentityOf = useCallback(async (accountId: string) => {
-    if (!api?.query?.identity?.identityOf || !accountId) {
+    if (!api?.query?.['identity']?.['identityOf'] || !accountId) {
       return;
     }
 
-    const i = await api.query.identity.identityOf(accountId);
-    const id = i.isSome ? i.unwrap()[0] as PalletIdentityRegistration : undefined;
+    const i = await api.query['identity']['identityOf'](accountId) as any;
+    const id = i.isSome ? i.unwrap()[0] as PalletIdentityRegistration : null;
 
     return id?.info
       ? {
@@ -38,23 +39,23 @@ export default function useIdentity(genesisHash: string | undefined, formatted: 
         legal: hexToString(id.info.legal.asRaw.toHex()),
         riot: id.info.riot
           ? hexToString(id.info.riot.asRaw.toHex())
-          : id.info.matrix
-            ? hexToString(id.info.matrix.asRaw.toHex())
+          : (id.info as any).matrix
+            ? hexToString((id.info as any).matrix.asRaw.toHex())
             : '',
         // github: id.info.github && hexToString(id.info.github.asRaw.toHex()),
         twitter: hexToString(id.info.twitter.asRaw.toHex()),
         web: hexToString(id.info.web.asRaw.toHex())
       }
-      : undefined;
+      : null;
   }, [api]);
 
   const getSubIdentityOf = useCallback(async (): Promise<SubIdentity | undefined> => {
-    if (!api?.query?.identity?.superOf || !formatted) {
+    if (!api?.query?.['identity']?.['superOf'] || !formatted) {
       return;
     }
 
-    const s = await api.query.identity.superOf(formatted);
-    const subId = s.isSome ? s.unwrap() : undefined;
+    const s = await api.query['identity']['superOf'](formatted) as any;
+    const subId = s.isSome ? s.unwrap()  : undefined;
 
     return subId
       ? {
@@ -93,6 +94,8 @@ export default function useIdentity(genesisHash: string | undefined, formatted: 
                 return setInfo(subIdentity);
               }
             }).catch(console.error);
+          }else{
+            setInfo(null);
           }
         }).catch(console.error);
       }

--- a/packages/extension-polkagate/src/hooks/usePeopleChain.ts
+++ b/packages/extension-polkagate/src/hooks/usePeopleChain.ts
@@ -1,6 +1,5 @@
 // Copyright 2019-2024 @polkadot/extension-polkagate authors & contributors
 // SPDX-License-Identifier: Apache-2.0
-// @ts-nocheck
 
 import { createWsEndpoints } from '@polkagate/apps-config';
 import { useMemo } from 'react';
@@ -25,15 +24,15 @@ interface PeopleChainInfo {
  */
 
 const getPeopleChainGenesisHash = (chainName: string | undefined) => {
-  switch (chainName) {
+  const relayChainNames = ['Westend', 'Kusama', 'Polkadot'];
+  const startWith = relayChainNames.find((name) => chainName?.startsWith(name)) || undefined;
+
+  switch (startWith) {
     case 'Westend':
-    case 'WestendPeople':
       return WESTEND_PEOPLE_GENESIS_HASH;
     case 'Kusama':
-    case 'KusamaPeople':
       return KUSAMA_PEOPLE_GENESIS_HASH;
     case 'Polkadot':
-    case 'PolkadotPeople':
       return POLKADOT_GENESIS_HASH; // should be changed to POLKADOT_PEOPLE_GENESIS_HASH in the future
     default:
       return undefined;
@@ -44,6 +43,7 @@ export default function usePeopleChain(address: string | undefined, genesisHash?
   const { chain } = useInfo(address);
   const _chain = chain || getChain(genesisHash);
   const _chainName = sanitizeChainName(_chain?.name);
+
   const peopleChainGenesisHash = getPeopleChainGenesisHash(_chainName);
 
   const peopleChain = useMetadata(peopleChainGenesisHash, true);

--- a/packages/extension-polkagate/src/popup/manageProxies/AddProxy.tsx
+++ b/packages/extension-polkagate/src/popup/manageProxies/AddProxy.tsx
@@ -55,7 +55,10 @@ export default function AddProxy({ address, chain, onChange, proxyItems, setProx
   const possibleProxy = useMemo(() => ({ delay, delegate: realAddress, proxyType: selectedProxyType }) as Proxy, [delay, realAddress, selectedProxyType]);
   const alreadyExisting = useMemo(() => !!(proxyItems?.find((item) => isEqualProxy(item.proxy, possibleProxy))), [possibleProxy, proxyItems]);
 
-  const PROXY_TYPE = CHAIN_PROXY_TYPES[sanitizeChainName(chain.name) as keyof typeof CHAIN_PROXY_TYPES];
+  const chainName = sanitizeChainName(chain?.name)?.toLowerCase()?.includes('assethub')
+    ? 'AssetHubs'
+    : sanitizeChainName(chain?.name);
+  const PROXY_TYPE = CHAIN_PROXY_TYPES[chainName as keyof typeof CHAIN_PROXY_TYPES];
 
   const proxyTypeOptions = PROXY_TYPE.map((type: string): DropdownOption => ({
     text: type,

--- a/packages/extension-polkagate/src/popup/manageProxies/AddProxy.tsx
+++ b/packages/extension-polkagate/src/popup/manageProxies/AddProxy.tsx
@@ -55,10 +55,9 @@ export default function AddProxy({ address, chain, onChange, proxyItems, setProx
   const possibleProxy = useMemo(() => ({ delay, delegate: realAddress, proxyType: selectedProxyType }) as Proxy, [delay, realAddress, selectedProxyType]);
   const alreadyExisting = useMemo(() => !!(proxyItems?.find((item) => isEqualProxy(item.proxy, possibleProxy))), [possibleProxy, proxyItems]);
 
-  const chainName = sanitizeChainName(chain?.name)?.toLowerCase()?.includes('assethub')
-    ? 'AssetHubs'
-    : sanitizeChainName(chain?.name);
-  const PROXY_TYPE = CHAIN_PROXY_TYPES[chainName as keyof typeof CHAIN_PROXY_TYPES];
+  const chainName = sanitizeChainName(chain?.name);
+  const proxyTypeIndex = chainName?.toLowerCase()?.includes('assethub') ? 'AssetHubs' : chainName;
+  const PROXY_TYPE = CHAIN_PROXY_TYPES[proxyTypeIndex as keyof typeof CHAIN_PROXY_TYPES];
 
   const proxyTypeOptions = PROXY_TYPE.map((type: string): DropdownOption => ({
     text: type,
@@ -144,7 +143,7 @@ export default function AddProxy({ address, chain, onChange, proxyItems, setProx
       </Grid>
       {realAddress && !(myselfAsProxy || alreadyExisting) &&
         <ShowIdentity
-          accountIdentity={proxyAccountIdentity?.identity}
+          accountIdentity={proxyAccountIdentity !==undefined && proxyAccountIdentity?.identity || null}
           style={{ m: 'auto', width: '92%' }}
         />
       }

--- a/packages/extension-polkagate/src/util/constants.tsx
+++ b/packages/extension-polkagate/src/util/constants.tsx
@@ -75,7 +75,8 @@ export const TEST_NETS = [
 export const PROXY_CHAINS = [
   POLKADOT_GENESIS_HASH,
   KUSAMA_GENESIS_HASH,
-  WESTEND_GENESIS_HASH
+  WESTEND_GENESIS_HASH,
+  ...ASSET_HUBS
 ];
 
 export const CROWDLOANS_CHAINS = [
@@ -141,8 +142,9 @@ export const CONFIRMING_STATE = ['fail', 'success', 'confirming'];
 const PROXY_TYPE_POLKADOT = ['Any', 'NonTransfer', 'Staking', 'Governance', 'IdentityJudgement', 'CancelProxy', 'Auction', 'NominationPools'];
 const PROXY_TYPE_KUSAMA = ['Any', 'NonTransfer', 'Staking', 'Society', 'Governance', 'IdentityJudgement', 'CancelProxy', 'Auction', 'NominationPools'];
 const PROXY_TYPE_WESTEND = ['Any', 'NonTransfer', 'Staking', 'Governance', 'SudoBalances', 'IdentityJudgement', 'CancelProxy', 'Auction', 'NominationPools'];
+const PROXY_TYPE_ASSET_HUBS = ['Any', 'NonTransfer', 'CancelProxy', 'Assets', 'AssetOwner', 'AssetManager', 'Collator'];
 
-export const CHAIN_PROXY_TYPES = { Kusama: PROXY_TYPE_KUSAMA, Polkadot: PROXY_TYPE_POLKADOT, Westend: PROXY_TYPE_WESTEND };
+export const CHAIN_PROXY_TYPES = { Kusama: PROXY_TYPE_KUSAMA, Polkadot: PROXY_TYPE_POLKADOT, Westend: PROXY_TYPE_WESTEND, AssetHubs: PROXY_TYPE_ASSET_HUBS};
 
 export const VOTE_MAP = {
   AYE: 1,


### PR DESCRIPTION
## Work Done
Support adding proxy account on asset hubs.

Close: #1379 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for 'assethub' chain in proxy type options, enhancing flexibility for users on this chain.

- **Bug Fixes**
  - Improved identity query handling to provide more accurate and consistent data by allowing `null` values.

- **Refactor**
  - Refactored chain name resolution logic to use a `startWith` variable for more efficient processing in chain-related functions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->