### PR TITLE
fix: asset requested issue while currency is something other than USD

### DIFF
--- a/packages/extension-polkagate/src/fullscreen/governance/post/Metadata.tsx
+++ b/packages/extension-polkagate/src/fullscreen/governance/post/Metadata.tsx
@@ -1,7 +1,6 @@
 // Copyright 2019-2024 @polkadot/extension-polkagate authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-// @ts-nocheck
 /* eslint-disable react/jsx-max-props-per-line */
 
 import type { Chain } from '@polkadot/extension-chains/types';
@@ -22,8 +21,9 @@ import { isValidAddress } from '../../../util/utils';
 import useStyles from '../styles/styles';
 import { LabelValue } from '../TrackStats';
 import { pascalCaseToTitleCase } from '../utils/util';
+import useReferendaRequested from './useReferendaRequested';
 
-export function hexAddressToFormatted(hexString: string, chain: Chain | null | undefined): string | undefined {
+export function hexAddressToFormatted (hexString: string, chain: Chain | null | undefined): string | undefined {
   try {
     if (!chain || !hexString) {
       return undefined;
@@ -74,6 +74,8 @@ export default function Metadata ({ address, decisionDepositPayer, referendum }:
   const theme = useTheme();
   const { api, chain, chainName, decimal, token } = useInfo(address);
   const style = useStyles();
+
+  const { rDecimal, rToken } = useReferendaRequested(address, referendum);
 
   const [expanded, setExpanded] = React.useState(false);
   const [showJson, setShowJson] = React.useState(false);
@@ -181,9 +183,9 @@ export default function Metadata ({ address, decisionDepositPayer, referendum }:
                 style={{ justifyContent: 'flex-start' }}
                 value={<ShowBalance
                   balance={referendum?.call?.args?.['amount'] as string || referendum?.requested}
-                  decimal={referendum?.decimal || decimal}
+                  decimal={rDecimal}
                   decimalPoint={2}
-                  token={referendum?.token || token}
+                  token={rToken}
                 />}
                 valueStyle={{ fontSize: 16, fontWeight: 500 }}
               />

--- a/packages/extension-polkagate/src/fullscreen/governance/post/useReferendaRequested.tsx
+++ b/packages/extension-polkagate/src/fullscreen/governance/post/useReferendaRequested.tsx
@@ -26,21 +26,29 @@ export default function useReferendaRequested (address: string | undefined, refe
   const currency = useCurrency();
 
   const maybeAssetIdInNumber = referendum?.assetId ? Number(referendum.assetId) : undefined;
-  const maybeAssetHubs = referendum?.assetId
-    ? chainName?.includes('Polkadot')
+
+  const maybeAssetHubs = useMemo(() => {
+    if (!referendum?.assetId || !chainName) {
+      return undefined;
+    }
+
+    return chainName.includes('Polkadot')
       ? 'polkadot asset hub'
-      : 'kusama asset hub'
-    : undefined;
+      : chainName.includes('Kusama')
+        ? 'kusama asset hub'
+        : undefined;
+  }, [chainName, referendum?.assetId]);
+
   const priceInfo = useTokenPrice(address, maybeAssetIdInNumber, maybeAssetHubs);
   const _decimal = priceInfo?.decimal || referendum?.decimal || decimal;
   const _token = priceInfo?.token || referendum?.token || token;
 
   return useMemo(() => {
-    if (!referendum?.requested || !currency || !_decimal || !_token || !priceInfo.price || !priceInfo.decimal) {
+    if (!referendum?.requested || !currency || !_decimal || !_token || !priceInfo.price) {
       return DEFAULT_OUTPUT;
     }
 
-    const requestedAssetInCurrency = (Number(referendum.requested) / 10 ** priceInfo.decimal) * priceInfo.price;
+    const requestedAssetInCurrency = (Number(referendum.requested) / 10 ** _decimal) * priceInfo.price;
 
     return {
       rAssetInCurrency: requestedAssetInCurrency,

--- a/packages/extension-polkagate/src/fullscreen/governance/post/useReferendaRequested.tsx
+++ b/packages/extension-polkagate/src/fullscreen/governance/post/useReferendaRequested.tsx
@@ -1,0 +1,52 @@
+// Copyright 2019-2024 @polkadot/extension-polkagate authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Referendum } from '../utils/types';
+
+import { useMemo } from 'react';
+
+import { useCurrency, useInfo, useTokenPrice } from '../../../hooks';
+
+interface ReferendaRequested{
+  rAssetInCurrency: number,
+  rCurrencySign: string,
+  rDecimal: number,
+  rToken: string
+}
+
+const DEFAULT_OUTPUT = {
+  rAssetInCurrency: undefined,
+  rCurrencySign: undefined,
+  rDecimal: undefined,
+  rToken: undefined
+};
+
+export default function useReferendaRequested (address: string | undefined, referendum: Referendum | undefined): ReferendaRequested | typeof DEFAULT_OUTPUT {
+  const { chainName, decimal, token } = useInfo(address);
+  const currency = useCurrency();
+
+  const maybeAssetIdInNumber = referendum?.assetId ? Number(referendum.assetId) : undefined;
+  const maybeAssetHubs = referendum?.assetId
+    ? chainName?.includes('Polkadot')
+      ? 'polkadot asset hub'
+      : 'kusama asset hub'
+    : undefined;
+  const priceInfo = useTokenPrice(address, maybeAssetIdInNumber, maybeAssetHubs);
+  const _decimal = priceInfo?.decimal || referendum?.decimal || decimal;
+  const _token = priceInfo?.token || referendum?.token || token;
+
+  return useMemo(() => {
+    if (!referendum?.requested || !currency || !_decimal || !_token || !priceInfo.price || !priceInfo.decimal) {
+      return DEFAULT_OUTPUT;
+    }
+
+    const requestedAssetInCurrency = (Number(referendum.requested) / 10 ** priceInfo.decimal) * priceInfo.price;
+
+    return {
+      rAssetInCurrency: requestedAssetInCurrency,
+      rCurrencySign: currency.sign,
+      rDecimal: _decimal,
+      rToken: _token
+    };
+  }, [_decimal, _token, currency, priceInfo, referendum?.requested]);
+}

--- a/packages/extension-polkagate/src/util/types.ts
+++ b/packages/extension-polkagate/src/util/types.ts
@@ -614,6 +614,8 @@ export interface PricesInCurrencies {
 
 export interface Price {
   price: number;
+  decimal: number;
+  token: string;
   priceChainName: string;
   priceDate: number;
 }


### PR DESCRIPTION
closes #1588

![Screenshot 2024-10-22 at 12 11 15](https://github.com/user-attachments/assets/a055b9ca-a355-490e-9693-e0d82f53e36e)

![Screenshot 2024-10-22 at 12 12 01](https://github.com/user-attachments/assets/6c222947-1c94-4400-9d52-eb20bbb4eae6)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new custom hook, `useReferendaRequested`, for improved management of referendum-related data.
	- Enhanced `Metadata` and `ReferendumDescription` components to utilize the new hook for better clarity in displaying asset and currency information.

- **Bug Fixes**
	- Streamlined the logic for displaying requested amounts by removing deprecated calculations and dependencies.

- **Documentation**
	- Updated interfaces to include additional properties for more detailed price information.

- **Refactor**
	- Reorganized state management within components to improve maintainability and performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->