### PR TITLE
fix: resolve available balance

### DIFF
--- a/packages/extension-polkagate/src/hooks/useSoloStakingInfo.tsx
+++ b/packages/extension-polkagate/src/hooks/useSoloStakingInfo.tsx
@@ -5,11 +5,11 @@ import type React from 'react';
 import type { ApiPromise } from '@polkadot/api';
 import type { Balance } from '@polkadot/types/interfaces';
 import type { BN } from '@polkadot/util';
-import type { AccountStakingInfo, BalancesInfo, StakingConsts } from '../util/types';
+import type { AccountStakingInfo, StakingConsts } from '../util/types';
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import { BN_ZERO, bnMax } from '@polkadot/util';
+import { BN_ZERO } from '@polkadot/util';
 
 import { getStorage, setStorage } from '../util';
 import { isHexToBn } from '../util/utils';

--- a/packages/extension-polkagate/src/hooks/useSoloStakingInfo.tsx
+++ b/packages/extension-polkagate/src/hooks/useSoloStakingInfo.tsx
@@ -136,34 +136,6 @@ function reviveSoloStakingInfoBNs (info: SavedSoloStakingInfo): SavedSoloStaking
   };
 }
 
-/**
- * Calculates the balance available for staking
- *
- * @param balances - Account balance information
- * @param stakingAccount - User's staking account information
- * @param unlockingAmount - Amount currently in the unlocking process
- * @returns The amount available to stake, or undefined if required data is missing
- */
-const getAvailableToStake = (balances: BalancesInfo | undefined, stakingAccount: AccountStakingInfo | null | undefined, unlockingAmount: BN | undefined) => {
-  if (!balances || !stakingAccount || !unlockingAmount) {
-    return undefined;
-  }
-
-  const staked = stakingAccount?.stakingLedger?.active as unknown as BN;
-  const redeemable = stakingAccount?.redeemable;
-
-  if (!balances?.freeBalance || !staked || !unlockingAmount) {
-    return undefined;
-  }
-
-  const _availableToStake = balances.freeBalance.sub(staked).sub(unlockingAmount).sub(redeemable || BN_ZERO);
-
-  // the reserved balance can be considered here as the amount which can be staked as well in solo,
-  // but since pooled balance are migrating to the reserved balance. and also the pallet has issue to accept reserved,
-  // hence it needs more workaround on it
-  return bnMax(BN_ZERO, _availableToStake);
-};
-
 const DEFAULT_VALUE = {
   availableBalanceToStake: undefined,
   rewardDestinationAddress: undefined,
@@ -224,7 +196,7 @@ export default function useSoloStakingInfo (address: string | undefined, genesis
     }
   }, [fetchSessionInfo, sessionInfo]);
 
-  const availableBalanceToStake = getAvailableToStake(balances, stakingAccount, sessionInfo?.unlockingAmount);
+  const availableBalanceToStake = balances?.freeBalance;
 
   // Separate effect for updating the state
   useEffect(() => {

--- a/packages/extension-polkagate/src/hooks/useStakingApi.ts
+++ b/packages/extension-polkagate/src/hooks/useStakingApi.ts
@@ -20,7 +20,7 @@ import { getValue } from '../popup/account/util';
 import { INITIAL_POOL_FILTER_STATE, poolFilterReducer } from '../popup/staking/partial/PoolFilter';
 import { type RolesState, updateRoleReducer } from '../popup/staking/pool-new/createPool/UpdateRoles';
 import { DATE_OPTIONS, POLKAGATE_POOL_IDS } from '../util/constants';
-import { amountToHuman, amountToMachine, blockToDate, isHexToBn } from '../util/utils';
+import { amountToHuman, amountToMachine, blockToDate, isHexToBn, safeSubtraction } from '../util/utils';
 import { calcPrice } from './useYouHave2';
 import { useAccountAssets, useChainInfo, useCurrentBlockNumber2, useEstimatedFee2, useFormatted3, useIsExposed2, usePendingRewards3, usePool2, usePoolConst, usePoolStakingInfo, useSoloStakingInfo, useStakingConsts2, useTokenPriceBySymbol, useTranslation } from '.';
 
@@ -95,7 +95,9 @@ export const useUnstakingPool = (
       title: t('Fee')
     },
     {
-      content: unstakingValue && staked ? (staked as unknown as BN).sub(unstakingValue) : undefined,
+      content: unstakingValue && staked
+        ? safeSubtraction((staked as unknown as BN).sub(unstakingValue))
+        : undefined,
       title: t('Total stake after'),
       withLogo: true
     }];
@@ -125,7 +127,7 @@ export const useUnstakingPool = (
     // - and they want to keep some stake (not full unstake)
     // - and the remaining stake would be less than the minimum required to stay in the pool
     if (!isPoolOwner && !staked.sub(unstakingValue).isZero() && staked.sub(unstakingValue).lt(stakingInfo.poolStakingConsts.minJoinBond)) {
-      const remained = api.createType('Balance', staked.sub(unstakingValue)).toHuman();
+      const remained = api.createType('Balance', safeSubtraction(staked.sub(unstakingValue))).toHuman();
       const min = api.createType('Balance', stakingInfo.poolStakingConsts.minJoinBond).toHuman();
 
       return t('Remaining stake amount ({{remained}}) should not be less than {{min}}.', { replace: { min, remained } });
@@ -148,10 +150,10 @@ export const useUnstakingPool = (
     // Case 2: If user is the pool owner, but the pool is still active or there are other members
     // They can only unstake down to the minimum required to keep the pool alive
     if (isPoolOwner && (poolState !== 'Destroying' || poolMemberCounter !== 1)) {
-      const partial = staked.sub(stakingInfo.poolStakingConsts.minCreateBond);
+      const partial = safeSubtraction(staked.sub(stakingInfo.poolStakingConsts.minCreateBond));
 
       // If there's nothing above the minimum, return '0'
-      return partial.lten(0) ? '0' : partial.toString();
+      return partial.toString();
     }
 
     // Case 3: If user is NOT the pool owner, the user is able to unstake the full amount
@@ -235,7 +237,7 @@ export const useUnstakingSolo = (
     }
 
     if (stakingInfo.stakingConsts && !staked.sub(unstakingValue).isZero() && !isStopStaking && staked.sub(unstakingValue).lt(stakingInfo.stakingConsts.minNominatorBond)) {
-      const remained = api.createType('Balance', staked.sub(unstakingValue)).toHuman();
+      const remained = api.createType('Balance', safeSubtraction(staked.sub(unstakingValue))).toHuman();
       const min = api.createType('Balance', stakingInfo.stakingConsts.minNominatorBond).toHuman();
 
       return t('Remaining stake amount ({{remained}}) should not be less than {{min}}.', { replace: { min, remained } });
@@ -257,7 +259,9 @@ export const useUnstakingSolo = (
       title: t('Fee')
     },
     {
-      content: unstakingValue && staked ? (staked).sub(unstakingValue) : undefined,
+      content: unstakingValue && staked
+        ? safeSubtraction((staked).sub(unstakingValue))
+        : undefined,
       title: t('Total stake after'),
       withLogo: true
     }];
@@ -624,7 +628,9 @@ export const useBondExtraSolo = (
       return '0';
     }
 
-    return (stakingInfo.availableBalanceToStake.sub(stakingInfo.stakingConsts.existentialDeposit.muln(2))).toString(); // TO-DO: check if this is correct
+    const maxAmount = safeSubtraction(stakingInfo.availableBalanceToStake.sub(stakingInfo.stakingConsts.existentialDeposit.muln(2)));
+
+    return maxAmount.toString();
   }, [stakingInfo.availableBalanceToStake, stakingInfo.stakingConsts?.existentialDeposit]);
 
   return {
@@ -788,7 +794,9 @@ export const useBondExtraPool = (
       return '0';
     }
 
-    return (stakingInfo.availableBalanceToStake.sub(stakingInfo.stakingConsts.existentialDeposit.muln(2))).toString(); // TO-DO: check if this is correct
+    const maxAmount = safeSubtraction(stakingInfo.availableBalanceToStake.sub(stakingInfo.stakingConsts.existentialDeposit.muln(2)));
+
+    return maxAmount.toString();
   }, [formatted, staked, stakingInfo.availableBalanceToStake, stakingInfo.pool, stakingInfo.stakingConsts]);
 
   const onInputChange = useCallback((value: string | null | undefined) => {
@@ -981,7 +989,9 @@ export const useJoinPool = (
       return '0';
     }
 
-    return (stakingInfo.availableBalanceToStake.sub(stakingInfo.stakingConsts.existentialDeposit.muln(2))).toString(); // TO-DO: check if this is correct
+    const maxAmount = safeSubtraction(stakingInfo.availableBalanceToStake.sub(stakingInfo.stakingConsts.existentialDeposit.muln(2)));
+
+    return maxAmount.toString();
   }, [formatted, stakingInfo.availableBalanceToStake, stakingInfo.stakingConsts]);
 
   const onMinValue = useMemo(() => {
@@ -1112,7 +1122,9 @@ export const useCreatePool = (
       return '0';
     }
 
-    return (stakingInfo.availableBalanceToStake.sub(stakingInfo.stakingConsts.existentialDeposit.muln(2))).toString(); // TO-DO: check if this is correct
+    const maxAmount = safeSubtraction(stakingInfo.availableBalanceToStake.sub(stakingInfo.stakingConsts.existentialDeposit.muln(2)));
+
+    return maxAmount.toString();
   }, [formatted, stakingInfo.availableBalanceToStake, stakingInfo.stakingConsts]);
 
   const onMinValue = useMemo(() => {
@@ -1361,7 +1373,7 @@ export const useEasyStake = (
     }
 
     const ED = stakingConsts.existentialDeposit;
-    let max = availableBalanceToStake.sub(ED.muln(2)).sub(estimatedFee);
+    let max = safeSubtraction(availableBalanceToStake.sub(ED.muln(2)).sub(estimatedFee));
 
     let min = !selectedStakingType || selectedStakingType.type === 'pool' ? poolStakingConsts.minJoinBond : stakingConsts.minNominatorBond;
 

--- a/packages/extension-polkagate/src/popup/account/util.ts
+++ b/packages/extension-polkagate/src/popup/account/util.ts
@@ -47,10 +47,16 @@ export const getValue = (type: string, balances: BalancesInfo | FetchedBalance |
     case ('available'):
     case ('available balance'):
     case ('transferable'):
-      const frozen = toBN(balances?.frozenBalance ?? BN_ZERO);
-      const free = toBN(balances?.freeBalance ?? BN_ZERO);
+      const { freeBalance = BN_ZERO, frozenBalance = BN_ZERO, reservedBalance = BN_ZERO } = balances ?? {};
 
-      return bnMax(BN_ZERO, free.sub(frozen));
+      const frozen = toBN(frozenBalance);
+      const reserved = toBN(reservedBalance);
+      const free = toBN(freeBalance);
+
+      const frozenReserveDiff = frozen.sub(reserved);
+      const untouchable = bnMax(BN_ZERO, frozenReserveDiff);
+
+      return free.sub(untouchable);
     case ('reserved'):
       return balances.reservedBalance;
     case ('others'):

--- a/packages/extension-polkagate/src/popup/account/util.ts
+++ b/packages/extension-polkagate/src/popup/account/util.ts
@@ -48,15 +48,9 @@ export const getValue = (type: string, balances: BalancesInfo | FetchedBalance |
     case ('available balance'):
     case ('transferable'):
       const frozen = toBN(balances?.frozenBalance ?? BN_ZERO);
-      const reserved = toBN(balances?.reservedBalance ?? BN_ZERO);
       const free = toBN(balances?.freeBalance ?? BN_ZERO);
 
-      const noFrozenReserved = frozen.isZero() && reserved.isZero();
-      const frozenReserveDiff = frozen.sub(reserved);
-      const maybeED = noFrozenReserved ? BN_ZERO : toBN(balances.ED || BN_ZERO);
-      const untouchable = bnMax(maybeED, frozenReserveDiff);
-
-      return free.sub(untouchable);
+      return bnMax(BN_ZERO, free.sub(frozen));
     case ('reserved'):
       return balances.reservedBalance;
     case ('others'):

--- a/packages/extension-polkagate/src/util/utils.ts
+++ b/packages/extension-polkagate/src/util/utils.ts
@@ -13,7 +13,7 @@ import type { HexString } from '@polkadot/util/types';
 import type { SavedAssets } from '../hooks/useAssetsBalances';
 import type { DropdownOption, FastestConnectionType, RecentChainsType, TransactionDetail, UserAddedChains } from './types';
 
-import { BN, BN_TEN, BN_ZERO, hexToBn, hexToString, hexToU8a, isHex, stringToU8a, u8aToHex, u8aToString } from '@polkadot/util';
+import { BN, BN_TEN, BN_ZERO, bnMax, hexToBn, hexToString, hexToU8a, isHex, stringToU8a, u8aToHex, u8aToString } from '@polkadot/util';
 import { decodeAddress, encodeAddress } from '@polkadot/util-crypto';
 
 import { EXTRA_PRICE_IDS } from './api/getPrices';
@@ -769,3 +769,7 @@ export const getSubscanChainName = (chainName?: string): string | undefined => {
       ? lcChainName?.replace(/(.*)assethub/, 'assethub-$1')
       : chainName;
     };
+
+export const safeSubtraction = (subtraction: BN, preferredMin = BN_ZERO) => {
+  return bnMax(preferredMin, subtraction);
+};


### PR DESCRIPTION
- available to stake
- available to transfer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Prevented negative displayed “available/transferable” balances by clamping results to zero.
  - Ensured staking-related calculations (unstake, max amounts, validations) never produce negative values, improving error messages and transaction gating.

- Refactor
  - Simplified balance and staking computations to rely on free balance and safe subtraction, reducing complexity and improving consistency across account and staking views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->