### PR TITLE
chore: add full-screen URL in settings

### DIFF
--- a/packages/extension-polkagate/src/popup/settings/about/index.tsx
+++ b/packages/extension-polkagate/src/popup/settings/about/index.tsx
@@ -2,9 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Container, Grid, Stack } from '@mui/material';
-import React, { useCallback, useContext } from 'react';
+import React, { useCallback } from 'react';
+import { useNavigate } from 'react-router';
 
-import { ActionContext, BackWithLabel, Motion } from '../../../components';
+import { BackWithLabel, Motion } from '../../../components';
 import { useTranslation } from '../../../hooks';
 import { UserDashboardHeader } from '../../../partials';
 import HomeMenu from '../../../partials/HomeMenu';
@@ -17,13 +18,13 @@ import Resources from './Resources';
 
 function About (): React.ReactElement {
   const { t } = useTranslation();
-  const onAction = useContext(ActionContext);
+  const navigate = useNavigate();
 
-  const onBack = useCallback(() => onAction('/settings'), [onAction]);
+  const onBack = useCallback(() => navigate('/settings') as void, [navigate]);
 
   return (
     <Container disableGutters sx={{ position: 'relative' }}>
-      <UserDashboardHeader homeType='default' />
+      <UserDashboardHeader fullscreenURL='/settingsfs/about' homeType='default' />
       <Motion variant='slide'>
         <BackWithLabel
           onClick={onBack}
@@ -32,7 +33,7 @@ function About (): React.ReactElement {
         <Grid container item sx={{ px: '10px' }}>
           <Introduction style={{ border: '4px solid', borderColor: 'border.paper', height: '54px' }} />
           <RateUs />
-          <Grid alignItems='flex-start' container item justifyContent='flex-start' pt='5px' pb='15px' sx={{ border: '4px solid', borderColor: 'border.paper', borderRadius: '14px', mt: '5px', bgcolor: 'background.paper', height: '262px', px: '10px' }}>
+          <Grid alignItems='flex-start' container item justifyContent='flex-start' pb='15px' pt='5px' sx={{ bgcolor: 'background.paper', border: '4px solid', borderColor: 'border.paper', borderRadius: '14px', height: '262px', mt: '5px', px: '10px' }}>
             <Socials label={t('STAY TUNED')} short style={{ alignItems: 'start' }} />
             <Stack columnGap='35px' direction='row' justifyItems='start' my='5px'>
               <Resources />

--- a/packages/extension-polkagate/src/popup/settings/accountSettings/index.tsx
+++ b/packages/extension-polkagate/src/popup/settings/accountSettings/index.tsx
@@ -45,7 +45,7 @@ function AccountSettings (): React.ReactElement {
 
   return (
     <Container disableGutters sx={{ position: 'relative' }}>
-      <UserDashboardHeader homeType='default' />
+      <UserDashboardHeader fullscreenURL='/settingsfs/account' homeType='default' />
       <BackWithLabel
         onClick={onBack}
         text={t('Account Settings')}

--- a/packages/extension-polkagate/src/popup/settings/extensionSettings/index.tsx
+++ b/packages/extension-polkagate/src/popup/settings/extensionSettings/index.tsx
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Container, Grid } from '@mui/material';
-import React, { useCallback, useContext } from 'react';
-import { useLocation } from 'react-router';
+import React, { useCallback, useMemo } from 'react';
+import { useLocation, useNavigate } from 'react-router';
 
-import { ActionContext, BackWithLabel, Motion } from '../../../components';
+import { BackWithLabel, Motion } from '../../../components';
 import { useIsDark, useTranslation } from '../../../hooks';
 import { UserDashboardHeader } from '../../../partials';
 import HomeMenu from '../../../partials/HomeMenu';
@@ -18,14 +18,15 @@ function ExtensionSettings (): React.ReactElement {
   const { t } = useTranslation();
   const { pathname } = useLocation();
   const isDark = useIsDark();
+  const navigate = useNavigate();
 
-  const onAction = useContext(ActionContext);
+  const fullscreenURL = useMemo(() => pathname === '/settings-extension/chains' ? '/settingsfs/network' : '/settingsfs/', [pathname]);
 
-  const onBack = useCallback(() => onAction('/settings'), [onAction]);
+  const onBack = useCallback(() => navigate('/settings') as void, [navigate]);
 
   return (
     <Container disableGutters sx={{ position: 'relative' }}>
-      <UserDashboardHeader homeType='default' />
+      <UserDashboardHeader fullscreenURL={fullscreenURL} homeType='default' />
       <BackWithLabel
         onClick={onBack}
         text={t('Extension Settings')}

--- a/packages/extension-polkagate/src/popup/settings/index.tsx
+++ b/packages/extension-polkagate/src/popup/settings/index.tsx
@@ -27,7 +27,11 @@ function Settings (): React.ReactElement {
   const account = useSelectedAccount();
 
   const onClick = useCallback((input: SETTING_PAGES) => {
-    return () => navigate(`/settings-${input}/${input === SETTING_PAGES.ACCOUNT ? account?.address : ''}`) as void;
+    const path = input === SETTING_PAGES.ACCOUNT
+      ? `/settings-${input}/${account?.address ?? ''}`
+      : `/settings-${input}/`;
+
+    return () => navigate(path) as void;
   }, [account?.address, navigate]);
 
   return (

--- a/packages/extension-polkagate/src/popup/settings/index.tsx
+++ b/packages/extension-polkagate/src/popup/settings/index.tsx
@@ -3,9 +3,10 @@
 
 import { Container, Grid } from '@mui/material';
 import { Category, User } from 'iconsax-react';
-import React, { useCallback, useContext } from 'react';
+import React, { useCallback } from 'react';
+import { useNavigate } from 'react-router';
 
-import { ActionCard, ActionContext, Motion } from '../../components';
+import { ActionCard, Motion } from '../../components';
 import { useIsDark, useSelectedAccount, useTranslation } from '../../hooks';
 import { UserDashboardHeader } from '../../partials';
 import HomeMenu from '../../partials/HomeMenu';
@@ -22,16 +23,16 @@ enum SETTING_PAGES {
 function Settings (): React.ReactElement {
   const { t } = useTranslation();
   const isDark = useIsDark();
-  const onAction = useContext(ActionContext);
+  const navigate = useNavigate();
   const account = useSelectedAccount();
 
   const onClick = useCallback((input: SETTING_PAGES) => {
-    return () => onAction(`/settings-${input}/${input === SETTING_PAGES.ACCOUNT ? account?.address : ''}`);
-  }, [account?.address, onAction]);
+    return () => navigate(`/settings-${input}/${input === SETTING_PAGES.ACCOUNT ? account?.address : ''}`) as void;
+  }, [account?.address, navigate]);
 
   return (
     <Container disableGutters sx={{ position: 'relative' }}>
-      <UserDashboardHeader homeType='default' />
+      <UserDashboardHeader fullscreenURL='/settingsfs/' homeType='default' />
       <Motion style={{ padding: '0 10px' }} variant='slide'>
         <Grid container item sx={{ bgcolor: isDark ? '#1B133C' : '#F5F4FF', borderRadius: '14px', mt: '10px', p: '4px', position: 'relative' }}>
           <Introduction />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Added fullscreen header mode across Settings pages (Settings home, Account, About, and Extension Settings).
  * Header now adapts fullscreen destination based on the current section for a more consistent experience.

* Refactor
  * Migrated Settings navigation to the app router for smoother, more predictable back navigation.
  * Streamlined internal dependencies and tidied layout styles without visual changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->