### PR TITLE
feat: re-authorize new accounts

### DIFF
--- a/packages/extension-base/src/background/handlers/Extension.ts
+++ b/packages/extension-base/src/background/handlers/Extension.ts
@@ -58,6 +58,8 @@ export default class Extension {
   }
 
   private applyAddedTime ({ pair }: ApplyAddedTime): void {
+    assert(pair, 'Unable to find pair');
+
     const addedTime = Date.now();
 
     keyring.saveAccountMeta(pair, { ...pair.meta, addedTime });

--- a/packages/extension-base/src/background/handlers/Extension.ts
+++ b/packages/extension-base/src/background/handlers/Extension.ts
@@ -537,7 +537,9 @@ export default class Extension {
       suri
     });
 
-    keyring.addPair(childPair, password);
+    const { pair } = keyring.addPair(childPair, password);
+
+    this.applyAddedTime({ pair });
 
     return true;
   }

--- a/packages/extension-base/src/background/handlers/Extension.ts
+++ b/packages/extension-base/src/background/handlers/Extension.ts
@@ -7,7 +7,7 @@ import type { SignerPayloadJSON, SignerPayloadRaw } from '@polkadot/types/types'
 import type { SubjectInfo } from '@polkadot/ui-keyring/observable/types';
 import type { KeypairType } from '@polkadot/util-crypto/types';
 // added for plus to import RequestUpdateMeta
-import type { AccountJson, AllowedPath, AuthorizeRequest, AuthUrls, MessageTypes, MetadataRequest, RequestAccountBatchExport, RequestAccountChangePassword, RequestAccountCreateExternal, RequestAccountCreateHardware, RequestAccountCreateSuri, RequestAccountEdit, RequestAccountExport, RequestAccountForget, RequestAccountShow, RequestAccountTie, RequestAccountValidate, RequestAuthorizeApprove, RequestBatchRestore, RequestDeriveCreate, RequestDeriveValidate, RequestJsonRestore, RequestMetadataApprove, RequestMetadataReject, RequestSeedCreate, RequestSeedValidate, RequestSigningApprovePassword, RequestSigningApproveSignature, RequestSigningCancel, RequestSigningIsLocked, RequestTypes, RequestUpdateAuthorizedAccounts, RequestUpdateMeta, ResponseAccountExport, ResponseAccountsExport, ResponseAuthorizeList, ResponseDeriveValidate, ResponseJsonGetAccountInfo, ResponseSeedCreate, ResponseSeedValidate, ResponseSigningIsLocked, ResponseType, SigningRequest } from '../types';
+import type { AccountJson, AllowedPath, ApplyAddedTime, AuthorizeRequest, AuthUrls, MessageTypes, MetadataRequest, RequestAccountBatchExport, RequestAccountChangePassword, RequestAccountCreateExternal, RequestAccountCreateHardware, RequestAccountCreateSuri, RequestAccountEdit, RequestAccountExport, RequestAccountForget, RequestAccountShow, RequestAccountTie, RequestAccountValidate, RequestAuthorizeApprove, RequestBatchRestore, RequestDeriveCreate, RequestDeriveValidate, RequestJsonRestore, RequestMetadataApprove, RequestMetadataReject, RequestSeedCreate, RequestSeedValidate, RequestSigningApprovePassword, RequestSigningApproveSignature, RequestSigningCancel, RequestSigningIsLocked, RequestTypes, RequestUpdateAuthorizedAccounts, RequestUpdateMeta, ResponseAccountExport, ResponseAccountsExport, ResponseAuthorizeList, ResponseDeriveValidate, ResponseJsonGetAccountInfo, ResponseSeedCreate, ResponseSeedValidate, ResponseSigningIsLocked, ResponseType, SigningRequest } from '../types';
 import type State from './State';
 
 import { ALLOWED_PATH, PASSWORD_EXPIRY_MS, START_WITH_PATH } from '@polkadot/extension-base/defaults';
@@ -57,20 +57,32 @@ export default class Extension {
     this.#state = state;
   }
 
+  private applyAddedTime ({ pair }: ApplyAddedTime): void {
+    const addedTime = Date.now();
+
+    keyring.saveAccountMeta(pair, { ...pair.meta, addedTime });
+  }
+
   private accountsCreateExternal ({ address, genesisHash, name }: RequestAccountCreateExternal): boolean {
-    keyring.addExternal(address, { genesisHash, name });
+    const { pair } = keyring.addExternal(address, { genesisHash, name });
+
+    this.applyAddedTime({ pair });
 
     return true;
   }
 
   private accountsCreateHardware ({ accountIndex, address, addressOffset, genesisHash, hardwareType, name }: RequestAccountCreateHardware): boolean {
-    keyring.addHardware(address, hardwareType, { accountIndex, addressOffset, genesisHash, name });
+    const { pair } = keyring.addHardware(address, hardwareType, { accountIndex, addressOffset, genesisHash, name });
+
+    this.applyAddedTime({ pair });
 
     return true;
   }
 
   private accountsCreateSuri ({ genesisHash, name, password, suri, type }: RequestAccountCreateSuri): boolean {
-    keyring.addUri(getSuri(suri, type), password, { genesisHash, name }, type);
+    const { pair } = keyring.addUri(getSuri(suri, type), password, { genesisHash, name }, type);
+
+    this.applyAddedTime({ pair });
 
     return true;
   }
@@ -302,7 +314,9 @@ export default class Extension {
 
   private jsonRestore ({ file, password }: RequestJsonRestore): void {
     try {
-      keyring.restoreAccount(file, password);
+      const pair = keyring.restoreAccount(file, password);
+
+      this.applyAddedTime({ pair });
     } catch (error) {
       throw new Error((error as Error).message);
     }

--- a/packages/extension-base/src/background/handlers/State.ts
+++ b/packages/extension-base/src/background/handlers/State.ts
@@ -187,13 +187,6 @@ export default class State {
       this.authUrlSubjects[url] = new BehaviorSubject<AuthUrlInfo>(authInfo);
     });
 
-    // set the timestamp to 0 for old authorized requests
-    Object.entries(previousAuth).forEach(([url, _authInfo]) => {
-      if (this.authUrlSubjects[url].getValue().authorizedTime === undefined) {
-        this.authUrlSubjects[url].getValue().authorizedTime = 0;
-      }
-    });
-
     // retrieve previously set default auth accounts
     const storageDefaultAuthAccounts: Record<string, string> = await chrome.storage.local.get(DEFAULT_AUTH_ACCOUNTS);
     const defaultAuthString: string = storageDefaultAuthAccounts?.[DEFAULT_AUTH_ACCOUNTS] || '[]';

--- a/packages/extension-base/src/background/handlers/Tabs.ts
+++ b/packages/extension-base/src/background/handlers/Tabs.ts
@@ -80,10 +80,10 @@ export default class Tabs {
       return Promise.resolve([]);
     }
 
-    const hasNewerAccountsSinceAuth = transformedAccounts.some(({ addedTime }) => addedTime && addedTime > auth.authorizedTime);
+    const hasNewerAccountsSinceAuth = !auth.authorizedTime || transformedAccounts.some(({ addedTime }) => addedTime && addedTime > auth.authorizedTime);
 
     if (hasNewerAccountsSinceAuth) {
-      return this.authorize(url, { origin: this.#state.stripUrl(url) }, true).then(() => this.accountsListAuthorized(url, { anyType }));
+      return this.authorize(url, { origin: auth.origin }, true).then(() => this.accountsListAuthorized(url, { anyType }));
     } else {
       return Promise.resolve(authorizedAccounts);
     }

--- a/packages/extension-base/src/background/handlers/Tabs.ts
+++ b/packages/extension-base/src/background/handlers/Tabs.ts
@@ -69,7 +69,7 @@ export default class Tabs {
     return accessAccounts;
   }
 
-  private accountsListAuthorized (url: string, { anyType }: RequestAccountList): Promise<AuthResponse | InjectedAccount[]> {
+  private accountsListAuthorized (url: string, { anyType }: RequestAccountList): InjectedAccount[] {
     const transformedAccounts = transformAccounts(accountsObservable.subject.getValue(), anyType);
     const authorizedAccounts = this.filterForAuthorizedAccounts(transformedAccounts, url);
 
@@ -77,16 +77,16 @@ export default class Tabs {
 
     // just a check for linting issue, it already checked by "ensureUrlAuthorized"
     if (!auth) {
-      return Promise.resolve([]);
+      return [];
     }
 
     const hasNewerAccountsSinceAuth = !auth.authorizedTime || transformedAccounts.some(({ addedTime }) => addedTime && addedTime > auth.authorizedTime);
 
     if (hasNewerAccountsSinceAuth) {
-      return this.authorize(url, { origin: auth.origin }, true).then(() => this.accountsListAuthorized(url, { anyType }));
-    } else {
-      return Promise.resolve(authorizedAccounts);
+      this.authorize(url, { origin: auth.origin }, true).then(() => this.accountsListAuthorized(url, { anyType })).catch(console.error);
     }
+
+    return authorizedAccounts;
   }
 
   private accountsSubscribeAuthorized (url: string, id: string, port: chrome.runtime.Port): string {

--- a/packages/extension-base/src/background/types.ts
+++ b/packages/extension-base/src/background/types.ts
@@ -20,6 +20,7 @@ export interface AuthUrlInfo {
   origin: string;
   url: string;
   authorizedAccounts: string[];
+  authorizedTime: number;
 }
 
 type KeysWithDefinedValues<T> = {
@@ -56,6 +57,7 @@ export interface AccountJson extends KeyringPair$Meta {
   isQR?: boolean;
   profile?: string;
   stakingAccount?: string;
+  addedTime?: number; // for DApp authorization check
 }
 
 export type AccountWithChildren = AccountJson & {
@@ -441,4 +443,8 @@ export interface ResponseJsonGetAccountInfo {
 
 export interface ResponseAuthorizeList {
   list: AuthUrls;
+}
+
+export interface ApplyAddedTime {
+  pair: KeyringPair;
 }

--- a/packages/extension-inject/src/types.ts
+++ b/packages/extension-inject/src/types.ts
@@ -14,6 +14,7 @@ export type Unsubcall = () => void;
 
 export interface InjectedAccount {
   address: string;
+  addedTime?: number;
   genesisHash?: string | null;
   name?: string;
   type?: KeypairType;

--- a/packages/extension-inject/src/types.ts
+++ b/packages/extension-inject/src/types.ts
@@ -18,6 +18,7 @@ export interface InjectedAccount {
   genesisHash?: string | null;
   name?: string;
   type?: KeypairType;
+  whenCreated?: number;
 }
 
 export interface InjectedAccountWithMeta {

--- a/packages/extension-polkagate/src/messaging.ts
+++ b/packages/extension-polkagate/src/messaging.ts
@@ -206,8 +206,8 @@ export async function removeAuthorization (id: string): Promise<ResponseAuthoriz
   return sendMessage('pri(authorize.remove)', id);
 }
 
-export async function ignoreAuthRequest (url: string): Promise<void> {
-  return sendMessage('pri(authorize.ignore)', url);
+export async function ignoreAuthRequest (id: string): Promise<void> {
+  return sendMessage('pri(authorize.ignore)', id);
 }
 
 export async function subscribeMetadataRequests (cb: (accounts: MetadataRequest[]) => void): Promise<boolean> {

--- a/packages/extension-polkagate/src/popup/authorize/AuthFullScreenMode.tsx
+++ b/packages/extension-polkagate/src/popup/authorize/AuthFullScreenMode.tsx
@@ -123,7 +123,7 @@ function AuthFullScreenMode ({ onNextAuth, onPreviousAuth, requestIndex, request
                 onPrimaryClick={onApprove}
                 onSecondaryClick={onReject}
                 primaryBtnText={t('Allow')}
-                secondaryBtnText={t('Reject')}
+                secondaryBtnText={t('Ignore')}
               />
             </Grid>
           </Grid>

--- a/packages/extension-polkagate/src/popup/authorize/AuthFullScreenMode.tsx
+++ b/packages/extension-polkagate/src/popup/authorize/AuthFullScreenMode.tsx
@@ -7,14 +7,14 @@ import type { AuthorizeRequest } from '@polkadot/extension-base/background/types
 
 import { KeyboardDoubleArrowLeft as KeyboardDoubleArrowLeftIcon, KeyboardDoubleArrowRight as KeyboardDoubleArrowRightIcon } from '@mui/icons-material';
 import { Avatar, Grid, IconButton, Typography, useTheme } from '@mui/material';
-import React, { useCallback, useContext, useMemo, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 
 import { FULLSCREEN_WIDTH } from '@polkadot/extension-polkagate/src/util/constants';
 
 import { AccountContext, AccountsTable, ActionContext, TwoButtons, VaadinIcon, Warning } from '../../components';
 import { FullScreenHeader } from '../../fullscreen/governance/FullScreenHeader';
 import { useFavIcon, useFullscreen, useTranslation } from '../../hooks';
-import { approveAuthRequest, ignoreAuthRequest } from '../../messaging';
+import { approveAuthRequest, getAuthList, ignoreAuthRequest } from '../../messaging';
 import { areArraysEqual, extractBaseUrl } from '../../util/utils';
 
 interface Props {
@@ -28,15 +28,36 @@ function AuthFullScreenMode ({ onNextAuth, onPreviousAuth, requestIndex, request
   useFullscreen();
   const { t } = useTranslation();
   const theme = useTheme();
-  const { accounts } = useContext(AccountContext);
+
   const onAction = useContext(ActionContext);
+  const { accounts } = useContext(AccountContext);
+
+  const url = requests[requestIndex].url;
+  const faviconUrl = useFavIcon(url);
 
   const [selectedAccounts, setSelectedAccounts] = useState<string[]>([]);
+  const [alreadySelectedAccounts, setAlreadySelectedAccounts] = useState<string[]>([]);
 
-  const faviconUrl = useFavIcon(requests[requestIndex].url);
 
   const allAccounts = useMemo(() => accounts.map(({ address }) => address), [accounts]);
   const areAllCheck = useMemo(() => areArraysEqual([allAccounts, selectedAccounts]), [allAccounts, selectedAccounts]);
+
+  useEffect(() => {
+    getAuthList()
+      .then(({ list: authList }) => {
+        const dappURL = extractBaseUrl(url);
+
+        const availableDapp = Object.values(authList).find(({ url }) => dappURL === extractBaseUrl(url));
+
+        if (availableDapp) {
+          const alreadySelectedAccounts = availableDapp.authorizedAccounts ?? [];
+
+          setSelectedAccounts(alreadySelectedAccounts);
+          setAlreadySelectedAccounts(alreadySelectedAccounts);
+        }
+      })
+      .catch(console.error);
+  }, [url]);
 
   const onApprove = useCallback((): void => {
     approveAuthRequest(selectedAccounts, requests[requestIndex].id)
@@ -44,11 +65,15 @@ function AuthFullScreenMode ({ onNextAuth, onPreviousAuth, requestIndex, request
       .catch((error: Error) => console.error(error));
   }, [onAction, requestIndex, requests, selectedAccounts]);
 
-  const onReject = useCallback((): void => {
-    ignoreAuthRequest(requests[requestIndex].id)
-      .then(() => onAction())
+  const onIgnore = useCallback((): void => {
+    const id = requests[requestIndex].id;
+
+    (alreadySelectedAccounts.length
+      ? approveAuthRequest(alreadySelectedAccounts, id)
+      : ignoreAuthRequest(id)
+    ).then(() => onAction())
       .catch((error: Error) => console.error(error));
-  }, [onAction, requestIndex, requests]);
+  }, [alreadySelectedAccounts, onAction, requestIndex, requests]);
 
   return (
     <Grid bgcolor='backgroundFL.primary' container item justifyContent='center'>
@@ -93,7 +118,7 @@ function AuthFullScreenMode ({ onNextAuth, onPreviousAuth, requestIndex, request
               variant='circular'
             />
             <span style={{ fontSize: '15px', fontWeight: 400, overflowWrap: 'anywhere' }}>
-              {extractBaseUrl(requests[requestIndex].url)}
+              {extractBaseUrl(url)}
             </span>
           </Grid>
           <Grid container item sx={{ marginBottom: '15px', marginTop: '10px' }}>
@@ -121,7 +146,7 @@ function AuthFullScreenMode ({ onNextAuth, onPreviousAuth, requestIndex, request
                 disabled={selectedAccounts.length === 0}
                 mt='15px'
                 onPrimaryClick={onApprove}
-                onSecondaryClick={onReject}
+                onSecondaryClick={onIgnore}
                 primaryBtnText={t('Allow')}
                 secondaryBtnText={t('Ignore')}
               />

--- a/packages/extension-polkagate/src/popup/authorize/Request.tsx
+++ b/packages/extension-polkagate/src/popup/authorize/Request.tsx
@@ -89,7 +89,7 @@ export default function Request ({ authRequest, hasBanner }: Props): React.React
       <ButtonWithCancel
         _onClick={onApprove}
         _onClickCancel={onReject}
-        cancelText={t('Reject')}
+        cancelText={t('Ignore')}
         disabled={selectedAccounts.length === 0}
         text={t('Allow')}
       />

--- a/packages/extension-polkagate/src/popup/authorize/Request.tsx
+++ b/packages/extension-polkagate/src/popup/authorize/Request.tsx
@@ -26,6 +26,7 @@ export default function Request ({ authRequest, hasBanner }: Props): React.React
   const faviconUrl = useFavIcon(authRequest.url);
 
   const [selectedAccounts, setSelectedAccounts] = useState<string[]>([]);
+  const [alreadySelectedAccounts, setAlreadySelectedAccounts] = useState<string[]>([]);
 
   useEffect(() => {
     getAuthList()
@@ -35,7 +36,10 @@ export default function Request ({ authRequest, hasBanner }: Props): React.React
         const availableDapp = Object.values(authList).find(({ url }) => dappURL === extractBaseUrl(url));
 
         if (availableDapp) {
-          setSelectedAccounts(availableDapp.authorizedAccounts ?? []);
+          const alreadySelectedAccounts = availableDapp.authorizedAccounts ?? [];
+
+          setSelectedAccounts(alreadySelectedAccounts);
+          setAlreadySelectedAccounts(alreadySelectedAccounts);
         }
       })
       .catch(console.error);
@@ -51,10 +55,14 @@ export default function Request ({ authRequest, hasBanner }: Props): React.React
   }, [authRequest.id, onAction, selectedAccounts]);
 
   const onReject = useCallback((): void => {
-    ignoreAuthRequest(authRequest.id)
-      .then(() => onAction())
-      .catch((error: Error) => console.error(error));
-  }, [authRequest.id, onAction]);
+    alreadySelectedAccounts.length
+      ? approveAuthRequest(alreadySelectedAccounts, authRequest.id)
+        .then(() => onAction())
+        .catch((error: Error) => console.error(error))
+      : ignoreAuthRequest(authRequest.id)
+        .then(() => onAction())
+        .catch((error: Error) => console.error(error));
+  }, [alreadySelectedAccounts, authRequest.id, onAction]);
 
   return (
     <Grid container justifyContent='center'>

--- a/packages/extension-polkagate/src/popup/authorize/Request.tsx
+++ b/packages/extension-polkagate/src/popup/authorize/Request.tsx
@@ -35,7 +35,7 @@ export default function Request ({ authRequest, hasBanner }: Props): React.React
         }
       })
       .catch(console.error);
-  }, [authRequest, authRequest.request.origin]);
+  }, [authRequest.request.origin]);
 
   const allAccounts = useMemo(() => accounts.map(({ address }) => address), [accounts]);
   const areAllCheck = useMemo(() => areArraysEqual([allAccounts, selectedAccounts]), [allAccounts, selectedAccounts]);

--- a/packages/extension-polkagate/src/popup/authorize/Request.tsx
+++ b/packages/extension-polkagate/src/popup/authorize/Request.tsx
@@ -6,11 +6,11 @@
 import type { AuthorizeRequest } from '@polkadot/extension-base/background/types';
 
 import { Avatar, Grid, Typography, useTheme } from '@mui/material';
-import React, { useCallback, useContext, useMemo, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 
 import { AccountContext, AccountsTable, ActionContext, ButtonWithCancel, Warning } from '../../components';
 import { useFavIcon, useTranslation } from '../../hooks';
-import { approveAuthRequest, ignoreAuthRequest } from '../../messaging';
+import { approveAuthRequest, getAuthList, ignoreAuthRequest } from '../../messaging';
 import { areArraysEqual, extractBaseUrl } from '../../util/utils';
 
 interface Props {
@@ -26,6 +26,16 @@ export default function Request ({ authRequest, hasBanner }: Props): React.React
   const faviconUrl = useFavIcon(authRequest.url);
 
   const [selectedAccounts, setSelectedAccounts] = useState<string[]>([]);
+
+  useEffect(() => {
+    getAuthList()
+      .then(({ list: authList }) => {
+        if (authRequest.request.origin in authList) {
+          setSelectedAccounts(authList[authRequest.request.origin]?.authorizedAccounts ?? []);
+        }
+      })
+      .catch(console.error);
+  }, [authRequest, authRequest.request.origin]);
 
   const allAccounts = useMemo(() => accounts.map(({ address }) => address), [accounts]);
   const areAllCheck = useMemo(() => areArraysEqual([allAccounts, selectedAccounts]), [allAccounts, selectedAccounts]);
@@ -61,7 +71,7 @@ export default function Request ({ authRequest, hasBanner }: Props): React.React
       </Grid>
       <AccountsTable
         areAllCheck={areAllCheck}
-        maxHeight= { hasBanner ? '150px' : '170px'}
+        maxHeight={hasBanner ? '150px' : '170px'}
         selectedAccounts={selectedAccounts}
         setSelectedAccounts={setSelectedAccounts}
         style={{

--- a/packages/extension-polkagate/src/popup/authorize/Request.tsx
+++ b/packages/extension-polkagate/src/popup/authorize/Request.tsx
@@ -30,12 +30,16 @@ export default function Request ({ authRequest, hasBanner }: Props): React.React
   useEffect(() => {
     getAuthList()
       .then(({ list: authList }) => {
-        if (authRequest.request.origin in authList) {
-          setSelectedAccounts(authList[authRequest.request.origin]?.authorizedAccounts ?? []);
+        const dappURL = extractBaseUrl(authRequest.url);
+
+        const availableDapp = Object.values(authList).find(({ url }) => dappURL === extractBaseUrl(url));
+
+        if (availableDapp) {
+          setSelectedAccounts(availableDapp.authorizedAccounts ?? []);
         }
       })
       .catch(console.error);
-  }, [authRequest.request.origin]);
+  }, [authRequest.url]);
 
   const allAccounts = useMemo(() => accounts.map(({ address }) => address), [accounts]);
   const areAllCheck = useMemo(() => areArraysEqual([allAccounts, selectedAccounts]), [allAccounts, selectedAccounts]);

--- a/packages/extension-polkagate/src/popup/import/restoreJSONFullScreen/index.tsx
+++ b/packages/extension-polkagate/src/popup/import/restoreJSONFullScreen/index.tsx
@@ -20,7 +20,7 @@ import { jsonDecrypt, jsonEncrypt } from '@polkadot/util-crypto';
 import { Address, InputFileWithLabel, Password, TwoButtons, VaadinIcon, Warning, WrongPasswordAlert } from '../../../components';
 import { FullScreenHeader } from '../../../fullscreen/governance/FullScreenHeader';
 import { useFullscreen, useTranslation } from '../../../hooks';
-import { batchRestore, jsonGetAccountInfo, jsonRestore } from '../../../messaging';
+import { batchRestore, jsonGetAccountInfo, jsonRestore, updateMeta } from '../../../messaging';
 import { DEFAULT_TYPE } from '../../../util/defaultType';
 import { isKeyringPairs$Json } from '../../../util/typeGuards';
 import { pgBoxShadow } from '../../../util/utils';
@@ -126,13 +126,18 @@ export default function RestoreJson (): React.ReactElement {
   const handleKeyringPairsJson = useCallback(async (jsonFile: KeyringPairs$Json) => {
     const selected = selectedAccountsInfo.map(({ address }) => address);
     let encryptFile = jsonFile;
+    let accountToAddTime = accountsInfo.map(({ address }) => address);
 
     if (selected.length !== accountsInfo.length) {
+      accountToAddTime = selected;
       encryptFile = await filterAndEncryptFile(encryptFile, selected);
     }
 
     await batchRestore(encryptFile, password);
-  }, [accountsInfo.length, filterAndEncryptFile, password, selectedAccountsInfo]);
+    const updateMetaList = accountToAddTime.map((address) => updateMeta(address, JSON.stringify({ addedTime: Date.now() })));
+
+    await Promise.all(updateMetaList);
+  }, [accountsInfo, filterAndEncryptFile, password, selectedAccountsInfo]);
 
   const handleRegularJson = useCallback(async (jsonFile: KeyringPair$Json) => {
     await jsonRestore(jsonFile, password);

--- a/packages/extension/public/locales/en/translation.json
+++ b/packages/extension/public/locales/en/translation.json
@@ -1382,5 +1382,6 @@
   "{{accountName}} default chain switched to {{chainName}}.": "",
   "Social Media": "",
   "Need": "",
-  "Help?": ""
+  "Help?": "",
+  "Ignore": ""
 }


### PR DESCRIPTION
- fix sending authenticated accounts to dapp while re-auth popup is open
- move re-auth check to auth function
- utilize whenCreated besides addedTime for re-auth check
- apply extension mode changes on AuthFullScreenMode


```
private applyAddedTime ({ pair }: ApplyAddedTime): void {
    assert(pair, 'Unable to find pair');

    const addedTime = Date.now();

    keyring.saveAccountMeta(pair, { ...pair.meta, addedTime });
  }
```
  
@AMIRKHANEF  assert may fail the parent function, right?

address #1492 
  
  
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced account management with timestamp tracking for account creation and restoration.
	- Improved authorization handling with time-based tracking and reauthorization logic.
	- Added functionality to retrieve and manage authorized accounts for DApps.

- **Bug Fixes**
	- Adjusted logic in authorization request handling to improve user experience.

- **Documentation**
	- Updated translation files to support new UI terms.

- **Chores**
	- Minor adjustments to improve code readability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->