### PR TITLE
fix white screen lock

### DIFF
--- a/packages/extension-polkagate/src/components/Loading.tsx
+++ b/packages/extension-polkagate/src/components/Loading.tsx
@@ -252,7 +252,7 @@ export default function Loading ({ children }: Props): React.ReactElement<Props>
             {isFlying && isPopupOpenedByExtension
               ? <FlyingLogo theme={theme} />
               : <>
-                { step !== undefined && [STEPS.ASK_TO_SET_PASSWORD, STEPS.SHOW_LOGIN].includes(step) && (isPopupOpenedByExtension || isExtensionLocked) &&
+                {step !== undefined && ([STEPS.ASK_TO_SET_PASSWORD, STEPS.SHOW_LOGIN].includes(step) || isExtensionLocked) &&
                   <Grid container item justifyContent='center' mt='33px' my='35px'>
                     <StillLogo theme={theme} />
                   </Grid>
@@ -270,7 +270,7 @@ export default function Loading ({ children }: Props): React.ReactElement<Props>
                     setStep={setStep}
                   />
                 }
-                {step !== undefined && [STEPS.SHOW_LOGIN].includes(step) &&
+                {step !== undefined && ([STEPS.SHOW_LOGIN].includes(step) || isExtensionLocked) &&
                   <Login
                     isPasswordError={isPasswordError}
                     onPassChange={onPassChange}


### PR DESCRIPTION
**to reproduce:** unlock the extension, close it, reopen and lock the extension, the following screen  has been shown:

![Screenshot 2024-08-25 at 20 15 30](https://github.com/user-attachments/assets/7e81df1b-4518-48a5-a830-3f256e587ee8)



with this PR being merged, the issue will be fixed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced user feedback by displaying the `StillLogo` component when the extension is locked.
  - Improved accessibility of the `Login` component under various conditions, including when the extension is locked.

These changes aim to provide a better user experience during authentication by ensuring relevant UI elements are visible when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->