### PR TITLE
fix: set profile to default on removing the last member of a profile [2]

### DIFF
--- a/packages/extension-polkagate/src/fullscreen/homeFullScreen/partials/ProfileMenu.tsx
+++ b/packages/extension-polkagate/src/fullscreen/homeFullScreen/partials/ProfileMenu.tsx
@@ -224,7 +224,7 @@ function ProfileMenu ({ address, closeParentMenu }: Props): React.ReactElement<P
       return;
     }
 
-    const accountsInAProfileTag = accounts.filter(({ profile }) => profile && profile === currentProfile);
+    const accountsInAProfileTag = accounts.filter(({ profile }) => profile?.split(',').find((accountProfile) => accountProfile === currentProfile));
 
     const newProfiles = profileNames.filter((item) => item !== profileToBeRemoved);
 


### PR DESCRIPTION
Close: #1533 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced profile management by integrating account context, allowing for more effective profile removal and state updates.
	- Improved responsiveness to profile data changes, ensuring a smoother user experience.

- **Bug Fixes**
	- Resolved potential issues with profile removal logic by considering both profiles and accounts.

- **Refactor**
	- Updated state management and logic for handling profile removals to reflect current profiles accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->