### PR TITLE
feat: add fullscreenURL in staking popup pages, fix some issues

### DIFF
--- a/packages/extension-polkagate/src/popup/staking/pool-new/Info.tsx
+++ b/packages/extension-polkagate/src/popup/staking/pool-new/Info.tsx
@@ -44,9 +44,9 @@ export default function Info (): React.ReactElement {
   const theme = useTheme();
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const selectedAccount = useSelectedAccount();
+  const address = useSelectedAccount()?.address;
   const { genesisHash } = useParams<{ genesisHash: string }>();
-  const stakingInfo = usePoolStakingInfo(selectedAccount?.address, genesisHash);
+  const stakingInfo = usePoolStakingInfo(address, genesisHash);
   const { decimal, token } = useChainInfo(genesisHash, true);
 
   const getValue = useCallback((value: number | undefined) => {
@@ -73,7 +73,7 @@ export default function Info (): React.ReactElement {
   return (
     <>
       <Grid alignContent='flex-start' container sx={{ position: 'relative' }}>
-        <UserDashboardHeader homeType='default' />
+        <UserDashboardHeader fullscreenURL={'/fullscreen-stake/pool/' + address + '/' + genesisHash} homeType='default' />
         <Motion variant='slide'>
           <BackWithLabel
             onClick={onBack}

--- a/packages/extension-polkagate/src/popup/staking/pool-new/bondExtra/index.tsx
+++ b/packages/extension-polkagate/src/popup/staking/pool-new/bondExtra/index.tsx
@@ -21,9 +21,9 @@ export default function BondExtra (): React.ReactElement {
 
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const selectedAccount = useSelectedAccount();
+  const address = useSelectedAccount()?.address;
   const { genesisHash } = useParams<{ genesisHash: string }>();
-  const stakingInfo = usePoolStakingInfo(selectedAccount?.address, genesisHash);
+  const stakingInfo = usePoolStakingInfo(address, genesisHash);
   const { api, decimal, token } = useChainInfo(genesisHash);
 
   const [review, setReview] = useState<boolean>(false);
@@ -35,7 +35,7 @@ export default function BondExtra (): React.ReactElement {
     onMaxValue,
     setBondAmount,
     transactionInformation,
-    tx } = useBondExtraPool(selectedAccount?.address, genesisHash);
+    tx } = useBondExtraPool(address, genesisHash);
 
   const onNext = useCallback(() => setReview(true), []);
   const closeReview = useCallback(() => {
@@ -45,7 +45,7 @@ export default function BondExtra (): React.ReactElement {
   const onBack = useCallback(() => navigate('/pool/' + genesisHash) as void, [genesisHash, navigate]);
 
   const transactionFlow = useTransactionFlow({
-    address: selectedAccount?.address,
+    address,
     backPathTitle: t('Stake more'),
     closeReview,
     genesisHash: genesisHash ?? '',
@@ -59,7 +59,7 @@ export default function BondExtra (): React.ReactElement {
   return transactionFlow || (
     <>
       <Grid alignContent='flex-start' container sx={{ position: 'relative' }}>
-        <UserDashboardHeader homeType='default' />
+        <UserDashboardHeader fullscreenURL={'/fullscreen-stake/pool/' + address + '/' + genesisHash} homeType='default' />
         <Motion variant='slide'>
           <BackWithLabel
             onClick={onBack}

--- a/packages/extension-polkagate/src/popup/staking/pool-new/createPool/index.tsx
+++ b/packages/extension-polkagate/src/popup/staking/pool-new/createPool/index.tsx
@@ -45,11 +45,11 @@ export default function CreatePool () {
   useBackground('staking');
 
   const { t } = useTranslation();
-  const selectedAccount = useSelectedAccount();
+  const address = useSelectedAccount()?.address;
   const { genesisHash } = useParams<{ genesisHash: string }>();
   const navigate = useNavigate();
   const { api, decimal, token } = useChainInfo(genesisHash);
-  const formatted = useFormatted3(selectedAccount?.address, genesisHash);
+  const formatted = useFormatted3(address, genesisHash);
 
   const { bondAmount,
     errorMessage,
@@ -65,7 +65,7 @@ export default function CreatePool () {
     setBondAmount,
     setRoles,
     transactionInformation,
-    tx } = useCreatePool(selectedAccount?.address, genesisHash);
+    tx } = useCreatePool(address, genesisHash);
 
   const [review, setReview] = useState<boolean>(false);
 
@@ -77,7 +77,7 @@ export default function CreatePool () {
   }, [setBondAmount]);
 
   const transactionFlow = useTransactionFlow({
-    address: selectedAccount?.address,
+    address,
     backPathTitle: t('Creating Pool'),
     closeReview,
     genesisHash: genesisHash ?? '',
@@ -91,7 +91,7 @@ export default function CreatePool () {
 
   return transactionFlow || (
     <Grid alignContent='flex-start' container sx={{ height: '100%', position: 'relative' }}>
-      <UserDashboardHeader homeType='default' />
+      <UserDashboardHeader fullscreenURL={'/fullscreen-stake/pool/' + address + '/' + genesisHash} homeType='default' />
       <Motion style={{ height: 'calc(100% - 55px)' }} variant='slide'>
         <BackWithLabel
           onClick={onBack}
@@ -123,7 +123,7 @@ export default function CreatePool () {
             titleInColor={` (${token?.toUpperCase() ?? '--'})`}
           />
           <UpdateRoles
-            address={formatted ?? selectedAccount?.address ?? ''}
+            address={formatted ?? address ?? ''}
             roles={roles}
             setRoles={setRoles}
           />

--- a/packages/extension-polkagate/src/popup/staking/pool-new/index.tsx
+++ b/packages/extension-polkagate/src/popup/staking/pool-new/index.tsx
@@ -46,11 +46,11 @@ export default function Pool (): React.ReactElement {
 
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const selectedAccount = useSelectedAccount();
+  const address = useSelectedAccount()?.address;
   const { genesisHash } = useParams<{ genesisHash: string }>();
   const { decimal, token } = useChainInfo(genesisHash, true);
-  const stakingInfo = usePoolStakingInfo(selectedAccount?.address, genesisHash);
-  const accountAssets = useAccountAssets(selectedAccount?.address);
+  const stakingInfo = usePoolStakingInfo(address, genesisHash);
+  const accountAssets = useAccountAssets(address);
 
   const [unstakingMenu, setUnstakingMenu] = useState<boolean>(false);
   const [restakeReward, setRestakeReward] = useState<boolean>(false);
@@ -58,11 +58,11 @@ export default function Pool (): React.ReactElement {
 
   const { redeemable,
     transactionInformation: withdrawTransactionInformation,
-    tx: withdrawTx } = useWithdrawPool(selectedAccount?.address, genesisHash);
+    tx: withdrawTx } = useWithdrawPool(address, genesisHash);
 
   const { myClaimable,
     transactionInformation: rewardTransactionInformation,
-    tx: rewardTx } = useClaimRewardPool(selectedAccount?.address, genesisHash, restakeReward);
+    tx: rewardTx } = useClaimRewardPool(address, genesisHash, restakeReward);
 
   const asset = useMemo(() =>
     accountAssets?.find(({ assetId, genesisHash: accountGenesisHash }) => accountGenesisHash === genesisHash && String(assetId) === '0')
@@ -101,7 +101,7 @@ export default function Pool (): React.ReactElement {
   const onBack = useCallback(() => navigate('/stakingIndex') as void, [navigate]);
 
   const transactionFlow = useTransactionFlow({
-    address: selectedAccount?.address,
+    address,
     backPathTitle: review === Review.Reward ? t('Claim rewards') : t('Withdraw redeemable'),
     closeReview,
     extraDetailConfirmationPage: { amount: review === Review.Reward ? myClaimable?.toString() : undefined },
@@ -119,7 +119,7 @@ export default function Pool (): React.ReactElement {
   return transactionFlow || (
     <>
       <Grid alignContent='flex-start' container sx={{ position: 'relative' }}>
-        <UserDashboardHeader fullscreenURL={'/fullscreen-stake/pool/' + genesisHash} homeType='default' />
+        <UserDashboardHeader fullscreenURL={'/fullscreen-stake/pool/' + address + '/' + genesisHash} homeType='default' />
         <Motion variant='slide'>
           <BackWithLabel
             content={<Back />}
@@ -138,7 +138,7 @@ export default function Pool (): React.ReactElement {
             type='pool'
           />
           <Tiles
-            address={selectedAccount?.address}
+            address={address}
             asset={asset}
             genesisHash={genesisHash}
             onClaimReward={onClaimReward}

--- a/packages/extension-polkagate/src/popup/staking/pool-new/joinPool/index.tsx
+++ b/packages/extension-polkagate/src/popup/staking/pool-new/joinPool/index.tsx
@@ -23,7 +23,7 @@ export default function JoinPool () {
   useBackground('staking');
 
   const { t } = useTranslation();
-  const selectedAccount = useSelectedAccount();
+  const address = useSelectedAccount()?.address;
   const { genesisHash } = useParams<{ genesisHash: string }>();
   const navigate = useNavigate();
   const pools = usePools2(genesisHash);
@@ -43,7 +43,7 @@ export default function JoinPool () {
     setBondAmount,
     setSelectedPool,
     transactionInformation,
-    tx } = useJoinPool(selectedAccount?.address, genesisHash);
+    tx } = useJoinPool(address, genesisHash);
 
   const [step, setStep] = useState(POOL_STEPS.CHOOSE_POOL);
 
@@ -58,7 +58,7 @@ export default function JoinPool () {
   }, [genesisHash, navigate, setBondAmount, step]);
 
   const transactionFlow = useTransactionFlow({
-    address: selectedAccount?.address,
+    address,
     backPathTitle: t('Joining Pool'),
     closeReview: onBack,
     genesisHash: genesisHash ?? '',
@@ -72,7 +72,7 @@ export default function JoinPool () {
 
   return transactionFlow || (
     <Grid alignContent='flex-start' container sx={{ height: '100%', position: 'relative' }}>
-      <UserDashboardHeader homeType='default' />
+      <UserDashboardHeader fullscreenURL={'/fullscreen-stake/pool/' + address + '/' + genesisHash} homeType='default' />
       <Motion style={{ height: 'calc(100% - 50px)' }} variant='slide'>
         <JoinPoolBackButton
           dispatchFilter={dispatchFilter}

--- a/packages/extension-polkagate/src/popup/staking/pool-new/stake/index.tsx
+++ b/packages/extension-polkagate/src/popup/staking/pool-new/stake/index.tsx
@@ -10,7 +10,7 @@ import { type BN } from '@polkadot/util';
 
 import { CreatePoolIcon, JoinPoolIcon } from '../../../../assets/icons';
 import { BackWithLabel, FormatBalance2, Motion } from '../../../../components';
-import { useBackground, useChainInfo, useIsExtensionPopup, useIsHovered, usePoolConst, useTranslation } from '../../../../hooks';
+import { useBackground, useChainInfo, useIsExtensionPopup, useIsHovered, usePoolConst, useSelectedAccount, useTranslation } from '../../../../hooks';
 import { UserDashboardHeader } from '../../../../partials';
 
 const OptionBox = styled(Box, {
@@ -98,7 +98,8 @@ export default function Stake () {
 
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const { genesisHash } = useParams<{ genesisHash: string }>();
+  const address = useSelectedAccount()?.address;
+  const { genesisHash } = useParams<{ genesisHash: string; }>();
   const { decimal, token } = useChainInfo(genesisHash, true);
   const poolStakingConsts = usePoolConst(genesisHash);
 
@@ -109,7 +110,7 @@ export default function Stake () {
   return (
     <>
       <Grid alignContent='flex-start' container sx={{ position: 'relative' }}>
-        <UserDashboardHeader homeType='default' />
+        <UserDashboardHeader fullscreenURL={'/fullscreen-stake/pool/' + address + '/' + genesisHash} homeType='default' />
         <Motion variant='slide'>
           <BackWithLabel
             onClick={onBack}

--- a/packages/extension-polkagate/src/popup/staking/pool-new/unstake/index.tsx
+++ b/packages/extension-polkagate/src/popup/staking/pool-new/unstake/index.tsx
@@ -23,7 +23,7 @@ export default function Unstake (): React.ReactElement {
 
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const selectedAccount = useSelectedAccount();
+  const address = useSelectedAccount()?.address;
   const { genesisHash } = useParams<{ genesisHash: string }>();
   const { api, decimal, token } = useChainInfo(genesisHash);
 
@@ -35,7 +35,7 @@ export default function Unstake (): React.ReactElement {
     staked,
     transactionInformation,
     tx,
-    unstakingValue } = useUnstakingPool(selectedAccount?.address, genesisHash);
+    unstakingValue } = useUnstakingPool(address, genesisHash);
 
   const [review, setReview] = useState<boolean>(false);
 
@@ -47,7 +47,7 @@ export default function Unstake (): React.ReactElement {
   const onBack = useCallback(() => navigate('/pool/' + genesisHash) as void, [genesisHash, navigate]);
 
   const transactionFlow = useTransactionFlow({
-    address: selectedAccount?.address,
+    address,
     backPathTitle: t('Unstaking'),
     closeReview,
     genesisHash: genesisHash ?? '',
@@ -61,7 +61,7 @@ export default function Unstake (): React.ReactElement {
   return transactionFlow || (
     <>
       <Grid alignContent='flex-start' container sx={{ position: 'relative' }}>
-        <UserDashboardHeader homeType='default' />
+        <UserDashboardHeader fullscreenURL={'/fullscreen-stake/pool/' + address + '/' + genesisHash} homeType='default' />
         <Motion variant='slide'>
           <BackWithLabel
             onClick={onBack}

--- a/packages/extension-polkagate/src/popup/staking/solo-new/Info.tsx
+++ b/packages/extension-polkagate/src/popup/staking/solo-new/Info.tsx
@@ -13,7 +13,7 @@ import { isBn } from '@polkadot/util';
 
 import { info } from '../../../assets/gif';
 import { BackWithLabel, Motion, ShowValue } from '../../../components';
-import { useBackground, useChainInfo, useSoloStakingInfo, useTranslation } from '../../../hooks';
+import { useBackground, useChainInfo, useSelectedAccount, useSoloStakingInfo, useTranslation } from '../../../hooks';
 import UserDashboardHeader from '../../../partials/UserDashboardHeader';
 import { amountToHuman } from '../../../util/utils';
 import StakingMenu from '../partial/StakingMenu';
@@ -43,7 +43,8 @@ export default function Info (): React.ReactElement {
 
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const { address, genesisHash } = useParams<{ address: string; genesisHash: string }>();
+  const address = useSelectedAccount()?.address;
+  const { genesisHash } = useParams<{ genesisHash: string }>();
   const stakingInfo = useSoloStakingInfo(address, genesisHash);
   const { decimal, token } = useChainInfo(genesisHash, true);
 
@@ -61,7 +62,7 @@ export default function Info (): React.ReactElement {
   return (
     <>
       <Grid alignContent='flex-start' container sx={{ position: 'relative' }}>
-        <UserDashboardHeader fullscreenURL={'/fullscreen-stake/solo/' + genesisHash} homeType='default' />
+        <UserDashboardHeader fullscreenURL={'/fullscreen-stake/solo/' + address + '/' + genesisHash} homeType='default' />
         <Motion variant='slide'>
           <BackWithLabel
             onClick={onBack}

--- a/packages/extension-polkagate/src/popup/staking/solo-new/bondExtra/index.tsx
+++ b/packages/extension-polkagate/src/popup/staking/solo-new/bondExtra/index.tsx
@@ -21,7 +21,7 @@ export default function BondExtra (): React.ReactElement {
 
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const selectedAccount = useSelectedAccount();
+  const address = useSelectedAccount()?.address;
   const { genesisHash } = useParams<{ genesisHash: string }>();
   const { api, decimal, token } = useChainInfo(genesisHash);
 
@@ -33,7 +33,7 @@ export default function BondExtra (): React.ReactElement {
     onMaxValue,
     setBondExtraValue,
     transactionInformation,
-    tx } = useBondExtraSolo(selectedAccount?.address, genesisHash);
+    tx } = useBondExtraSolo(address, genesisHash);
 
   const [review, setReview] = useState<boolean>(false);
 
@@ -45,7 +45,7 @@ export default function BondExtra (): React.ReactElement {
   }, [setBondExtraValue]);
 
   const transactionFlow = useTransactionFlow({
-    address: selectedAccount?.address,
+    address,
     backPathTitle: t('Stake more'),
     closeReview,
     genesisHash: genesisHash ?? '',
@@ -58,7 +58,7 @@ export default function BondExtra (): React.ReactElement {
 
   return transactionFlow || (
     <Grid alignContent='flex-start' container sx={{ position: 'relative' }}>
-      <UserDashboardHeader fullscreenURL={'/fullscreen-stake/solo/' + genesisHash} homeType='default' />
+      <UserDashboardHeader fullscreenURL={'/fullscreen-stake/solo/' + address + '/' + genesisHash} homeType='default' />
       <Motion variant='slide'>
         <BackWithLabel
           onClick={onBack}

--- a/packages/extension-polkagate/src/popup/staking/solo-new/fast-unstake/FastUnstake.tsx
+++ b/packages/extension-polkagate/src/popup/staking/solo-new/fast-unstake/FastUnstake.tsx
@@ -115,14 +115,14 @@ export default function FastUnstake (): React.ReactElement {
 
   const { t } = useTranslation();
   const { genesisHash } = useParams<{ genesisHash: string }>();
-  const selectedAccount = useSelectedAccount();
+  const address = useSelectedAccount()?.address;
   const navigate = useNavigate();
 
   const { checkDone,
     eligibilityCheck,
     isEligible,
     transactionInformation,
-    tx } = useFastUnstaking(selectedAccount?.address, genesisHash);
+    tx } = useFastUnstaking(address, genesisHash);
 
   const [review, setReview] = useState<boolean>(false);
 
@@ -131,7 +131,7 @@ export default function FastUnstake (): React.ReactElement {
   const closeReview = useCallback(() => setReview(false), []);
 
   const transactionFlow = useTransactionFlow({
-    address: selectedAccount?.address,
+    address,
     backPathTitle: t('Withdraw redeemable'),
     closeReview,
     genesisHash: genesisHash ?? '',
@@ -144,7 +144,7 @@ export default function FastUnstake (): React.ReactElement {
 
   return transactionFlow || (
     <Grid alignContent='flex-start' container sx={{ height: '100%', position: 'relative' }}>
-      <UserDashboardHeader fullscreenURL={'/fullscreen-stake/solo/' + genesisHash} homeType='default' />
+      <UserDashboardHeader fullscreenURL={'/fullscreen-stake/solo/' + address + '/' + genesisHash} homeType='default' />
       <Motion variant='slide'>
         <BackWithLabel
           onClick={onBack}

--- a/packages/extension-polkagate/src/popup/staking/solo-new/index.tsx
+++ b/packages/extension-polkagate/src/popup/staking/solo-new/index.tsx
@@ -86,7 +86,7 @@ export default function Solo (): React.ReactElement {
   return transactionFlow || (
     <>
       <Grid alignContent='flex-start' container sx={{ position: 'relative' }}>
-        <UserDashboardHeader fullscreenURL={'/fullscreen-stake/solo/' + genesisHash} homeType='default' />
+        <UserDashboardHeader fullscreenURL={'/fullscreen-stake/solo/' + address + '/' + genesisHash} homeType='default' />
         <Motion variant='slide'>
           <BackWithLabel
             content={<Back />}

--- a/packages/extension-polkagate/src/popup/staking/solo-new/nominations/NominationsSetting.tsx
+++ b/packages/extension-polkagate/src/popup/staking/solo-new/nominations/NominationsSetting.tsx
@@ -8,7 +8,7 @@ import { useParams } from 'react-router-dom';
 
 import { EmptyWarning } from '../../../../assets/icons/index';
 import { FadeOnScroll, Motion, NeonButton, Progress } from '../../../../components';
-import { useBackground, useSoloStakingInfo, useTranslation, useValidatorsInformation } from '../../../../hooks';
+import { useBackground, useSelectedAccount, useSoloStakingInfo, useTranslation, useValidatorsInformation } from '../../../../hooks';
 import { UserDashboardHeader } from '../../../../partials';
 import NominationsBackButton from '../../partial/NominationsBackButton';
 import NominatorsTable from '../../partial/NominatorsTable';
@@ -52,7 +52,8 @@ export default function NominationsSetting (): React.ReactElement {
   useBackground('staking');
 
   const { t } = useTranslation();
-  const { address, genesisHash } = useParams<{ address: string; genesisHash: string }>();
+  const address = useSelectedAccount()?.address;
+  const { genesisHash } = useParams<{ genesisHash: string }>();
   const refContainer = useRef(null);
 
   const [refresh, setRefresh] = useState<boolean>(false);
@@ -81,7 +82,7 @@ export default function NominationsSetting (): React.ReactElement {
 
   return (
     <Grid alignContent='flex-start' container sx={{ position: 'relative' }}>
-      <UserDashboardHeader fullscreenURL={'/fullscreen-stake/solo/' + genesisHash} homeType='default' />
+      <UserDashboardHeader fullscreenURL={'/fullscreen-stake/solo/' + address + '/' + genesisHash} homeType='default' />
       <Motion variant='slide'>
         <NominationsBackButton style={{ mt: '8px' }} />
         <Stack direction='row' ref={refContainer} sx={{ maxHeight: '500px', mt: '12px', overflowY: 'auto', px: '15px', width: '100%' }}>

--- a/packages/extension-polkagate/src/popup/staking/solo-new/pendingReward/index.tsx
+++ b/packages/extension-polkagate/src/popup/staking/solo-new/pendingReward/index.tsx
@@ -19,7 +19,7 @@ export default function PendingReward () {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { genesisHash } = useParams<{ genesisHash: string }>();
-  const selectedAccount = useSelectedAccount();
+  const address = useSelectedAccount()?.address;
   const { api, decimal, token } = useChainInfo(genesisHash);
 
   const { adaptiveDecimalPoint,
@@ -30,7 +30,7 @@ export default function PendingReward () {
     selectedToPayout,
     totalSelectedPending,
     transactionInformation,
-    tx } = usePendingRewardsSolo(selectedAccount?.address, genesisHash);
+    tx } = usePendingRewardsSolo(address, genesisHash);
 
   const [review, setReview] = useState<boolean>(false);
 
@@ -39,7 +39,7 @@ export default function PendingReward () {
   const closeReview = useCallback(() => setReview(false), []);
 
   const transactionFlow = useTransactionFlow({
-    address: selectedAccount?.address,
+    address,
     backPathTitle: t('Payout rewards'),
     closeReview,
     genesisHash: genesisHash ?? '',
@@ -53,7 +53,7 @@ export default function PendingReward () {
   return transactionFlow || (
     <>
       <Grid alignContent='flex-start' container sx={{ position: 'relative' }}>
-        <UserDashboardHeader fullscreenURL={'/fullscreen-stake/solo/' + genesisHash} homeType='default' />
+        <UserDashboardHeader fullscreenURL={'/fullscreen-stake/solo/' + address + '/' + genesisHash} homeType='default' />
         <Motion variant='slide'>
           <BackWithLabel
             onClick={onBack}

--- a/packages/extension-polkagate/src/popup/staking/solo-new/restake/index.tsx
+++ b/packages/extension-polkagate/src/popup/staking/solo-new/restake/index.tsx
@@ -21,7 +21,7 @@ export default function Restake (): React.ReactElement {
 
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const selectedAccount = useSelectedAccount();
+  const address = useSelectedAccount()?.address;
   const { genesisHash } = useParams<{ genesisHash: string }>();
   const { api, decimal, token } = useChainInfo(genesisHash);
 
@@ -33,7 +33,7 @@ export default function Restake (): React.ReactElement {
     setRebondValue,
     transactionInformation,
     tx,
-    unlockingAmount } = useRestakeSolo(selectedAccount?.address, genesisHash);
+    unlockingAmount } = useRestakeSolo(address, genesisHash);
 
   const [review, setReview] = useState<boolean>(false);
 
@@ -45,7 +45,7 @@ export default function Restake (): React.ReactElement {
   }, [setRebondValue]);
 
   const transactionFlow = useTransactionFlow({
-    address: selectedAccount?.address,
+    address,
     backPathTitle: t('Re-staking'),
     closeReview,
     genesisHash: genesisHash ?? '',
@@ -59,7 +59,7 @@ export default function Restake (): React.ReactElement {
   return transactionFlow || (
     <>
       <Grid alignContent='flex-start' container sx={{ position: 'relative' }}>
-        <UserDashboardHeader fullscreenURL={'/fullscreen-stake/solo/' + genesisHash} homeType='default' />
+        <UserDashboardHeader fullscreenURL={'/fullscreen-stake/solo/' + address + '/' + genesisHash} homeType='default' />
         <Motion variant='slide'>
           <BackWithLabel
             onClick={onBack}

--- a/packages/extension-polkagate/src/popup/staking/solo-new/settings/index.tsx
+++ b/packages/extension-polkagate/src/popup/staking/solo-new/settings/index.tsx
@@ -178,7 +178,7 @@ export default function Settings (): React.ReactElement {
 
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const selectedAccount = useSelectedAccount();
+  const address = useSelectedAccount()?.address;
   const { genesisHash } = useParams<{ genesisHash: string }>();
   const isBlueish = useIsBlueish();
 
@@ -193,14 +193,14 @@ export default function Settings (): React.ReactElement {
     setSpecificAccount,
     specificAccount,
     transactionInformation,
-    tx } = useSoloSettings(selectedAccount?.address, genesisHash);
+    tx } = useSoloSettings(address, genesisHash);
 
   const onBack = useCallback(() => navigate('/solo/' + genesisHash) as void, [genesisHash, navigate]);
   const onNext = useCallback(() => setReview(true), []);
   const closeReview = useCallback(() => setReview(false), []);
 
   const transactionFlow = useTransactionFlow({
-    address: selectedAccount?.address,
+    address,
     backPathTitle: t('Settings'),
     closeReview,
     genesisHash: genesisHash ?? '',
@@ -214,7 +214,7 @@ export default function Settings (): React.ReactElement {
   return transactionFlow || (
     <>
       <Grid alignContent='flex-start' container sx={{ position: 'relative', zIndex: 1 }}>
-        <UserDashboardHeader fullscreenURL={'/fullscreen-stake/solo/' + genesisHash} homeType='default' />
+        <UserDashboardHeader fullscreenURL={'/fullscreen-stake/solo/' + address + '/' + genesisHash} homeType='default' />
         <Motion variant='slide'>
           <BackWithLabel
             onClick={onBack}

--- a/packages/extension-polkagate/src/popup/staking/solo-new/unstake/index.tsx
+++ b/packages/extension-polkagate/src/popup/staking/solo-new/unstake/index.tsx
@@ -21,7 +21,7 @@ export default function Unstake (): React.ReactElement {
 
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const selectedAccount = useSelectedAccount();
+  const address = useSelectedAccount()?.address;
   const { genesisHash } = useParams<{ genesisHash: string }>();
   const { api, decimal, token } = useChainInfo(genesisHash);
 
@@ -33,7 +33,7 @@ export default function Unstake (): React.ReactElement {
     staked,
     transactionInformation,
     tx,
-    unstakingValue } = useUnstakingSolo(selectedAccount?.address, genesisHash);
+    unstakingValue } = useUnstakingSolo(address, genesisHash);
 
   const [review, setReview] = useState<boolean>(false);
 
@@ -45,7 +45,7 @@ export default function Unstake (): React.ReactElement {
   }, [setUnstakingValue]);
 
   const transactionFlow = useTransactionFlow({
-    address: selectedAccount?.address,
+    address,
     backPathTitle: t('Unstaking'),
     closeReview,
     genesisHash: genesisHash ?? '',
@@ -58,7 +58,7 @@ export default function Unstake (): React.ReactElement {
 
   return transactionFlow || (
     <Grid alignContent='flex-start' container sx={{ position: 'relative' }}>
-      <UserDashboardHeader fullscreenURL={'/fullscreen-stake/solo/' + genesisHash} homeType='default' />
+      <UserDashboardHeader fullscreenURL={'/fullscreen-stake/solo/' + address + '/' + genesisHash} homeType='default' />
       <Motion variant='slide'>
         <BackWithLabel
           onClick={onBack}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Fullscreen links for staking now include the selected account address, enabling direct per-account views across pool and solo flows (stake, unstake, bond extra, join/create pool, rewards, restake, settings, nominations, fast-unstake).
  - Header updated to support per-account fullscreen navigation throughout staking pages.

- Refactor
  - Standardized staking screens to use the selected account’s address consistently for data fetching, transactions, and navigation, improving reliability and coherence across the experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->