### PR TITLE
style: hide scrollbar on window and display only when needed

### DIFF
--- a/packages/extension-polkagate/src/components/Main.tsx
+++ b/packages/extension-polkagate/src/components/Main.tsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 
-import { useBackground } from '../hooks';
+import { useBackground, useScrollbarAutoHide } from '../hooks';
 
 interface Props {
   children: React.ReactNode;
@@ -11,6 +11,8 @@ interface Props {
 
 export default function Main ({ children }: Props): React.ReactElement<Props> {
   const background = useBackground();
+
+  useScrollbarAutoHide();
 
   return (
     <main id='main' style={{ height: '100%', width: '100%' }}>

--- a/packages/extension-polkagate/src/components/View.tsx
+++ b/packages/extension-polkagate/src/components/View.tsx
@@ -64,36 +64,78 @@ function View ({ children }: Props): React.ReactElement<Props> {
 const BodyTheme = createGlobalStyle<{ theme: Theme }>`
   body {
     background-color: ${(props) => props.theme.palette.background.paper};
-    position: relative; /* Add position relative to body */
+    position: relative;
   }
-  
+
   div#root{
     background-color: ${(props) => props.theme.palette.background.default};
   }
-  
+
+  /* Hide all scrollbars completely - no space consumption */
   * {
-    scrollbar-width: thin; /* Firefox */
-    scrollbar-color: ${(props) => props.theme.palette.label.primary} transparent;
+    /* Firefox - completely hide scrollbars */
+    scrollbar-width: none;
+    -ms-overflow-style: none; /* IE and Edge */
     
+    /* Webkit - completely hide scrollbars */
     &::-webkit-scrollbar {
-      width: 8px;
-      height: 8px;
-      position: absolute; /* Add absolute positioning to scrollbar */
-      right: 0;
-      top: 0;
+      display: none;
+      width: 0 !important;
+      height: 0 !important;
+      background: transparent;
     }
     
     &::-webkit-scrollbar-thumb {
-      background-color: ${(props) => props.theme.palette.label.primary};
-      border-radius: 4px;
-      position: absolute; /* Add absolute positioning to scrollbar thumb */
+      display: none;
     }
     
     &::-webkit-scrollbar-track {
-      background: transparent;
-      position: absolute; /* Add absolute positioning to scrollbar track */
-      right: 0;
+      display: none;
     }
+  }
+
+  /* Custom overlay scrollbar that appears only when needed */
+  .scrollbar-overlay {
+    position: relative;
+    
+    &::after {
+      content: '';
+      position: absolute;
+      top: 0;
+      right: 0;
+      width: 8px;
+      height: 100%;
+      background: ${(props) => props.theme.palette.label.primary};
+      border-radius: 4px;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.3s ease;
+      z-index: 1000;
+      transform: translateY(0%);
+    }
+    
+    &.scrolling::after,
+    &:hover::after {
+      opacity: 0.6;
+    }
+  }
+
+  /* Alternative: Use margin compensation technique */
+  .no-scrollbar-space {
+    /* Make container wider to hide scrollbar outside viewport */
+    padding-right: 17px; /* Standard scrollbar width on Windows */
+    margin-right: -17px;
+    
+    /* For horizontal scrollbars */
+    &.horizontal {
+      padding-bottom: 17px;
+      margin-bottom: -17px;
+    }
+  }
+
+  /* Auto-hide scrollbars script injection */
+  @keyframes fadeOut {
+    to { opacity: 0; }
   }
 `;
 

--- a/packages/extension-polkagate/src/fullscreen/history/HistoryIcon.tsx
+++ b/packages/extension-polkagate/src/fullscreen/history/HistoryIcon.tsx
@@ -7,28 +7,29 @@ import React, { memo } from 'react';
 import { type ActionType } from '../../util';
 
 interface Props {
-  action: string
+  action: string;
+  isFullscreen?: boolean;
 }
 
-const HistoryIcon = ({ action }: Props) => {
+const HistoryIcon = ({ action, isFullscreen = true }: Props) => {
   const normalizedAction = action.toLowerCase() as ActionType;
 
-  const DEFAULT_ICON = <Polkadot color='#AA83DC' size='20' />;
+  const DEFAULT_ICON = <Polkadot color='#AA83DC' size={isFullscreen ? 20 : 26} />;
 
   const actionIcons: Record<ActionType, React.JSX.Element> = {
-    abstain: <LikeDislike color='#AA83DC' size='20' variant='Bold' />,
-    aye: <Like1 color='#82FFA5' size='15' variant='Bold' />,
-    balances: <ArrowSwapHorizontal color='#AA83DC' size='20' />,
-    delegate: <Sagittarius color='#AA83DC' size='20' variant='Bulk' />,
-    governance: <Record color='#AA83DC' size='16' variant='Bulk' />,
-    nay: <Dislike color='#FF165C' size='15' variant='Bold' />,
-    'pool staking': <Strongbox2 color='#AA83DC' size='20' />,
-    proxy: <Data color='#AA83DC' size='14' />,
-    receive: <ArrowCircleDown2 color='#82FFA5' size='16' variant='Linear' />,
-    reward: <Money color='#82FFA5' size='16' />,
-    send: <ArrowCircleRight2 color='#AA83DC' size='16' />,
-    'solo staking': <Strongbox color='#AA83DC' size='20' />,
-    utility: <ShoppingBag color='#AA83DC' size='16' />
+    abstain: <LikeDislike color='#AA83DC' size={isFullscreen ? 20 : 26} variant='Bold' />,
+    aye: <Like1 color='#82FFA5' size={isFullscreen ? 15 : 22} variant='Bold' />,
+    balances: <ArrowSwapHorizontal color='#AA83DC' size={isFullscreen ? 20 : 26 } />,
+    delegate: <Sagittarius color='#AA83DC' size={isFullscreen ? 20 : 26} variant='Bulk' />,
+    governance: <Record color='#AA83DC' size={isFullscreen ? 16 : 22} variant='Bulk' />,
+    nay: <Dislike color='#FF165C' size={isFullscreen ? 15 : 26} variant='Bold' />,
+    'pool staking': <Strongbox2 color='#AA83DC' size={isFullscreen ? 16 : 26} />,
+    proxy: <Data color='#AA83DC' size={isFullscreen ? 14 : 20 } />,
+    receive: <ArrowCircleDown2 color='#82FFA5' size={isFullscreen ? 16 : 22} variant='Linear' />,
+    reward: <Money color='#82FFA5' size={isFullscreen ? 16 : 22} />,
+    send: <ArrowCircleRight2 color='#AA83DC' size={isFullscreen ? 16 : 22} />,
+    'solo staking': <Strongbox color='#AA83DC' size={isFullscreen ? 16 : 26} />,
+    utility: <ShoppingBag color='#AA83DC' size={isFullscreen ? 16 : 22 } />
   };
 
   return actionIcons[normalizedAction] || DEFAULT_ICON;

--- a/packages/extension-polkagate/src/hooks/index.ts
+++ b/packages/extension-polkagate/src/hooks/index.ts
@@ -138,6 +138,7 @@ export { default as useReferendum } from './useReferendum';
 export { default as useReservedDetails } from './useReservedDetails';
 export { default as useReservedDetails2 } from './useReservedDetails2';
 export { default as useRouteRefresh } from './useRouteRefresh';
+export { default as useScrollbarAutoHide } from './useScrollbarAutoHide';
 export { default as useSelectedAccount } from './useSelectedAccount';
 export { default as useSelectedChains } from './useSelectedChains';
 export { default as useSelectedLanguage } from './useSelectedLanguage';

--- a/packages/extension-polkagate/src/hooks/useScrollbarAutoHide.tsx
+++ b/packages/extension-polkagate/src/hooks/useScrollbarAutoHide.tsx
@@ -1,0 +1,222 @@
+// Copyright 2017-2025 @polkadot/extension-polkagate authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// @ts-nocheck
+
+import { useEffect, useMemo } from 'react';
+
+export default function useScrollbarAutoHide () {
+  const opts = useMemo(() => ({
+    autoHideAfter: 700,
+    bgColor: 'transparent',
+    minThumb: 20,
+    thumbColor: '#674394',
+    width: 4
+  }), []);
+
+  useEffect(() => {
+    // ---- style (once per hook instance)
+    const style = document.createElement('style');
+
+    style.textContent = `
+      .osb-track {
+        position: fixed;
+        top: 0;
+        right: 0;
+        width: ${opts.width}px;
+        background: ${opts.bgColor};
+        border-radius: 6px;
+        opacity: 0;
+        transition: opacity .2s ease;
+        z-index: 2147483646; /* on top, but below browser UI */
+        pointer-events: auto;
+      }
+      .osb-track:hover { background: ${opts.bgColor}; }
+      .osb-thumb {
+        position: absolute;
+        top: 0;
+        right: 0;
+        width: 100%;
+        min-height: ${opts.minThumb}px;
+        border-radius: 6px;
+        background: ${opts.thumbColor};
+        cursor: default;
+        transition: background-color .2s;
+        will-change: transform, height;
+      }
+      .osb-thumb:active { cursor: default; }
+    `;
+    document.head.appendChild(style);
+
+    interface Data {
+      track: HTMLDivElement;
+      thumb: HTMLDivElement;
+      ro: ResizeObserver;
+      hideTimer?: ReturnType<typeof setTimeout>;
+    }
+
+    const map = new WeakMap<HTMLElement, Data>();
+    const raf = (cb: FrameRequestCallback) => requestAnimationFrame(cb);
+
+    const isScrollable = (el: HTMLElement) => {
+      const SCROLL_OPTIONS = ['auto', 'scroll', 'overlay'];
+      const cs = getComputedStyle(el);
+      const overflowY = cs.overflowY;
+      const overflowX = cs.overflowX;
+      const overflowOK = SCROLL_OPTIONS.includes(overflowY) || SCROLL_OPTIONS.includes(overflowX);
+
+      if (!overflowOK) {
+        return false;
+      }
+
+      // allow a tiny epsilon for subpixel rounding
+      return el.scrollHeight - el.clientHeight > 1;
+    };
+
+    const updateFor = (el: HTMLElement) => {
+      const d = map.get(el);
+
+      if (!d) {
+        return;
+      }
+
+      const rect = el.getBoundingClientRect();
+      const rtl = getComputedStyle(el).direction === 'rtl';
+
+      d.track.style.height = `${rect.height}px`;
+      d.track.style.top = `${rect.top}px`;
+
+      if (rtl) {
+        d.track.style.left = `${rect.left}px`;
+        d.track.style.right = '';
+      } else {
+        d.track.style.right = `${window.innerWidth - rect.right}px`;
+        d.track.style.left = '';
+      }
+
+      const canScroll = isScrollable(el);
+
+      d.track.style.display = canScroll ? 'block' : 'none';
+
+      if (!canScroll) {
+        return;
+      }
+
+      const trackH = d.track.offsetHeight;
+      const thumbH = Math.max(
+        opts.minThumb,
+        (el.clientHeight / el.scrollHeight) * trackH
+      );
+      const maxTop = trackH - thumbH;
+      const ratio =
+        el.scrollTop / Math.max(1, el.scrollHeight - el.clientHeight);
+
+      d.thumb.style.height = `${thumbH}px`;
+      d.thumb.style.transform = `translateY(${ratio * maxTop}px)`;
+    };
+
+    const ensure = (el: HTMLElement): Data => {
+      const existing = map.get(el);
+
+      if (existing) {
+        return existing;
+      }
+
+      const track = document.createElement('div');
+
+      track.className = 'osb-track'.trim();
+
+      const thumb = document.createElement('div');
+
+      thumb.className = 'osb-thumb';
+      track.appendChild(thumb);
+      document.body.appendChild(track);
+
+      const showThenAutoHide = (_el: HTMLElement, d: Data) => {
+        d.track.style.opacity = '1';
+
+        if (d.hideTimer) {
+          clearTimeout(d.hideTimer);
+        }
+
+        d.hideTimer = setTimeout(() => {
+          d.track.style.opacity = '0';
+        }, opts.autoHideAfter);
+      };
+
+      const ro = new ResizeObserver(() => raf(() => updateFor(el)));
+
+      ro.observe(el);
+
+      const onScroll = () => {
+        const d = map.get(el);
+
+        if (!d) {
+          return;
+        }
+
+        showThenAutoHide(el, d);
+        raf(() => updateFor(el));
+      };
+
+      el.addEventListener('scroll', onScroll, { passive: true });
+
+      const data: Data = { ro, thumb, track };
+
+      map.set(el, data);
+
+      // initial paint
+      raf(() => {
+        updateFor(el);
+        showThenAutoHide(el, data);
+      });
+
+      return data;
+    };
+
+    // Activate when pointer enters scrollable elements
+    const onPointerEnter = (e: Event) => {
+      const el = e.target as HTMLElement | null;
+
+      if (!el || !isScrollable(el)) {
+        return;
+      }
+
+      const cs = getComputedStyle(el);
+      const maybeScrollable =
+        /auto|scroll/.test(cs.overflowY) || el.scrollHeight > el.clientHeight;
+
+      if (maybeScrollable) {
+        ensure(el);
+        raf(() => updateFor(el));
+      }
+    };
+
+    // Keep tracks aligned on window changes
+    const onGlobalLayoutChange = () => {
+      map.forEach((_, el) => raf(() => updateFor(el)));
+    };
+
+    document.addEventListener('pointerenter', onPointerEnter, true);
+    window.addEventListener('scroll', onGlobalLayoutChange, true);
+    window.addEventListener('resize', onGlobalLayoutChange);
+
+    // Cleanup
+    return () => {
+      document.head.removeChild(style);
+      document.removeEventListener('pointerenter', onPointerEnter, true);
+      window.removeEventListener('scroll', onGlobalLayoutChange, true);
+      window.removeEventListener('resize', onGlobalLayoutChange);
+      map.forEach((d) => {
+        d.ro.disconnect();
+
+        if (d.hideTimer) {
+          clearTimeout(d.hideTimer);
+        }
+
+        d.track.remove();
+      });
+      map.clear();
+    };
+  }, [opts.autoHideAfter, opts.bgColor, opts.minThumb, opts.thumbColor, opts.width]);
+}

--- a/packages/extension-polkagate/src/popup/history/newDesign/HistoryItem.tsx
+++ b/packages/extension-polkagate/src/popup/history/newDesign/HistoryItem.tsx
@@ -4,10 +4,10 @@
 import type { TransactionDetail } from '../../../util/types';
 
 import { Container, Grid, Typography, useTheme } from '@mui/material';
-import { ArrowCircleDown2, ArrowCircleRight2, ArrowSwapHorizontal, CloseCircle, Data, Dislike, Like1, LikeDislike, Money, Polkadot, Record, Sagittarius, ShoppingBag, Strongbox, Strongbox2, TickCircle } from 'iconsax-react';
+import { CloseCircle, TickCircle } from 'iconsax-react';
 import React, { memo, useCallback, useMemo, useState } from 'react';
 
-import { type ActionType, historyIconBgColor, isReward, resolveActionType } from '@polkadot/extension-polkagate/src/util/index';
+import { historyIconBgColor, isReward, resolveActionType } from '@polkadot/extension-polkagate/src/util/index';
 import { BN_ZERO } from '@polkadot/util';
 
 import { FormatBalance2, FormatPrice, ScrollingTextBox } from '../../../components';
@@ -16,36 +16,13 @@ import { calcPrice } from '../../../hooks/useYouHave';
 import GradientDivider from '../../../style/GradientDivider';
 import { amountToMachine } from '../../../util/utils';
 import HistoryDetail from './HistoryDetail';
+import HistoryIcon from '@polkadot/extension-polkagate/src/fullscreen/history/HistoryIcon';
 
 interface HistoryItemProps {
   historyDate: string;
   historyItems: TransactionDetail[];
   short: boolean;
 }
-
-const HistoryIcon = ({ action }: { action: string }) => {
-  const normalizedAction = action.toLowerCase() as ActionType;
-
-  const DEFAULT_ICON = <Polkadot color='#AA83DC' size='26' />;
-
-  const actionIcons: Record<ActionType, React.JSX.Element> = {
-    abstain: <LikeDislike color='#AA83DC' size='26' variant='Bold' />,
-    aye: <Like1 color='#82FFA5' size='22' variant='Bold' />,
-    balances: <ArrowSwapHorizontal color='#AA83DC' size='26' />,
-    delegate: <Sagittarius color='#AA83DC' size='26' variant='Bulk' />,
-    governance: <Record color='#AA83DC' size='22' variant='Bulk'/>,
-    nay: <Dislike color='#FF165C' size='22' variant='Bold' />,
-    'pool staking': <Strongbox2 color='#AA83DC' size='26' />,
-    proxy: <Data color='#AA83DC' size='20' />,
-    receive: <ArrowCircleDown2 color='#82FFA5' size='22' variant='Linear' />,
-    reward: <Money color='#82FFA5' size='22' />,
-    send: <ArrowCircleRight2 color='#AA83DC' size='22' />,
-    'solo staking': <Strongbox color='#AA83DC' size='26' />,
-    utility: <ShoppingBag color='#AA83DC' size='22' />
-  };
-
-  return actionIcons[normalizedAction] || DEFAULT_ICON;
-};
 
 const TimeOfTheDay = ({ date }: { date: number }) => {
   const formatTimestamp = useCallback((timestamp: number) => {
@@ -186,7 +163,7 @@ function HistoryItem ({ historyDate, historyItems, short }: HistoryItemProps) {
             <React.Fragment key={index}>
               <Grid alignItems='center' container item justifyContent='space-between' key={index} onClick={openDetail(historyItem)} sx={{ ':hover': { background: '#1B133C', px: '8px' }, borderRadius: '12px', columnGap: '8px', cursor: 'pointer', py: '4px', transition: 'all 250ms ease-out' }}>
                 <Grid alignItems='center' container item justifyContent='center' sx={{ background: iconBgColor, border: '2px solid', borderColor: '#2D1E4A', borderRadius: '999px', height: '36px', width: '36px' }}>
-                  <HistoryIcon action={action} />
+                  <HistoryIcon action={action} isFullscreen={false} />
                 </Grid>
                 <Grid container item justifyContent='space-between' xs>
                   <ActionSubAction


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enables an auto‑hiding overlay scrollbar across the app with draggable thumbs and timed fade‑out.

* **Style**
  * Refines scrollbar visuals with theme‑aware colors, fade animations, and utilities to avoid layout shifts when native scrollbars are hidden.

* **Refactor**
  * Composes background and content in main layout; history icons consolidated into a shared component and now adapt sizing for fullscreen vs compact views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->