### PR TITLE
fix: switch clicking problem in claim reward, RestakeRewardToggler.tsx

### DIFF
--- a/packages/extension-polkagate/src/fullscreen/stake/new-pool/claimReward/partials/RestakeRewardToggler.tsx
+++ b/packages/extension-polkagate/src/fullscreen/stake/new-pool/claimReward/partials/RestakeRewardToggler.tsx
@@ -7,7 +7,7 @@ import React, { useCallback } from 'react';
 
 import { noop } from '@polkadot/util';
 
-import { MySwitch } from '../../../../../components';
+import { GradientSwitch } from '../../../../../components';
 import { useIsExtensionPopup, useTranslation } from '../../../../../hooks';
 
 export interface RestakeRewardTogglerProps {
@@ -36,7 +36,7 @@ export default function RestakeRewardToggler ({ restake, setRestake }: RestakeRe
           {t('Your tokens will return to stake')}
         </Typography>
       </Stack>
-      <MySwitch
+      <GradientSwitch
         checked={restake}
         onChange={noop}
       />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the restake toggle in the claim rewards flow to a new gradient switch for a more modern, consistent look.
  * Preserves existing behavior, props, and event handling—no changes to how the toggle works.
  * Improves visual clarity and aligns with current theming and accessibility standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->