### PR TITLE
fix: transient label of selected profile name

### DIFF
--- a/packages/extension-polkagate/src/hooks/useSelectedProfile.tsx
+++ b/packages/extension-polkagate/src/hooks/useSelectedProfile.tsx
@@ -5,14 +5,14 @@ import { useEffect, useState } from 'react';
 
 import { getStorage, watchStorage } from '../components/Loading';
 
-export default function useSelectedProfile (): string | undefined {
-  const [selectedProfile, setSelectedProfile] = useState<string>();
+export default function useSelectedProfile (): string | undefined | null {
+  const [selectedProfile, setSelectedProfile] = useState<string | null>();
 
   useEffect(() => {
     /** set profile text in local storage and watch its change to apply on the UI */
     getStorage('profile')
       .then((res) => {
-        setSelectedProfile(res as string);
+        setSelectedProfile(res as string | undefined ?? null);
       })
       .catch(console.error);
 

--- a/packages/extension-polkagate/src/popup/home/AccountLabel.tsx
+++ b/packages/extension-polkagate/src/popup/home/AccountLabel.tsx
@@ -73,6 +73,10 @@ export function AccountLabel ({ account, ml, parentName }: Props): React.ReactEl
   const profiles = useMemo(() => {
     const profileSet = new Set(accountProfiles);
 
+    if (selectedProfile === undefined) {
+      return [];
+    }
+
     if (maybeAccountDefaultProfile) {
       profileSet.add(maybeAccountDefaultProfile);
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced profile selection handling by allowing for a `null` state in the profile management.
	- Improved the `AccountLabel` component to prevent displaying profiles when no profile is selected.

- **Bug Fixes**
	- Added a safeguard to ensure the profiles array is empty if no profile is selected, enhancing the component's reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->