### PR TITLE
fix: return staking home from nomination fs

### DIFF
--- a/packages/extension-polkagate/src/fullscreen/stake/new-solo/nominations/ReviewPopup.tsx
+++ b/packages/extension-polkagate/src/fullscreen/stake/new-solo/nominations/ReviewPopup.tsx
@@ -5,7 +5,8 @@ import type { Content } from '@polkadot/extension-polkagate/partials/Review';
 import type { ValidatorInformation } from '../../../../hooks/useValidatorsInformation';
 import type { StakingConsts } from '../../../../util/types';
 
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router';
 
 import { useChainInfo, useEstimatedFee2, useFormatted3, useTranslation } from '../../../../hooks';
 import { PROXY_TYPE } from '../../../../util/constants';
@@ -23,6 +24,7 @@ interface Props {
 export default function ReviewPopup ({ address, genesisHash, newSelectedValidators, onClose, stakingConsts }: Props): React.ReactElement {
   const { t } = useTranslation();
   const { api } = useChainInfo(genesisHash);
+  const navigate = useNavigate();
   const formatted = useFormatted3(address, genesisHash);
 
   const nominate = api?.tx['staking']['nominate'];
@@ -51,13 +53,23 @@ export default function ReviewPopup ({ address, genesisHash, newSelectedValidato
 
   const [flowStep, setFlowStep] = useState<FullScreenTransactionFlow>(FULLSCREEN_STAKING_TX_FLOW.REVIEW);
 
+  const handleClose = useCallback(() => {
+    if (flowStep === FULLSCREEN_STAKING_TX_FLOW.REVIEW) {
+      onClose();
+
+      return;
+    }
+
+    navigate(-1) as void;
+  }, [flowStep, navigate, onClose]);
+
   return (
     <StakingPopup
       address={address}
       extraDetailConfirmationPage={extraDetailConfirmationPage}
       flowStep={flowStep}
       genesisHash={genesisHash}
-      onClose={onClose}
+      onClose={handleClose}
       proxyTypeFilter={PROXY_TYPE.STAKING}
       setFlowStep={setFlowStep}
       title={t('Manage Nominations')}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved close behavior in the staking nominations review popup. When not on the final Review step, closing now returns to the previous step instead of exiting the flow; on the Review step, it closes as before. This reduces accidental exits and makes navigation more consistent during the solo staking process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->