### PR TITLE
feat: add support for pool migration

### DIFF
--- a/packages/extension-polkagate/src/fullscreen/governance/delegate/partial/AlreadyLockedTooltipText.tsx
+++ b/packages/extension-polkagate/src/fullscreen/governance/delegate/partial/AlreadyLockedTooltipText.tsx
@@ -1,18 +1,19 @@
-// Copyright 2019-2024 @polkadot/extension-polkagate authors & contributors
+// Copyright 2019-2025 @polkadot/extension-polkagate authors & contributors
 // SPDX-License-Identifier: Apache-2.0
-// @ts-nocheck
 
 /* eslint-disable react/jsx-max-props-per-line */
+// @ts-nocheck
 
-import type { DeriveBalancesAll } from '@polkadot/api-derive/types';
+import type { BalancesInfo } from '@polkadot/extension-polkagate/util/types';
+import type { BN } from '@polkadot/util';
+import type { Lock } from '../../../../hooks/useAccountLocks';
 
-import { Grid, Skeleton, Typography } from '@mui/material';
+import { Grid, Typography } from '@mui/material';
 import React from 'react';
 
-import { BN, BN_MAX_INTEGER } from '@polkadot/util';
+import { BN_MAX_INTEGER } from '@polkadot/util';
 
 import { useCurrentBlockNumber, useDecimal, useToken, useTranslation } from '../../../../hooks';
-import { Lock } from '../../../../hooks/useAccountLocks';
 import { amountToHuman, remainingTime } from '../../../../util/utils';
 
 interface Props {
@@ -20,7 +21,7 @@ interface Props {
   accountLocks: Lock[] | undefined
 }
 
-export function getAlreadyLockedValue(allBalances: DeriveBalancesAll | undefined): BN | undefined {
+export function getAlreadyLockedValue (allBalances: BalancesInfo | undefined): BN | undefined {
   const LOCKS_ORDERED = ['pyconvot', 'democrac', 'phrelect'];
   const sortedLocks = allBalances?.lockedBreakdown
     // first sort by amount, so greatest value first
@@ -30,6 +31,7 @@ export function getAlreadyLockedValue(allBalances: DeriveBalancesAll | undefined
     // then sort by the type of lock (we try to find relevant)
     .sort((a, b): number => {
       if (!a.id.eq(b.id)) {
+        // eslint-disable-next-line @typescript-eslint/prefer-for-of
         for (let i = 0; i < LOCKS_ORDERED.length; i++) {
           const lockName = LOCKS_ORDERED[i];
 
@@ -48,7 +50,7 @@ export function getAlreadyLockedValue(allBalances: DeriveBalancesAll | undefined
   return sortedLocks?.[0] || allBalances?.lockedBalance;
 }
 
-function AlreadyLockedTooltipText({ accountLocks, address }: Props): React.ReactElement {
+function AlreadyLockedTooltipText ({ accountLocks, address }: Props): React.ReactElement {
   const { t } = useTranslation();
   const currentBlock = useCurrentBlockNumber(address);
   const token = useToken(address);
@@ -80,7 +82,7 @@ function AlreadyLockedTooltipText({ accountLocks, address }: Props): React.React
         {currentBlock && accountLocks?.map((lock, index) => (
           <React.Fragment key={index}>
             <Grid item xs={2.5}>
-              {lock.refId.toNumber()}
+              {lock.refId?.toNumber()}
             </Grid>
             <Grid item xs={3.6}>
               {amountToHuman(lock.total, decimal)} {token}

--- a/packages/extension-polkagate/src/fullscreen/manageIdentity/Review.tsx
+++ b/packages/extension-polkagate/src/fullscreen/manageIdentity/Review.tsx
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 @polkadot/extension-polkagate authors & contributors
+// Copyright 2019-2025 @polkadot/extension-polkagate authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
 /* eslint-disable react/jsx-max-props-per-line */
@@ -76,7 +76,7 @@ export default function Review ({ address, api, chain, depositToPay, depositValu
 
   useEffect(() => {
     formatted && api?.derive.balances?.all(formatted).then((b) => {
-      setBalances(b as BalancesInfo);
+      setBalances(b as unknown as BalancesInfo);
     });
   }, [api, formatted]);
 

--- a/packages/extension-polkagate/src/hooks/useNativeAssetBalances.ts
+++ b/packages/extension-polkagate/src/hooks/useNativeAssetBalances.ts
@@ -1,7 +1,8 @@
-// Copyright 2019-2024 @polkadot/extension-polkagate authors & contributors
+// Copyright 2019-2025 @polkadot/extension-polkagate authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
 import type React from 'react';
+import type { Balance } from '@polkadot/types/interfaces';
 //@ts-ignore
 import type { FrameSystemAccountInfo } from '@polkadot/types/lookup';
 import type { HexString } from '@polkadot/util/types';
@@ -42,6 +43,8 @@ export default function useNativeAssetBalances (address: string | undefined, ref
         // some chains such as PARALLEL does not support this call hence BN_ZERO is set for them
         const frozenBalance = systemBalance?.frozen || BN_ZERO;
 
+        const votingBalance = api.createType('Balance', allBalances.freeBalance.add(allBalances.reservedBalance)) as unknown as Balance;
+
         setNewBalances({
           ED,
           assetId: isFetchingNativeTokenOfAssetHub ? NATIVE_TOKEN_ASSET_ID_ON_ASSETHUB : NATIVE_TOKEN_ASSET_ID,
@@ -53,7 +56,8 @@ export default function useNativeAssetBalances (address: string | undefined, ref
           genesisHash: api.genesisHash.toString(),
           pooledBalance: balances?.pooledBalance, // fill from saved balance it exists, it will be updated
           soloTotal: stakingAccount?.stakingLedger?.total as unknown as BN,
-          token
+          token,
+          votingBalance // since api derive does not updated after pools migration
         });
         setRefresh?.(false);
         isFetching.fetching[String(formatted)]['balances'] = false;

--- a/packages/extension-polkagate/src/hooks/useReservedDetails.ts
+++ b/packages/extension-polkagate/src/hooks/useReservedDetails.ts
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 @polkadot/extension-polkagate authors & contributors
+// Copyright 2019-2025 @polkadot/extension-polkagate authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
 // @ts-nocheck
@@ -13,17 +13,23 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { BN_ZERO } from '@polkadot/util';
 
-import { PROXY_CHAINS } from '../util/constants';
+import { MIGRATED_NOMINATION_POOLS_CHAINS, PROXY_CHAINS } from '../util/constants';
 import useActiveRecoveries from './useActiveRecoveries';
-import { useInfo } from '.';
+import { useAccountAssets, useInfo } from '.';
 
-type Item = 'identity' | 'proxy' | 'bounty' | 'recovery' | 'referenda' | 'index' | 'society' | 'multisig' | 'preimage';
+type Item = 'identity' | 'proxy' | 'bounty' | 'recovery' | 'referenda' | 'index' | 'society' | 'multisig' | 'preimage' | 'pooledBalance';
 export type Reserved = { [key in Item]?: Balance };
 
 export default function useReservedDetails (address: string | undefined): Reserved {
   const { api, formatted, genesisHash } = useInfo(address);
   const activeRecoveries = useActiveRecoveries(api);
+  const accountAssets = useAccountAssets(address);
+
   const [reserved, setReserved] = useState<Reserved>({});
+
+  const maybePooledBalance = useMemo(() =>
+    accountAssets?.find((balance) => balance.genesisHash === genesisHash)?.pooledBalance
+  , [accountAssets, genesisHash]);
 
   const activeLost = useMemo(() =>
     activeRecoveries && formatted
@@ -274,10 +280,21 @@ export default function useReservedDetails (address: string | undefined): Reserv
           }
         }).catch(console.error);
       }
+
+      /** handle pooleBalance as reserved  */
+      if (maybePooledBalance && MIGRATED_NOMINATION_POOLS_CHAINS.includes(genesisHash)) {
+        if (!maybePooledBalance.isZero()) {
+          setReserved((prev) => {
+            prev.pooledBalance = toBalance(maybePooledBalance);
+
+            return prev;
+          });
+        }
+      }
     } catch (e) {
-      console.error('Fatal error while fetching reserved details:', e)
+      console.error('Fatal error while fetching reserved details:', e);
     }
-  }, [activeLost?.deposit, api, formatted, genesisHash, toBalance]);
+  }, [activeLost?.deposit, api, formatted, genesisHash, maybePooledBalance, toBalance]);
 
   useEffect(() => {
     setReserved({});

--- a/packages/extension-polkagate/src/popup/account/util.ts
+++ b/packages/extension-polkagate/src/popup/account/util.ts
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 @polkadot/extension-polkagate authors & contributors
+// Copyright 2019-2025 @polkadot/extension-polkagate authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
 /**
@@ -9,6 +9,8 @@
 import type { BalancesInfo } from '../../util/types';
 
 import { BN, BN_ZERO, bnMax } from '@polkadot/util';
+
+import { MIGRATED_NOMINATION_POOLS_CHAINS } from '../../util/constants';
 
 function isEmptyObject (obj: object): boolean {
   return Object.keys(obj).length === 0;
@@ -22,8 +24,11 @@ export const getValue = (type: string, balances: BalancesInfo | null | undefined
   switch (type.toLocaleLowerCase()) {
     case ('total'):
     case ('total balance'):
+      // eslint-disable-next-line no-case-declarations
+      const isPoolsMigrated = MIGRATED_NOMINATION_POOLS_CHAINS.includes(balances.genesisHash);
+
       return balances?.freeBalance && balances.reservedBalance
-        ? new BN(balances.freeBalance).add(new BN(balances.reservedBalance)).add(balances?.pooledBalance ? new BN(balances.pooledBalance) : BN_ZERO)
+        ? new BN(balances.freeBalance).add(new BN(balances.reservedBalance)).add((balances?.pooledBalance && !isPoolsMigrated) ? new BN(balances.pooledBalance) : BN_ZERO)
         : new BN(balances?.totalBalance || 0);
     case ('pooled balance'):
     case ('pool stake'):

--- a/packages/extension-polkagate/src/popup/home/news.ts
+++ b/packages/extension-polkagate/src/popup/home/news.ts
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 @polkadot/extension-polkagate authors & contributors
+// Copyright 2019-2025 @polkadot/extension-polkagate authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
 /* eslint-disable sort-keys */
@@ -9,6 +9,12 @@ export interface News {
 }
 
 export const news: News[] = [
+  {
+    version: '0.34.1',
+    notes: [
+      'Added support for pool migration, allowing users to vote on governance using their staked funds in pools on Kusama.'
+    ]
+  },
   {
     version: '0.34.0',
     notes: [

--- a/packages/extension-polkagate/src/popup/home/news.ts
+++ b/packages/extension-polkagate/src/popup/home/news.ts
@@ -12,7 +12,8 @@ export const news: News[] = [
   {
     version: '0.34.1',
     notes: [
-      'Added support for pool migration, allowing users to vote on governance using their staked funds in pools on Kusama.'
+      'Added support for pool migration, allowing users to vote on governance using their staked funds in pools on Kusama.',
+      'PolkaGate is getting a complete new look, so stay tuned for the upcoming update!'
     ]
   },
   {

--- a/packages/extension-polkagate/src/util/constants.tsx
+++ b/packages/extension-polkagate/src/util/constants.tsx
@@ -1,4 +1,4 @@
-// Copyright 2019-2024 @polkadot/extension-polkagate authors & contributors
+// Copyright 2019-2025 @polkadot/extension-polkagate authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
 import type { ProxyTypes } from './types';
@@ -53,7 +53,6 @@ export const POLKADOT_PEOPLE_GENESIS_HASH = '0x67fa177a097bfa18f77ea95ab56e9bcdf
 export const KUSAMA_PEOPLE_GENESIS_HASH = '0xc1af4cb4eb3918e5db15086c0cc5ec17fb334f728b7c65dd44bfe1e174ff8b3f';
 export const WESTEND_PEOPLE_GENESIS_HASH = '0x1eb6fb0ba5187434de017a70cb84d4f47142df1d571d0ef9e7e1407f2b80b93c';
 
-
 /** relay chains info */
 export const RELAY_CHAINS_NAMES = ['Polkadot', 'Kusama', 'Westend', 'Paseo'];
 
@@ -61,6 +60,8 @@ export const POLKADOT_GENESIS_HASH = '0x91b171bb158e2d3848fa23a9f1c25182fb8e2031
 export const KUSAMA_GENESIS_HASH = '0xb0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe';
 export const WESTEND_GENESIS_HASH = '0xe143f23803ac50e8f6f8e62695d1ce9e4e1d68aa36c1cd2cfd15340213f3423e';
 export const PASEO_GENESIS_HASH = '0x77afd6190f1554ad45fd0d31aee62aacc33c6db0ea801129acb813f913e0764f';
+
+export const MIGRATED_NOMINATION_POOLS_CHAINS = [WESTEND_GENESIS_HASH, KUSAMA_GENESIS_HASH];
 
 export const RELAY_CHAINS_GENESISHASH = [
   POLKADOT_GENESIS_HASH,

--- a/packages/extension-polkagate/src/util/types.ts
+++ b/packages/extension-polkagate/src/util/types.ts
@@ -1,5 +1,7 @@
-// Copyright 2019-2024 @polkadot/extension-polkagate authors & contributors
+// Copyright 2019-2025 @polkadot/extension-polkagate authors & contributors
 // SPDX-License-Identifier: Apache-2.0
+
+/* eslint-disable @typescript-eslint/consistent-indexed-object-style */
 
 import type { LinkOption } from '@polkagate/apps-config/endpoints/types';
 import type React from 'react';
@@ -683,6 +685,7 @@ export interface BalancesInfo extends DeriveBalancesAll {
   decimal: number;
   genesisHash: string;
   pooledBalance?: BN;
+  votingBalance: Balance;
   frozenBalance: BN;
   soloTotal?: BN;
   token: string;

--- a/packages/extension-polkagate/src/util/workers/shared-helpers/getAssetOnRelayChain.js
+++ b/packages/extension-polkagate/src/util/workers/shared-helpers/getAssetOnRelayChain.js
@@ -1,7 +1,9 @@
-// Copyright 2019-2024 @polkadot/extension-polkagate authors & contributors
+// Copyright 2019-2025 @polkadot/extension-polkagate authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { NATIVE_TOKEN_ASSET_ID, TEST_NETS } from '../../constants';
+import { BN_ZERO } from '@polkadot/util';
+
+import { MIGRATED_NOMINATION_POOLS_CHAINS, NATIVE_TOKEN_ASSET_ID, TEST_NETS } from '../../constants';
 import { getPriceIdByChainName } from '../../utils';
 import { balancify, closeWebsockets } from '../utils';
 import { getBalances } from './getBalances.js';
@@ -23,8 +25,9 @@ export async function getAssetOnRelayChain (addresses, chainName, userAddedEndpo
     }
 
     balanceInfo.forEach(({ address, balances, pooledBalance, soloTotal }) => {
-      const totalBalance = balances.freeBalance.add(balances.reservedBalance).add(pooledBalance);
       const genesisHash = api.genesisHash.toString();
+      const isMigrated = MIGRATED_NOMINATION_POOLS_CHAINS.includes(genesisHash);
+      const totalBalance = balances.freeBalance.add(balances.reservedBalance).add(isMigrated ? BN_ZERO : pooledBalance);
 
       const priceId = TEST_NETS.includes(genesisHash)
         ? undefined

--- a/packages/extension-polkagate/src/util/workers/utils/balancify.js
+++ b/packages/extension-polkagate/src/util/workers/utils/balancify.js
@@ -1,7 +1,9 @@
-// Copyright 2019-2024 @polkadot/extension-polkagate authors & contributors
+// Copyright 2019-2025 @polkadot/extension-polkagate authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
 // @ts-nocheck
+import { BN_ZERO } from '@polkadot/util';
+
 
 export function balancify (balances) {
   const base = {
@@ -14,7 +16,8 @@ export function balancify (balances) {
     vestedClaimable: String(balances.vestedClaimable),
     vestingLocked: String(balances.vestingLocked),
     vestingTotal: String(balances.vestingTotal),
-    votingBalance: String(balances.votingBalance)
+    // votingBalance: String(balances.votingBalance)
+    votingBalance: String(balances.free.add(balances?.reserved || BN_ZERO)) // after pool migration the voting balance returned fro api is not correct
   };
 
   if (balances.soloTotal) {


### PR DESCRIPTION
Pooled balance is part of reserved on kusama and westend, hence no need to add them to total balance anymore.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - **Pool Migration Support:** Users can now vote on governance using staked funds from their pools.
  - **Enhanced Balance Integration:** The system now computes and displays asset balances more accurately, ensuring that all eligible staked funds are correctly reflected.
  - **Release News Update:** The latest version highlights these improvements along with additional optimizations for improved responsiveness during balance updates.
  - **Pooled Balance Handling:** The application now includes support for a new type of balance, enhancing the overall balance management functionality.
  - **Voting Balance Calculation:** The application now includes a new voting balance that sums free and reserved balances for improved accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->