### PR TITLE
fix: disable manage validators if the account is already a validator

### DIFF
--- a/packages/extension-polkagate/src/fullscreen/stake/solo/StakedSolo.tsx
+++ b/packages/extension-polkagate/src/fullscreen/stake/solo/StakedSolo.tsx
@@ -1,8 +1,10 @@
 // Copyright 2019-2024 @polkadot/extension-polkagate authors & contributors
 // SPDX-License-Identifier: Apache-2.0
-// @ts-nocheck
 
 /* eslint-disable react/jsx-max-props-per-line */
+
+import type { AccountStakingInfo, BalancesInfo } from '@polkadot/extension-polkagate/src/util/types';
+import type { BN } from '@polkadot/util';
 
 import { faArrowRotateLeft, faBolt, faCircleDown, faClockFour, faMinus, faPlus } from '@fortawesome/free-solid-svg-icons';
 import { Boy as BoyIcon } from '@mui/icons-material';
@@ -10,10 +12,7 @@ import { Grid } from '@mui/material';
 import React, { useCallback, useMemo } from 'react';
 import { useParams } from 'react-router';
 
-import type { AccountStakingInfo, BalancesInfo } from '@polkadot/extension-polkagate/src/util/types';
-import { BN } from '@polkadot/util';
-
-import { useAvailableToSoloStake, useStakingRewardDestinationAddress, useStakingRewards, useTranslation, useUnstakingAmount, useUnSupportedNetwork } from '../../../hooks';
+import { useAvailableToSoloStake, useIsValidator, useStakingRewardDestinationAddress, useStakingRewards, useTranslation, useUnstakingAmount, useUnSupportedNetwork } from '../../../hooks';
 import { STAKING_CHAINS } from '../../../util/constants';
 import Bread from '../../partials/Bread';
 import { Title } from '../../sendFund/InputPage';
@@ -33,11 +32,12 @@ interface Props {
   balances: BalancesInfo | undefined
 }
 
-export default function StakedSolo({ balances, refresh, setRefresh, setShow, stakingAccount }: Props): React.ReactElement {
+export default function StakedSolo ({ balances, refresh, setRefresh, setShow, stakingAccount }: Props): React.ReactElement {
   const { t } = useTranslation();
   const { address } = useParams<{ address: string }>();
 
   useUnSupportedNetwork(address, STAKING_CHAINS);
+  const isValidator = useIsValidator(address);
 
   const availableToSoloStake = useAvailableToSoloStake(address, refresh);
   const { toBeReleased, unlockingAmount } = useUnstakingAmount(address, refresh);
@@ -149,9 +149,11 @@ export default function StakedSolo({ balances, refresh, setRefresh, setShow, sta
           />
           <ActiveValidators
             address={address}
+            isValidator={isValidator}
           />
           <CommonTasks
             address={address}
+            isValidator={isValidator}
             setRefresh={setRefresh}
             staked={staked}
           />

--- a/packages/extension-polkagate/src/fullscreen/stake/solo/partials/ActiveValidators.tsx
+++ b/packages/extension-polkagate/src/fullscreen/stake/solo/partials/ActiveValidators.tsx
@@ -13,18 +13,19 @@ import { ArrowDropDown as ArrowDropDownIcon } from '@mui/icons-material';
 import { Collapse, Divider, Grid, Skeleton, Typography, useTheme } from '@mui/material';
 import React, { useCallback, useState } from 'react';
 
-import { useActiveValidators, useInfo, useIsValidator, useStakingConsts, useTranslation } from '../../../../hooks';
+import { useActiveValidators, useInfo, useStakingConsts, useTranslation } from '../../../../hooks';
 import ShowValidator from './ShowValidator';
 
 interface Props {
   address?: string;
+  isValidator: boolean | null | undefined
+
 }
 
-export default function ActiveValidators ({ address }: Props): React.ReactElement {
+export default function ActiveValidators ({ address, isValidator }: Props): React.ReactElement {
   const { t } = useTranslation();
   const theme = useTheme();
   const { api, chain, decimal, token } = useInfo(address);
-  const isValidator = useIsValidator(address);
 
   const { activeValidators, nonActiveValidators } = useActiveValidators(address);
   const stakingConsts = useStakingConsts(address);

--- a/packages/extension-polkagate/src/fullscreen/stake/solo/partials/CommonTasks.tsx
+++ b/packages/extension-polkagate/src/fullscreen/stake/solo/partials/CommonTasks.tsx
@@ -19,10 +19,10 @@ interface Props {
   address: string | undefined;
   setRefresh: React.Dispatch<React.SetStateAction<boolean>>;
   staked: BN | undefined;
-
+  isValidator: boolean | null | undefined
 }
 
-export default function CommonTasks ({ address, setRefresh, staked }: Props): React.ReactElement {
+export default function CommonTasks ({ address, isValidator, setRefresh, staked }: Props): React.ReactElement {
   const { t } = useTranslation();
   const theme = useTheme();
   const { genesisHash } = useInfo(address);
@@ -77,11 +77,11 @@ export default function CommonTasks ({ address, setRefresh, staked }: Props): Re
             text={t('Configure Reward Destination')}
           />
           <TaskButton
-            disabled={isDisabled}
+            disabled={isDisabled || isValidator === true }
             icon={
               <FontAwesomeIcon
-                bounce={!!stakedButNoValidators}
-                color={stakedButNoValidators ? `${theme.palette.warning.main}` : `${iconColor}`}
+                bounce={!!stakedButNoValidators && !isValidator}
+                color={stakedButNoValidators && !isValidator ? `${theme.palette.warning.main}` : `${iconColor}`}
                 fontSize='22px'
                 icon={faHand}
               />


### PR DESCRIPTION
![Screenshot 2024-11-09 at 12 28 47](https://github.com/user-attachments/assets/611d17bb-ce78-4767-8071-ac279c1ea3b8)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - The `StakedSolo` component now includes validator status checks, enhancing the user experience by providing relevant information about account validation.
  - The `ActiveValidators` and `CommonTasks` components have been updated to utilize the new validator status prop, improving rendering logic and user feedback.

- **Bug Fixes**
  - Adjusted button states and visual feedback in `CommonTasks` based on the validator status, ensuring accurate representation of user actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->