### PR TITLE
fix ledger issue

### DIFF
--- a/packages/extension-polkagate/src/hooks/useGenericLedger.ts
+++ b/packages/extension-polkagate/src/hooks/useGenericLedger.ts
@@ -1,12 +1,14 @@
 // Copyright 2019-2024 @polkadot/extension-polkagate authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
 import uiSettings from '@polkadot/ui-settings';
 import { assert } from '@polkadot/util';
-import useTranslation from './useTranslation';
-import { GenericLedger } from '../util/ledger/genericLedger';
+
 import { POLKADOT_SLIP44 } from '../util/constants';
+import { GenericLedger } from '../util/ledger/genericLedger';
+import useTranslation from './useTranslation';
 
 interface StateBase {
   isLedgerCapable: boolean;
@@ -23,8 +25,8 @@ interface State extends StateBase {
   warning: string | null;
 }
 
-function getState(): StateBase {
-  const isLedgerCapable = 'USB' in window
+function getState (): StateBase {
+  const isLedgerCapable = 'USB' in window;
 
   return {
     isLedgerCapable,
@@ -40,8 +42,9 @@ function retrieveLedger(chainSlip?: number | null, txMetadataChainId?: string): 
   return new GenericLedger('webusb', chainSlip || POLKADOT_SLIP44, txMetadataChainId);
 }
 
-export function useGenericLedger(accountIndex = 0, addressOffset = 0, chainSlip?: number | null, txMetadataChainId?: string): State {
+export function useGenericLedger (accountIndex = 0, addressOffset = 0, chainSlip?: number | null, txMetadataChainId?: string): State {
   const { t } = useTranslation();
+  const isFetching = useRef(false);
 
   const [isLoading, setIsLoading] = useState(false);
   const [isLocked, setIsLocked] = useState(false);
@@ -62,6 +65,7 @@ export function useGenericLedger(accountIndex = 0, addressOffset = 0, chainSlip?
     }
 
     return null;
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [refreshLock, chainSlip, txMetadataChainId]);
 
   useEffect(() => {
@@ -74,6 +78,12 @@ export function useGenericLedger(accountIndex = 0, addressOffset = 0, chainSlip?
     setIsLoading(true);
     setError(null);
     setWarning(null);
+
+    if (isFetching.current) {
+      return;
+    }
+
+    isFetching.current = true;
 
     ledger.getAddress(false, accountIndex, addressOffset)
       .then((res) => {
@@ -98,6 +108,8 @@ export function useGenericLedger(accountIndex = 0, addressOffset = 0, chainSlip?
         ));
         console.error(e);
         setAddress(null);
+      }).finally(() => {
+        isFetching.current = false;
       });
     // If the dependency array is exhaustive, with t, the translation function, it
     // triggers a useless re-render when ledger device is connected.

--- a/packages/extension-polkagate/src/popup/signing/LedgerSignGeneric.tsx
+++ b/packages/extension-polkagate/src/popup/signing/LedgerSignGeneric.tsx
@@ -3,17 +3,19 @@
 
 /* eslint-disable react/jsx-max-props-per-line */
 
-import type { HexString } from '@polkadot/util/types';
-import { Grid, useTheme } from '@mui/material';
-import React, { useCallback, useEffect, useState, useMemo } from 'react';
-import styled from 'styled-components';
-import { PButton, Warning } from '../../components';
-import useTranslation from '../../hooks/useTranslation';
-import { useGenericLedger, useInfo, useMetadataProof } from '../../hooks';
-import ledgerChains from '../../util/legerChains';
-import type { SignerPayloadJSON } from '@polkadot/types/types';
 import type { LedgerSignature } from '@polkadot/hw-ledger/types';
 import type { GenericExtrinsicPayload } from '@polkadot/types';
+import type { SignerPayloadJSON } from '@polkadot/types/types';
+import type { HexString } from '@polkadot/util/types';
+
+import { Grid, useTheme } from '@mui/material';
+import React, { useCallback, useEffect, useState } from 'react';
+import styled from 'styled-components';
+
+import { PButton, Warning } from '../../components';
+import { useGenericLedger, useInfo, useMetadataProof } from '../../hooks';
+import useTranslation from '../../hooks/useTranslation';
+import { POLKADOT_SLIP44 } from '../../util/constants';
 
 interface Props {
   accountIndex?: number;
@@ -27,22 +29,25 @@ interface Props {
   showError?: boolean;
 }
 
-function LedgerSignGeneric({ accountIndex, address, addressOffset, error, onSignature, payload, setError, showError = true }: Props): React.ReactElement<Props> {
+function LedgerSignGeneric ({ accountIndex, address, addressOffset, error, onSignature, payload, setError, showError = true }: Props): React.ReactElement<Props> {
   const { t } = useTranslation();
   const theme = useTheme();
-  const { api, account } = useInfo(address);
+  const { api } = useInfo(address);
   const metadataProof = useMetadataProof(api, payload);
 
   const [isBusy, setIsBusy] = useState<boolean>(false);
 
-  const chainSlip44 = useMemo(() => {
-    if (account?.genesisHash) {
-      return ledgerChains.find(({ genesisHash }) => genesisHash.includes(account.genesisHash as any))?.slip44 ?? null
-    }
-    return null;
-  }, [account, ledgerChains]);
+  // const chainSlip44 = useMemo(() => {
+  //   if (account?.genesisHash) {
+  //     const ledgerChain = ledgerChains.find(({ genesisHash }) => genesisHash.includes(account.genesisHash));
 
-  const { error: ledgerError, isLoading: ledgerLoading, isLocked: ledgerLocked, ledger, refresh, warning: ledgerWarning } = useGenericLedger(accountIndex, addressOffset, chainSlip44);
+  //     return ledgerChain?.slip44 ?? null;
+  //   }
+
+  //   return null;
+  // }, [account]);
+
+  const { error: ledgerError, isLoading: ledgerLoading, isLocked: ledgerLocked, ledger, refresh, warning: ledgerWarning } = useGenericLedger(accountIndex, addressOffset, POLKADOT_SLIP44);
 
   useEffect(() => {
     if (ledgerError) {


### PR DESCRIPTION
Done:

- Fixed the issue of multiple Ledger requests caused by occasional race conditions.
- Ensured the Ledger retrieves the address using the Polkadot SLIP-44 standard for signing.

TODO:
- Investigate why Zondax includes a chain prefix as an input parameter.

![Screenshot 2024-08-14 at 17 33 21](https://github.com/user-attachments/assets/1da20323-d29d-4e2c-98ee-8b84cb065338)


close #1470

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `useGenericLedger` hook to manage fetch operations more effectively, preventing concurrent requests.
	- Improved type safety in the `LedgerSignGeneric` component by refining type imports.

- **Bug Fixes**
	- Resolved potential race conditions in asynchronous operations within the `useGenericLedger` hook.

- **Refactor**
	- Streamlined the `LedgerSignGeneric` component's logic regarding ledger chains by removing unnecessary calculations and variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->