### PR TITLE
fix: staking balances get undefined in useBalances

### DIFF
--- a/packages/extension-polkagate/src/hooks/useNativeAssetBalances.ts
+++ b/packages/extension-polkagate/src/hooks/useNativeAssetBalances.ts
@@ -17,7 +17,7 @@ import { decodeMultiLocation } from '../util/utils';
 import { useInfo, useStakingAccount } from '.';
 
 export default function useNativeAssetBalances (address: string | undefined, refresh?: boolean, setRefresh?: React.Dispatch<React.SetStateAction<boolean>>, onlyNew = false): BalancesInfo | undefined {
-  const stakingAccount = useStakingAccount(address);
+  const stakingAccount = useStakingAccount(address, undefined, undefined, undefined, onlyNew);
   const { account, api, chainName, decimal: currentDecimal, formatted, genesisHash, token: currentToken } = useInfo(address);
   const isFetching = useContext(FetchingContext);
 
@@ -51,6 +51,8 @@ export default function useNativeAssetBalances (address: string | undefined, ref
           decimal,
           frozenBalance,
           genesisHash: api.genesisHash.toString(),
+          pooledBalance: balances?.pooledBalance, // fill from saved balance it exists, it will be updated
+          soloTotal: stakingAccount?.stakingLedger?.total as unknown as BN,
           token
         });
         setRefresh?.(false);
@@ -58,8 +60,8 @@ export default function useNativeAssetBalances (address: string | undefined, ref
         isFetching.set(isFetching.fetching);
       }).catch(console.error);
     }).catch(console.error);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [api, genesisHash, chainName, formatted, isFetching.fetching[String(formatted)]?.['length'], setRefresh]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [api, genesisHash, chainName, decimal, stakingAccount, token, isFetchingNativeTokenOfAssetHub, balances, formatted, isFetching.fetching[String(formatted)]?.['length'], setRefresh]);
 
   useEffect(() => {
     if (!formatted || !token || !decimal || !chainName || api?.genesisHash?.toString() !== genesisHash) {
@@ -144,7 +146,7 @@ export default function useNativeAssetBalances (address: string | undefined, ref
 
     setBalances(undefined);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [Object.keys(account ?? {})?.length, address, chainName, stakingAccount]);
+  }, [Object.keys(account ?? {})?.length, address, chainName, stakingAccount, genesisHash]);
 
   if (onlyNew) {
     return newBalances; // returns balances that have been fetched recently and are not from the local storage, and it does not include the pooledBalance

--- a/packages/extension-polkagate/src/popup/account/index.tsx
+++ b/packages/extension-polkagate/src/popup/account/index.tsx
@@ -10,7 +10,7 @@
  * */
 
 import type { HexString } from '@polkadot/util/types';
-import type { BalancesInfo, FormattedAddressState } from '../../util/types';
+import type { FormattedAddressState } from '../../util/types';
 
 import { faCoins, faHistory, faPaperPlane, faPiggyBank, faVoteYea } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -59,8 +59,6 @@ export default function AccountDetails (): React.ReactElement {
     balances?.soloTotal && balances?.pooledBalance && !balances.soloTotal.isZero() && !balances.pooledBalance.isZero()
   , [balances?.pooledBalance, balances?.soloTotal]);
 
-  console.log('balances:', balances && JSON.parse(JSON.stringify(balances)))
-  
   const gotToHome = useCallback(() => {
     if (showStakingOptions) {
       return setShowStakingOptions(false);

--- a/packages/extension-polkagate/src/popup/account/index.tsx
+++ b/packages/extension-polkagate/src/popup/account/index.tsx
@@ -49,7 +49,6 @@ export default function AccountDetails (): React.ReactElement {
   const [refresh, setRefresh] = useState<boolean>(false);
   const [assetId, setAssetId] = useState<number>();
   const balances = useBalances(address, refresh, setRefresh, false, assetId); // if assetId is undefined and chain is assethub it will fetch native token's balance
-  const [balanceToShow, setBalanceToShow] = useState<BalancesInfo>();
   const [showOthers, setShowOthers] = useState<boolean | undefined>(false);
   const [showReservedReasons, setShowReservedReasons] = useState<boolean | undefined>(false);
   const [showStakingOptions, setShowStakingOptions] = useState<boolean>(false);
@@ -57,9 +56,11 @@ export default function AccountDetails (): React.ReactElement {
   const showReservedChevron = useMemo(() => balances && !balances?.reservedBalance.isZero() && isOnRelayChain(genesisHash), [balances, genesisHash]);
   const supportStaking = useMemo(() => STAKING_CHAINS.includes(genesisHash ?? ''), [genesisHash]);
   const isDualStaking = useMemo(() =>
-    balanceToShow?.soloTotal && balanceToShow?.pooledBalance && !balanceToShow.soloTotal.isZero() && !balanceToShow.pooledBalance.isZero()
-  , [balanceToShow?.pooledBalance, balanceToShow?.soloTotal]);
+    balances?.soloTotal && balances?.pooledBalance && !balances.soloTotal.isZero() && !balances.pooledBalance.isZero()
+  , [balances?.pooledBalance, balances?.soloTotal]);
 
+  console.log('balances:', balances && JSON.parse(JSON.stringify(balances)))
+  
   const gotToHome = useCallback(() => {
     if (showStakingOptions) {
       return setShowStakingOptions(false);
@@ -71,14 +72,6 @@ export default function AccountDetails (): React.ReactElement {
   const goToAccount = useCallback(() => {
     chain?.genesisHash && onAction(`/account/${chain.genesisHash}/${address}/`);
   }, [address, chain, onAction]);
-
-  useEffect(() => {
-    if (balances?.chainName === chainName) {
-      return setBalanceToShow(balances);
-    }
-
-    setBalanceToShow(undefined);
-  }, [balances, chainName]);
 
   useEffect(() => {
     chain && goToAccount();
@@ -212,12 +205,12 @@ export default function AccountDetails (): React.ReactElement {
           ? <Grid item pt='10px' sx={{ height: window.innerHeight - 208, overflowY: 'scroll' }} xs>
             {assetId !== undefined
               ? <>
-                <LabelBalancePrice address={address} balances={balanceToShow} label={'Transferable'} title={t('Transferable')} />
+                <LabelBalancePrice address={address} balances={balances} label={'Transferable'} title={t('Transferable')} />
                 {balances?.lockedBalance &&
-                  <LabelBalancePrice address={address} balances={balanceToShow} label={'Locked'} title={t('Locked')} />
+                  <LabelBalancePrice address={address} balances={balances} label={'Locked'} title={t('Locked')} />
                 }
                 {balances?.reservedBalance && !balances?.lockedBalance &&
-                  <LabelBalancePrice address={address} balances={balanceToShow} label={'Reserved'} title={t('Reserved')} />
+                  <LabelBalancePrice address={address} balances={balances} label={'Reserved'} title={t('Reserved')} />
                 }
               </>
               : <>
@@ -233,27 +226,27 @@ export default function AccountDetails (): React.ReactElement {
                     </Warning>
                   </Grid>
                 }
-                <LabelBalancePrice address={address} balances={balanceToShow} label={'Total'} title={t('Total')} />
-                <LabelBalancePrice address={address} balances={balanceToShow} label={'Transferable'} onClick={goToSend} title={t('Transferable')} />
+                <LabelBalancePrice address={address} balances={balances} label={'Total'} title={t('Total')} />
+                <LabelBalancePrice address={address} balances={balances} label={'Transferable'} onClick={goToSend} title={t('Transferable')} />
                 {supportStaking &&
                  <>
-                   {!balanceToShow?.soloTotal?.isZero() &&
-                      <LabelBalancePrice address={address} balances={balanceToShow} label={'Solo Stake'} onClick={goToSoloStaking} title={t('Solo Stake')} />}
-                   {!balanceToShow?.pooledBalance?.isZero() &&
-                      <LabelBalancePrice address={address} balances={balanceToShow} label={'Pool Stake'} onClick={goToPoolStaking} title={t('Pool Stake')} />
+                   {balances?.soloTotal && !balances?.soloTotal?.isZero() &&
+                      <LabelBalancePrice address={address} balances={balances} label={'Solo Stake'} onClick={goToSoloStaking} title={t('Solo Stake')} />}
+                   {balances?.pooledBalance && !balances?.pooledBalance?.isZero() &&
+                      <LabelBalancePrice address={address} balances={balances} label={'Pool Stake'} onClick={goToPoolStaking} title={t('Pool Stake')} />
                    }
                  </>
                 }
                 {GOVERNANCE_CHAINS.includes(genesisHash)
                   ? <LockedInReferenda address={address} refresh={refresh} setRefresh={setRefresh} />
-                  : <LabelBalancePrice address={address} balances={balanceToShow} label={'Locked'} title={t('Locked')} />
+                  : <LabelBalancePrice address={address} balances={balances} label={'Locked'} title={t('Locked')} />
                 }
-                <LabelBalancePrice address={address} balances={balanceToShow} label={'Reserved'} onClick={showReservedChevron ? onReservedReasons : undefined} title={t('Reserved')} />
+                <LabelBalancePrice address={address} balances={balances} label={'Reserved'} onClick={showReservedChevron ? onReservedReasons : undefined} title={t('Reserved')} />
                 <OthersRow />
               </>
             }
           </Grid>
-          : <StakingOption balance={balanceToShow} setShowStakingOptions={setShowStakingOptions} showStakingOptions={showStakingOptions} />
+          : <StakingOption balance={balances} setShowStakingOptions={setShowStakingOptions} showStakingOptions={showStakingOptions} />
         }
         <Grid container justifyContent='space-around' sx={{ bgcolor: 'background.default', borderTop: '2px solid', borderTopColor: 'secondary.main', bottom: 0, height: '62px', left: '4%', position: 'absolute', pt: '7px', pb: '5px', width: '92%' }}>
           <HorizontalMenuItem


### PR DESCRIPTION
Since `useBalances` fetches new data, it does not incorporate staking values. As a result, we observe a hide/show effect for those amounts in the extension mode account details

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced balance tracking with improved handling of staking account data.
	- Added new properties to balance information for better insights.

- **Bug Fixes**
	- Streamlined balance management in the `AccountDetails` component, reducing potential discrepancies.

- **Refactor**
	- Simplified logic in balance hooks and components by removing unnecessary state and dependencies. 

- **Documentation**
	- Updated comments to clarify the handling of native assets and balance conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->