### PR TITLE
fix: remove release dependency on title

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -27,7 +27,7 @@ jobs:
               core.setFailed(`PR title does not follow the correct format. Example: feat: Add new feature.`);
             }
 
-  pr:
+  build:
     strategy:
       matrix:
         step: ['build']
@@ -57,7 +57,7 @@ jobs:
 
   release:
     name: Release
-    needs: [check-title, pr]
+    needs: [build]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the GitHub Actions workflow to enhance the build and release process.
	- Renamed the job from `pr` to `build` to better reflect its purpose.
	- Adjusted job dependencies to ensure the build process is completed before the release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->