### PR TITLE
fix: displaying pool name width issue in easy stake

### DIFF
--- a/packages/extension-polkagate/src/fullscreen/stake/easyStake/StakingTypeSelection/SelectedPoolInformation.tsx
+++ b/packages/extension-polkagate/src/fullscreen/stake/easyStake/StakingTypeSelection/SelectedPoolInformation.tsx
@@ -3,11 +3,11 @@
 
 import type { PoolInfo } from '../../../../util/types';
 
-import { Collapse, Container, Grid, Stack, Typography, useTheme } from '@mui/material';
+import { Collapse, Container, Grid, Stack, useTheme } from '@mui/material';
 import { ArrowRight2 } from 'iconsax-react';
 import React, { useMemo } from 'react';
 
-import { FormatBalance2 } from '../../../../components';
+import { FormatBalance2, ScrollingTextBox } from '../../../../components';
 import { useChainInfo } from '../../../../hooks';
 import { PoolIdenticon } from '../../../../popup/staking/partial/PoolIdenticon';
 import { isHexToBn } from '../../../../util/utils';
@@ -37,9 +37,14 @@ export const SelectedPoolInformation = ({ genesisHash, isExtension, onClick, ope
               size={24}
             />
             <Stack direction='column' sx={{ ml: '10px', mr: 'auto', width: 'fit-content' }}>
-              <Typography color='text.primary' sx={{ maxWidth: '250px', overflow: 'hidden', textAlign: 'left', textOverflow: 'ellipsis', textWrap: 'noWrap' }} variant='B-2'>
-                {poolDetail.metadata}
-              </Typography>
+              <ScrollingTextBox
+                text={poolDetail.metadata ?? ''}
+                textStyle={{
+                  color: theme.palette.text.primary,
+                  ...theme.typography['B-2']
+                }}
+                width={isExtension ? 230 : 250}
+              />
               <FormatBalance2
                 decimals={[decimal ?? 0]}
                 style={{ ...theme.typography['B-4'], color: textColor, width: 'fit-content' }}


### PR DESCRIPTION
<img width="582" height="366" alt="image" src="https://github.com/user-attachments/assets/f8dc5303-01b4-474d-a293-554db5c22572" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Style
  * Updated pool metadata display to a scrolling text box for better readability in limited space.
  * Applied adaptive width based on context (extension vs. full-screen) for a more balanced layout.
  * Ensured text color and typography match the app’s theme for visual consistency.
  * Preserved existing balance display and overall layout; no interaction changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->