### PR TITLE
Pool migration

### DIFF
--- a/packages/extension-polkagate/src/fullscreen/accountDetails/components/CommonTasks.tsx
+++ b/packages/extension-polkagate/src/fullscreen/accountDetails/components/CommonTasks.tsx
@@ -30,7 +30,7 @@ interface Props {
 }
 
 interface TaskButtonProps {
-  icon: unknown;
+  icon: React.JSX.Element;
   text: string;
   onClick: () => void;
   secondaryIconType: 'popup' | 'page';
@@ -106,7 +106,7 @@ export const TaskButton = ({ disabled, icon, loading, mr = '25px', noBorderButto
   );
 };
 
-export default function CommonTasks({ address, assetId, balance, genesisHash, setDisplayPopup }: Props): React.ReactElement {
+export default function CommonTasks ({ address, assetId, balance, genesisHash, setDisplayPopup }: Props): React.ReactElement {
   const { t } = useTranslation();
   const theme = useTheme();
   const api = useApi(address);
@@ -130,7 +130,7 @@ export default function CommonTasks({ address, assetId, balance, genesisHash, se
     (api?.tx?.['nominationPools']?.['migrateDelegation'] && balance?.pooledBalance?.isZero())
   ,
   [api, balance?.pooledBalance, hasSoloStake]);
-  
+
   const goToSend = useCallback(() => {
     address && genesisHash &&
       openOrFocusTab(`/send/${address}/${assetId || ''}`, true);

--- a/packages/extension-polkagate/src/fullscreen/accountDetails/components/CommonTasks.tsx
+++ b/packages/extension-polkagate/src/fullscreen/accountDetails/components/CommonTasks.tsx
@@ -130,9 +130,7 @@ export default function CommonTasks({ address, assetId, balance, genesisHash, se
     (api?.tx?.['nominationPools']?.['migrateDelegation'] && balance?.pooledBalance?.isZero())
   ,
   [api, balance?.pooledBalance, hasSoloStake]);
-
-  console.log('canManageSoloStake:',canManageSoloStake)
-
+  
   const goToSend = useCallback(() => {
     address && genesisHash &&
       openOrFocusTab(`/send/${address}/${assetId || ''}`, true);

--- a/packages/extension-polkagate/src/fullscreen/accountDetails/components/CommonTasks.tsx
+++ b/packages/extension-polkagate/src/fullscreen/accountDetails/components/CommonTasks.tsx
@@ -1,8 +1,10 @@
 // Copyright 2019-2024 @polkadot/extension-polkagate authors & contributors
 // SPDX-License-Identifier: Apache-2.0
-// @ts-nocheck
 
 /* eslint-disable react/jsx-max-props-per-line */
+
+import type { BalancesInfo } from 'extension-polkagate/src/util/types';
+import type { FetchedBalance } from '../../../hooks/useAssetsBalances';
 
 import { faCoins, faHistory, faPaperPlane, faVoteYea } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -10,12 +12,12 @@ import { ArrowForwardIosRounded as ArrowForwardIosRoundedIcon, Boy as BoyIcon, Q
 import { Divider, Grid, Typography, useTheme } from '@mui/material';
 // @ts-ignore
 import { Circle } from 'better-react-spinkit';
-import { BalancesInfo } from 'extension-polkagate/src/util/types';
 import React, { useCallback, useMemo } from 'react';
 
+import { noop } from '@polkadot/util';
+
 import { PoolStakingIcon } from '../../../components';
-import { useTranslation } from '../../../hooks';
-import { FetchedBalance } from '../../../hooks/useAssetsBalances';
+import { useApi, useTranslation } from '../../../hooks';
 import { GOVERNANCE_CHAINS, STAKING_CHAINS } from '../../../util/constants';
 import { popupNumbers } from '..';
 
@@ -41,7 +43,7 @@ interface TaskButtonProps {
 
 export const openOrFocusTab = (relativeUrl: string, closeCurrentTab?: boolean): void => {
   chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
-    if (tabs[0] && tabs[0].url) {
+    if (tabs[0]?.url) {
       const extensionUrl = tabs[0].url;
       const extensionBaseUrl = extensionUrl.split('#')[0];
 
@@ -54,7 +56,7 @@ export const openOrFocusTab = (relativeUrl: string, closeCurrentTab?: boolean): 
 
         closeCurrentTab && window.close();
 
-        if (existingTab && existingTab.id) {
+        if (existingTab?.id) {
           chrome.tabs.update(existingTab.id, { active: true }).catch(console.error);
         } else {
           chrome.tabs.create({ url: tabUrl }).catch(console.error);
@@ -73,8 +75,7 @@ export const TaskButton = ({ disabled, icon, loading, mr = '25px', noBorderButto
     <>
       {show &&
         <>
-          {/* eslint-disable-next-line react/jsx-no-bind */}
-          <Grid alignItems='center' container item justifyContent='space-between' onClick={disabled ? () => null : onClick} sx={{ '&:hover': { bgcolor: disabled ? 'transparent' : 'divider' }, borderRadius: '5px', cursor: disabled ? 'default' : 'pointer', m: 'auto', minHeight: '45px', p: '5px 10px' }} width='90%'>
+          <Grid alignItems='center' container item justifyContent='space-between' onClick={disabled ? noop : onClick} sx={{ '&:hover': { bgcolor: disabled ? 'transparent' : 'divider' }, borderRadius: '5px', cursor: disabled ? 'default' : 'pointer', m: 'auto', minHeight: '45px', p: '5px 10px' }} width='90%'>
             <Grid container item mr={mr} xs={1.5}>
               {icon}
             </Grid>
@@ -108,6 +109,7 @@ export const TaskButton = ({ disabled, icon, loading, mr = '25px', noBorderButto
 export default function CommonTasks({ address, assetId, balance, genesisHash, setDisplayPopup }: Props): React.ReactElement {
   const { t } = useTranslation();
   const theme = useTheme();
+  const api = useApi(address);
 
   const governanceDisabled = useMemo(() => !GOVERNANCE_CHAINS.includes(genesisHash ?? ''), [genesisHash]);
   const { stakingDisabled, stakingNotReady } = useMemo(() => {
@@ -121,6 +123,15 @@ export default function CommonTasks({ address, assetId, balance, genesisHash, se
   const hasSoloStake = Boolean(balance?.soloTotal && !balance.soloTotal.isZero());
   const hasPoolStake = Boolean(balance?.pooledBalance && !balance.pooledBalance.isZero());
   const notStakedYet = !hasPoolStake && !hasSoloStake;
+
+  const canManageSoloStake = useMemo(() =>
+    hasSoloStake ||
+    (api && !api.tx?.['nominationPools']?.['migrateDelegation']) ||
+    (api?.tx?.['nominationPools']?.['migrateDelegation'] && balance?.pooledBalance?.isZero())
+  ,
+  [api, balance?.pooledBalance, hasSoloStake]);
+
+  console.log('canManageSoloStake:',canManageSoloStake)
 
   const goToSend = useCallback(() => {
     address && genesisHash &&
@@ -222,7 +233,7 @@ export default function CommonTasks({ address, assetId, balance, genesisHash, se
           }
           onClick={goToSoloStaking}
           secondaryIconType='page'
-          show={(hasSoloStake || hasPoolStake) && !stakingDisabled}
+          show={(hasSoloStake || hasPoolStake) && !stakingDisabled && !!canManageSoloStake}
           text={t('Stake Solo')}
         />
         <TaskButton

--- a/packages/extension-polkagate/src/fullscreen/accountDetails/index.tsx
+++ b/packages/extension-polkagate/src/fullscreen/accountDetails/index.tsx
@@ -248,7 +248,7 @@ export default function AccountDetails(): React.ReactElement {
                       title={t('Solo Stake')}
                       token={balancesToShow?.token}
                     />}
-                  {supportStaking &&
+                  {supportStaking && !balancesToShow?.pooledBalance?.isZero() &&
                     <DisplayBalance
                       amount={balancesToShow?.pooledBalance}
                       decimal={balancesToShow?.decimal}

--- a/packages/extension/public/locales/en/translation.json
+++ b/packages/extension/public/locales/en/translation.json
@@ -1346,5 +1346,6 @@
   "Import the account into the extension": "",
   "Select accounts to import into the extension": "",
   "Remove from profile": "",
-  "My Portfolio": ""
+  "My Portfolio": "",
+  "Nomination Pools are evolving! Unstake your solo staked funds soon to benefit from automatic pool migration, which allows participation in both a pool and governance, and avoid manual changes.": ""
 }


### PR DESCRIPTION
address #1411

- Set warning for dual stakers
- hide staking row in account details if zero
- hide solo Stake menu, if already has pool staked, plus some other conditions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced staking management with clearer controls for "Stake Solo" button visibility based on user eligibility.
	- Added a warning message for users engaged in dual staking, advising on unstaking solo funds for automatic pool migration.
  
- **Bug Fixes**
	- Improved error handling in URL checks to enhance component reliability.

- **Improvements**
	- Optimized balance display logic for better clarity and responsiveness in the user interface.
	- Updated translation to improve user communication regarding changes in nomination pools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->