### PR TITLE
feat: add profile tab tooltip in FS

### DIFF
--- a/packages/extension-polkagate/src/components/Infotip2.tsx
+++ b/packages/extension-polkagate/src/components/Infotip2.tsx
@@ -1,6 +1,5 @@
 // Copyright 2019-2024 @polkadot/extension-polkagate authors & contributors
 // SPDX-License-Identifier: Apache-2.0
-// @ts-nocheck
 
 /* eslint-disable react/jsx-max-props-per-line */
 
@@ -20,7 +19,7 @@ interface Props {
   fontSize?: string;
 }
 
-function Infotip2({ children, fontSize = '14px', placement = 'top', showInfoMark = false, showQuestionMark = false, showWarningMark, text }: Props): React.ReactElement<Props> {
+function Infotip2 ({ children, fontSize = '14px', placement = 'top', showInfoMark = false, showQuestionMark = false, showWarningMark, text }: Props): React.ReactElement<Props> {
   const theme = useTheme();
 
   return (
@@ -89,7 +88,7 @@ function Infotip2({ children, fontSize = '14px', placement = 'top', showInfoMark
                 : <FontAwesomeIcon
                   color={theme.palette.secondary.light}
                   icon={faExclamationTriangle}
-                  style={{ paddingLeft: '7px', fontSize: '17px' }}
+                  style={{ fontSize: '17px', paddingLeft: '7px' }}
                 />
             }
           </Tooltip>

--- a/packages/extension-polkagate/src/components/contexts.tsx
+++ b/packages/extension-polkagate/src/components/contexts.tsx
@@ -8,8 +8,7 @@ import type { AccountsAssetsContextType, AlertContextType, APIsContext, Currency
 import React from 'react';
 
 import settings from '@polkadot/ui-settings';
-
-import { noop } from '../util/utils';
+import { noop } from '@polkadot/util';
 
 const AccountContext = React.createContext<AccountsContext>({ accounts: [], hierarchy: [], master: undefined });
 const AccountsAssetsContext = React.createContext<AccountsAssetsContextType>({ accountsAssets: undefined, setAccountsAssets: noop });

--- a/packages/extension-polkagate/src/fullscreen/homeFullScreen/partials/ProfileTabFullScreen.tsx
+++ b/packages/extension-polkagate/src/fullscreen/homeFullScreen/partials/ProfileTabFullScreen.tsx
@@ -10,7 +10,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { getProfileColor } from '@polkadot/extension-polkagate/src/util/utils';
 
-import { VaadinIcon } from '../../../components/index';
+import { Infotip2, VaadinIcon } from '../../../components/index';
 import { getStorage, setStorage, watchStorage } from '../../../components/Loading';
 import { useAlerts, useProfileAccounts, useTranslation } from '../../../hooks';
 import { showAccount } from '../../../messaging';
@@ -28,7 +28,7 @@ interface Props {
 export default function ProfileTabFullScreen ({ index, isHovered, orderedAccounts, selectedProfile, setSelectedProfile, text }: Props): React.ReactElement {
   const { t } = useTranslation();
   const theme = useTheme();
-  const { notify } = useAlerts();
+  const { alerts, notify } = useAlerts();
   const profileAccounts = useProfileAccounts(orderedAccounts, text);
 
   /** set by user click on a profile tab */
@@ -84,55 +84,63 @@ export default function ProfileTabFullScreen ({ index, isHovered, orderedAccount
   }, [setSelectedProfile, t]);
 
   return (
-    <Grid
-      alignItems='center'
-      columnGap='5px'
-      container
-      item
-      justifyContent='center'
-      onClick={onClick}
-      px='8px'
-      sx={{
-        '&:hover': {
-          boxShadow: shadowOnHover
-        },
-        bgcolor: getProfileColor(index, theme) || 'background.paper',
-        borderRadius: '0 0 12px 12px',
-        boxShadow: shadow,
-        cursor: 'pointer',
-        flexShrink: 0,
-        minWidth: '100px',
-        position: 'relative',
-        transform: hideCard ? `translateY(-${HIDDEN_PERCENT})` : undefined,
-        transformOrigin: 'top',
-        transition: 'transform 0.2s, box-shadow 0.2s',
-        userSelect: 'none',
-        width: 'fit-content'
-      }}
+    <Infotip2
+      text={
+        !alerts?.length && isSelected && !areAllHidden
+          ? t('Click to hide all the profile accounts from websites!')
+          : undefined
+      }
     >
-      <VaadinIcon icon={'vaadin:check'} style={{ height: '13px', visibility: isSelected ? 'visible' : 'hidden', width: '15px' }} />
-      <Typography
-        color={'text.primary'} display='block' fontSize='16px' fontWeight={isSelected ? 500 : 400}
+      <Grid
+        alignItems='center'
+        columnGap='5px'
+        container
+        item
+        justifyContent='center'
+        onClick={onClick}
+        px='8px'
         sx={{
-          maxWidth: '100px',
-          overflow: 'hidden',
-          textOverflow: 'ellipsis',
-          transition: isSelected ? 'none' : 'visibility 0.1s ease-in-out',
-          visibility: visibleContent ? 'visible' : 'hidden',
-          whiteSpace: 'nowrap'
-        }} textAlign='center'
-      >
-        {t(text)}
-      </Typography>
-      <VaadinIcon
-        icon={areAllHidden ? 'vaadin:eye-slash' : ''}
-        style={{
-          height: '13px',
-          transition: isSelected ? 'none' : 'visibility 0.1s ease-in-out',
-          visibility: visibleContent ? 'visible' : 'hidden',
-          width: '15px'
+          '&:hover': {
+            boxShadow: shadowOnHover
+          },
+          bgcolor: getProfileColor(index, theme) || 'background.paper',
+          borderRadius: '0 0 12px 12px',
+          boxShadow: shadow,
+          cursor: 'pointer',
+          flexShrink: 0,
+          minWidth: '100px',
+          position: 'relative',
+          transform: hideCard ? `translateY(-${HIDDEN_PERCENT})` : undefined,
+          transformOrigin: 'top',
+          transition: 'transform 0.2s, box-shadow 0.2s',
+          userSelect: 'none',
+          width: 'fit-content'
         }}
-      />
-    </Grid>
+      >
+        <VaadinIcon icon={'vaadin:check'} style={{ height: '13px', visibility: isSelected ? 'visible' : 'hidden', width: '15px' }} />
+        <Typography
+          color={'text.primary'} display='block' fontSize='16px' fontWeight={isSelected ? 500 : 400}
+          sx={{
+            maxWidth: '100px',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            transition: isSelected ? 'none' : 'visibility 0.1s ease-in-out',
+            visibility: visibleContent ? 'visible' : 'hidden',
+            whiteSpace: 'nowrap'
+          }} textAlign='center'
+        >
+          {t(text)}
+        </Typography>
+        <VaadinIcon
+          icon={areAllHidden ? 'vaadin:eye-slash' : ''}
+          style={{
+            height: '13px',
+            transition: isSelected ? 'none' : 'visibility 0.1s ease-in-out',
+            visibility: visibleContent ? 'visible' : 'hidden',
+            width: '15px'
+          }}
+        />
+      </Grid>
+    </Infotip2>
   );
 }

--- a/packages/extension-polkagate/src/fullscreen/homeFullScreen/partials/ProfileTabsFullScreen.tsx
+++ b/packages/extension-polkagate/src/fullscreen/homeFullScreen/partials/ProfileTabsFullScreen.tsx
@@ -90,7 +90,7 @@ export default function ProfileTabsFullScreen ({ orderedAccounts }: Props): Reac
           bgcolor: 'backgroundFL.secondary',
           flexFlow: 'nowrap',
           overflowX: 'scroll',
-          pb: '5px',
+          pb: '6px',
           px: '25px',
           whiteSpace: 'nowrap'
         }}

--- a/packages/extension-polkagate/src/hooks/useAlerts.ts
+++ b/packages/extension-polkagate/src/hooks/useAlerts.ts
@@ -3,20 +3,30 @@
 
 import type { Severity } from '../util/types';
 
-import { useCallback, useContext } from 'react';
+import { Chance } from 'chance';
+import { useCallback, useContext, useMemo } from 'react';
 
 import { AlertContext } from '../components';
+
+export const TIME_TO_REMOVE_ALERT = 5000; // 5 secs
 
 export default function useAlerts () {
   const { alerts, setAlerts } = useContext(AlertContext);
 
-  const notify = useCallback((text: string, severity?: Severity) => {
-    setAlerts((prev) => [...prev, { severity: severity || 'info', text }]);
+  const random = useMemo(() => new Chance(), []);
+
+  const removeAlert = useCallback((idToRemove: string) => {
+    setAlerts((prev) => prev.filter(({ id }) => id !== idToRemove));
   }, [setAlerts]);
 
-  const removeAlert = useCallback((index: number) => {
-    setAlerts((prev) => prev.filter((_, i) => i !== index));
-  }, [setAlerts]);
+  const notify = useCallback((text: string, severity?: Severity) => {
+    const id = random.string({ length: 10 });
+
+    setAlerts((prev) => [...prev, { id, severity: severity || 'info', text }]);
+    const timeout = setTimeout(() => removeAlert(id), TIME_TO_REMOVE_ALERT);
+
+    return () => clearTimeout(timeout);
+  }, [random, removeAlert, setAlerts]);
 
   return { alerts, notify, removeAlert };
 }

--- a/packages/extension-polkagate/src/hooks/useAlerts.ts
+++ b/packages/extension-polkagate/src/hooks/useAlerts.ts
@@ -8,11 +8,15 @@ import { useCallback, useContext } from 'react';
 import { AlertContext } from '../components';
 
 export default function useAlerts () {
-  const { setAlerts } = useContext(AlertContext);
+  const { alerts, setAlerts } = useContext(AlertContext);
 
   const notify = useCallback((text: string, severity?: Severity) => {
     setAlerts((prev) => [...prev, { severity: severity || 'info', text }]);
   }, [setAlerts]);
 
-  return { notify };
+  const removeAlert = useCallback((index: number) => {
+    setAlerts((prev) => prev.filter((_, i) => i !== index));
+  }, [setAlerts]);
+
+  return { alerts, notify, removeAlert };
 }

--- a/packages/extension-polkagate/src/hooks/useAssetsBalances.ts
+++ b/packages/extension-polkagate/src/hooks/useAssetsBalances.ts
@@ -9,6 +9,7 @@ import type { MetadataDef } from '@polkadot/extension-inject/types';
 import type { AlertType, DropdownOption, UserAddedChains } from '../util/types';
 
 import { createAssets } from '@polkagate/apps-config/assets';
+import { Chance } from 'chance';
 import { type Dispatch, type SetStateAction, useCallback, useEffect, useMemo, useState } from 'react';
 
 import { BN, isObject } from '@polkadot/util';
@@ -19,6 +20,7 @@ import { updateMetadata } from '../messaging';
 import { ASSET_HUBS, RELAY_CHAINS_GENESISHASH, TEST_NETS } from '../util/constants';
 import getChainName from '../util/getChainName';
 import { isHexToBn } from '../util/utils';
+import { TIME_TO_REMOVE_ALERT } from './useAlerts';
 import useSelectedChains from './useSelectedChains';
 import { useIsTestnetEnabled, useTranslation } from '.';
 
@@ -135,6 +137,8 @@ export default function useAssetsBalances (accounts: AccountJson[] | null, setAl
   const isTestnetEnabled = useIsTestnetEnabled();
   const selectedChains = useSelectedChains();
 
+  const random = useMemo(() => new Chance(), []);
+
   /** to limit calling of this heavy call on just home and account details */
   const SHOULD_FETCH_ASSETS = window.location.hash === '#/' || window.location.hash.startsWith('#/accountfs');
 
@@ -146,6 +150,15 @@ export default function useAssetsBalances (accounts: AccountJson[] | null, setAl
   const [isWorking, setIsWorking] = useState<boolean>(false);
   const [workersCalled, setWorkersCalled] = useState<Worker[]>();
   const [isUpdate, setIsUpdate] = useState<boolean>(false);
+
+  const addAlert = useCallback(() => {
+    const id = random.string({ length: 10 });
+
+    setAlerts((perv) => [...perv, { id, severity: 'success', text: t('Accounts\' balances updated!') }]);
+    const timeout = setTimeout(() => setAlerts((prev) => prev.filter(({ id: alertId }) => alertId !== id)), TIME_TO_REMOVE_ALERT);
+
+    return () => clearTimeout(timeout);
+  }, [random, setAlerts, t]);
 
   useEffect(() => {
     SHOULD_FETCH_ASSETS && getStorage(ASSETS_NAME_IN_STORAGE, true).then((savedAssets) => {
@@ -207,9 +220,9 @@ export default function useAssetsBalances (accounts: AccountJson[] | null, setAl
     /** when one round fetch is done, we will save fetched assets in storage */
     if (addresses && workersCalled?.length === 0) {
       handleAccountsSaving();
-      setAlerts((perv) => [...perv, { severity: 'success', text: t('Accounts\' balances updated!') }]);
+      addAlert();
     }
-  }, [addresses, handleAccountsSaving, setAlerts, t, workersCalled?.length]);
+  }, [addAlert, addresses, handleAccountsSaving, workersCalled?.length]);
 
   useEffect(() => {
     /** chain list may have changed */

--- a/packages/extension-polkagate/src/partials/Alert.tsx
+++ b/packages/extension-polkagate/src/partials/Alert.tsx
@@ -8,9 +8,9 @@ import '@vaadin/icons';
 import type { AlertType } from '../util/types';
 
 import { Alert as MuiAlert, Slide } from '@mui/material';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback } from 'react';
 
-import { useTranslation } from '../hooks';
+import { useAlerts, useTranslation } from '../hooks';
 
 interface Props {
   alert: AlertType;
@@ -18,21 +18,14 @@ interface Props {
 
 function Alert ({ alert }: Props): React.ReactElement {
   const { t } = useTranslation();
+  const { removeAlert } = useAlerts();
 
-  const [showAlert, setShowAlert] = useState<boolean>(true);
-
-  useEffect(() => {
-    const timeoutId = setTimeout(() => {
-      setShowAlert(false);
-    }, 10000);
-
-    return () => clearTimeout(timeoutId);
-  }, []);
-
-  const closeAlert = useCallback(() => setShowAlert(false), []);
+  const closeAlert = useCallback(() => {
+    removeAlert(alert.id);
+  }, [alert.id, removeAlert]);
 
   return (
-    <Slide direction='left' in={showAlert} mountOnEnter unmountOnExit>
+    <Slide direction='left' in mountOnEnter unmountOnExit>
       <MuiAlert
         onClose={closeAlert}
         severity={alert.severity}

--- a/packages/extension-polkagate/src/partials/AlertBox.tsx
+++ b/packages/extension-polkagate/src/partials/AlertBox.tsx
@@ -6,27 +6,15 @@
 import '@vaadin/icons';
 
 import { Grid } from '@mui/material';
-import React, { useEffect } from 'react';
+import React from 'react';
 
 import { useAlerts, useTransactionState } from '../hooks';
 import Alert from './Alert';
 
-const TIME_TO_REMOVE_ALERT = 5000;
-
 function AlertBox (): React.ReactElement {
-  const { alerts, removeAlert } = useAlerts();
+  const { alerts } = useAlerts();
 
   useTransactionState();
-
-  useEffect(() => {
-    alerts.forEach((_, index) => {
-      const timeout = setTimeout(
-        () => removeAlert(index)
-        , TIME_TO_REMOVE_ALERT);
-
-      return () => clearTimeout(timeout);
-    });
-  }, [alerts, removeAlert]);
 
   return (
     <Grid container display='flex' item justifyContent='flex-end' sx={{ maxWidth: '500px', position: 'absolute', right: '20px', rowGap: '15px', top: '85px', zIndex: 100 }}>

--- a/packages/extension-polkagate/src/partials/AlertBox.tsx
+++ b/packages/extension-polkagate/src/partials/AlertBox.tsx
@@ -6,16 +6,27 @@
 import '@vaadin/icons';
 
 import { Grid } from '@mui/material';
-import React, { useContext } from 'react';
+import React, { useEffect } from 'react';
 
-import { AlertContext } from '../components';
-import { useTransactionState } from '../hooks';
+import { useAlerts, useTransactionState } from '../hooks';
 import Alert from './Alert';
 
+const TIME_TO_REMOVE_ALERT = 5000;
+
 function AlertBox (): React.ReactElement {
-  const { alerts } = useContext(AlertContext);
+  const { alerts, removeAlert } = useAlerts();
 
   useTransactionState();
+
+  useEffect(() => {
+    alerts.forEach((_, index) => {
+      const timeout = setTimeout(
+        () => removeAlert(index)
+        , TIME_TO_REMOVE_ALERT);
+
+      return () => clearTimeout(timeout);
+    });
+  }, [alerts, removeAlert]);
 
   return (
     <Grid container display='flex' item justifyContent='flex-end' sx={{ maxWidth: '500px', position: 'absolute', right: '20px', rowGap: '15px', top: '85px', zIndex: 100 }}>

--- a/packages/extension-polkagate/src/util/types.ts
+++ b/packages/extension-polkagate/src/util/types.ts
@@ -782,6 +782,7 @@ export interface AccountsAssetsContextType {
 export type Severity= 'error' | 'warning' | 'info' | 'success'
 
 export interface AlertType {
+  id: string;
   text: string;
   severity: Severity
 }

--- a/packages/extension/public/locales/en/translation.json
+++ b/packages/extension/public/locales/en/translation.json
@@ -1402,5 +1402,6 @@
   "No information found from this RPC node!": "",
   "Add a new chain": "",
   "Invalid endpoint format!": "",
-  "The chain already exists, no need to add it again!": ""
+  "The chain already exists, no need to add it again!": "",
+  "Click to hide all the profile accounts from websites!": ""
 }


### PR DESCRIPTION
+ removing alerts after shown from context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced alert management with the introduction of a `removeAlert` method for better control over alert visibility.
	- New localization string added to improve user interaction: "Click to hide all the profile accounts from websites!"

- **Bug Fixes**
	- Adjusted the `ProfileTabFullScreen` component to improve the display of contextual tooltips.

- **Style**
	- Minor styling adjustments made to the `ProfileTabsFullScreen` component for improved visual spacing.

- **Refactor**
	- Updated the `useAlerts` hook to provide additional functionality for managing alerts and streamline alert handling in the `AlertBox` component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->