### PR TITLE
refactor: use navigate instead of onAction, route back to home after remove account

### DIFF
--- a/packages/extension-polkagate/src/partials/RemoveAccount.tsx
+++ b/packages/extension-polkagate/src/partials/RemoveAccount.tsx
@@ -18,6 +18,7 @@ import { SharePopup } from '.';
 interface Props {
   onClose: ExtensionPopupCloser;
   open: boolean;
+  onRemoved?: () => void;
 }
 
 /**
@@ -25,7 +26,7 @@ interface Props {
  *
  * Has been used in both full-screen & extension mode!
 */
-function RemoveAccount ({ onClose, open }: Props): React.ReactElement {
+function RemoveAccount ({ onClose, onRemoved, open }: Props): React.ReactElement {
   const { t } = useTranslation();
   const account = useSelectedAccount();
 
@@ -46,6 +47,11 @@ function RemoveAccount ({ onClose, open }: Props): React.ReactElement {
     setPasswordError(false);
     onClose();
   }, [onClose]);
+
+  const handleCloseSnackbar = useCallback(() => {
+    handleClose();
+    onRemoved?.();
+  }, [handleClose, onRemoved]);
 
   const onRemove = useCallback(() => {
     try {
@@ -136,7 +142,7 @@ function RemoveAccount ({ onClose, open }: Props): React.ReactElement {
           />
         </Stack>
         <MySnackbar
-          onClose={handleClose}
+          onClose={handleCloseSnackbar}
           open={showSnackbar}
           text={t('Account successfully removed!')}
         />

--- a/packages/extension-polkagate/src/popup/settings/accountSettings/index.tsx
+++ b/packages/extension-polkagate/src/popup/settings/accountSettings/index.tsx
@@ -3,15 +3,15 @@
 
 import { Container, Stack, Typography } from '@mui/material';
 import { Edit2, ExportCurve, ImportCurve, LogoutCurve, Notification, ShieldSecurity } from 'iconsax-react';
-import React, { useCallback, useContext, useEffect } from 'react';
-import { useLocation, useParams } from 'react-router-dom';
+import React, { useCallback, useEffect } from 'react';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 
 import { windowOpen } from '@polkadot/extension-polkagate/src/messaging';
 import { setStorage } from '@polkadot/extension-polkagate/src/util';
 import { useExtensionPopups } from '@polkadot/extension-polkagate/src/util/handleExtensionPopup';
 import { noop } from '@polkadot/util';
 
-import { ActionCard, ActionContext, BackWithLabel, Motion } from '../../../components';
+import { ActionCard, BackWithLabel, Motion } from '../../../components';
 import { useTranslation } from '../../../hooks';
 import { UserDashboardHeader, WebsitesAccess } from '../../../partials';
 import HomeMenu from '../../../partials/HomeMenu';
@@ -24,6 +24,7 @@ type State = { pathname: string } | undefined;
 function AccountSettings (): React.ReactElement {
   const { t } = useTranslation();
   const location = useLocation();
+  const navigate = useNavigate();
   const { address } = useParams<{ address: string }>();
   const { extensionPopup, extensionPopupCloser, extensionPopupOpener } = useExtensionPopups();
 
@@ -35,13 +36,15 @@ function AccountSettings (): React.ReactElement {
     setStorage(STORAGE_KEY.SELECTED_ACCOUNT, address).catch(console.error);
   }, [address]);
 
-  const onAction = useContext(ActionContext);
-
   const isComingFromAccountsList = (location.state as State)?.pathname === '/accounts';
-  const onBack = useCallback(() => onAction(isComingFromAccountsList ? (location.state as State)?.pathname : '/settings'), [isComingFromAccountsList, location, onAction]);
+  const onBack = useCallback(() => navigate(isComingFromAccountsList ? (location.state as State)?.pathname ?? '' : '/settings') as void, [isComingFromAccountsList, location, navigate]);
 
-  const onExport = useCallback(() => onAction('/settings-account-export'), [onAction]);
+  const onExport = useCallback(() => navigate('/settings-account-export') as void, [navigate]);
   const onImport = useCallback(() => windowOpen('/account/have-wallet') as unknown as void, []);
+  const onCloseRemove = useCallback(() => {
+    extensionPopupCloser();
+    navigate('/') as void;
+  }, [extensionPopupCloser, navigate]);
 
   return (
     <Container disableGutters sx={{ position: 'relative' }}>
@@ -129,7 +132,7 @@ function AccountSettings (): React.ReactElement {
         open={extensionPopup === ExtensionPopups.RENAME}
       />
       <RemoveAccount
-        onClose={extensionPopupCloser}
+        onClose={onCloseRemove}
         open={extensionPopup === ExtensionPopups.REMOVE}
       />
       <WebsitesAccess

--- a/packages/extension-polkagate/src/popup/settings/accountSettings/index.tsx
+++ b/packages/extension-polkagate/src/popup/settings/accountSettings/index.tsx
@@ -42,9 +42,8 @@ function AccountSettings (): React.ReactElement {
   const onExport = useCallback(() => navigate('/settings-account-export') as void, [navigate]);
   const onImport = useCallback(() => windowOpen('/account/have-wallet') as unknown as void, []);
   const onCloseRemove = useCallback(() => {
-    extensionPopupCloser();
     navigate('/') as void;
-  }, [extensionPopupCloser, navigate]);
+  }, [navigate]);
 
   return (
     <Container disableGutters sx={{ position: 'relative' }}>
@@ -132,7 +131,8 @@ function AccountSettings (): React.ReactElement {
         open={extensionPopup === ExtensionPopups.RENAME}
       />
       <RemoveAccount
-        onClose={onCloseRemove}
+        onClose={extensionPopupCloser}
+        onRemoved={onCloseRemove}
         open={extensionPopup === ExtensionPopups.REMOVE}
       />
       <WebsitesAccess


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Account removal now triggers an optional callback that returns you to the home screen after completion.

- Enhancements
  - Back navigation in Account Settings is more consistent, returning to the previous screen or Settings as appropriate.
  - Export flow now navigates directly to the Account Export screen.
  - Remove and Rename account flows have improved closing and post-removal behavior for a smoother experience.

- Refactor
  - Navigation handling updated for greater reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->