### PR TITLE
fix transferable issue when frozen is zero

### DIFF
--- a/packages/extension-polkagate/src/hooks/useBalances.ts
+++ b/packages/extension-polkagate/src/hooks/useBalances.ts
@@ -37,8 +37,8 @@ export default function useBalances(address: string | undefined, refresh?: boole
   const [pooledBalance, setPooledBalance] = useState<{ balance: BN, genesisHash: string } | null>();
   const [overall, setOverall] = useState<BalancesInfo | undefined>();
 
-  const token = api && api.registry.chainTokens[0];
-  const decimal = api && api.registry.chainDecimals[0];
+  const token = api?.registry.chainTokens[0];
+  const decimal = api?.registry.chainDecimals[0];
 
   const getPoolBalances = useCallback(() => {
     if (api && !api.query['nominationPools']) {
@@ -198,13 +198,14 @@ export default function useBalances(address: string | undefined, refresh?: boole
     const savedBalances = JSON.parse(account?.balances ?? '{}') as SavedBalances;
 
     const balances = {
+      ED: overall.ED.toString(),
       assetId: overall.assetId,
       availableBalance: overall.availableBalance.toString(),
       freeBalance: overall.freeBalance.toString(),
       frozenBalance: overall.frozenBalance.toString(),
       genesisHash: overall.genesisHash,
       lockedBalance: overall.lockedBalance.toString(),
-      pooledBalance: overall.pooledBalance && overall.pooledBalance.toString(),
+      pooledBalance: overall.pooledBalance?.toString(),
       reservedBalance: overall.reservedBalance.toString(),
       vestedBalance: overall.vestedBalance.toString(),
       vestedClaimable: overall.vestedClaimable.toString(),
@@ -231,6 +232,7 @@ export default function useBalances(address: string | undefined, refresh?: boole
       const sb = savedBalances[chainName].balances;
 
       const lastBalances = {
+        ED: new BN(sb['ED'] || '0'),
         assetId: sb['assetId'] && parseInt(sb['assetId']),
         availableBalance: new BN(sb['availableBalance']),
         chainName,

--- a/packages/extension-polkagate/src/popup/account/util.ts
+++ b/packages/extension-polkagate/src/popup/account/util.ts
@@ -39,8 +39,11 @@ export const getValue = (type: string, balances: BalancesInfo | null | undefined
     case ('transferable'):
     {
       const frozenBalance = balances.frozenBalance || BN_ZERO; // for backward compatibility of PolkaGate extension
+      const noFrozenReserved = frozenBalance.isZero() && balances.reservedBalance.isZero();
+
       const frozenReserveDiff = frozenBalance.sub(balances.reservedBalance);
-      const untouchable = bnMax(balances.ED || BN_ZERO, frozenReserveDiff);
+      const maybeED = noFrozenReserved ? BN_ZERO : (balances.ED || BN_ZERO);
+      const untouchable = bnMax(maybeED, frozenReserveDiff);
 
       return balances.freeBalance.sub(untouchable);
     }

--- a/packages/extension-polkagate/src/popup/account/util.ts
+++ b/packages/extension-polkagate/src/popup/account/util.ts
@@ -38,7 +38,8 @@ export const getValue = (type: string, balances: BalancesInfo | null | undefined
 
     case ('transferable'):
     {
-      const frozenReserveDiff = balances.frozenBalance.isZero() ? BN_ZERO : balances.frozenBalance.sub(balances.reservedBalance);
+      const frozenBalance = balances.frozenBalance || BN_ZERO; // for backward compatibility of PolkaGate extension
+      const frozenReserveDiff = frozenBalance.sub(balances.reservedBalance);
       const untouchable = bnMax(balances.ED || BN_ZERO, frozenReserveDiff);
 
       return balances.freeBalance.sub(untouchable);

--- a/packages/extension-polkagate/src/popup/home/news.ts
+++ b/packages/extension-polkagate/src/popup/home/news.ts
@@ -10,6 +10,12 @@ export interface News {
 
 export const news: News[] = [
   {
+    version: '0.7.6',
+    notes: [
+      'New Transferable Formula: The on-chain formula for calculating transferable balance has changed, so some users may notice an increase in their transferable balance.'
+    ]
+  },
+  {
     version: '0.7.5',
     notes: [
       'Alerts now keep you informed: Notifications have been added to update you on tasks running in the background.',


### PR DESCRIPTION
when frozen is zero and we have reserved we should consider ED as untouchable plus reserved.

**TODO: Available to stake needs to be checked!**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced balance calculations for transferable and available balances, improving accuracy in displaying available funds.
	- Added an update note for version `0.7.6` regarding changes in on-chain formulas that may increase transferable balances.

- **Bug Fixes**
	- Improved error handling in the `useBalances` hook, ensuring better data representation.

- **Chores**
	- Updated dependencies for balance calculation utilities to ensure optimal functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->