### PR TITLE
fix: displaying pool detail issue in extension mode staking pages

### DIFF
--- a/packages/extension-polkagate/src/popup/staking/partial/PoolDetail.tsx
+++ b/packages/extension-polkagate/src/popup/staking/partial/PoolDetail.tsx
@@ -378,7 +378,7 @@ export default function PoolDetail ({ comprehensive, genesisHash, handleClose, o
         }
       }}
       fullScreen
-      open={Boolean(poolDetail || openMenu)}
+      open={Boolean(openMenu)}
     >
       {!poolDetail &&
         <Progress
@@ -471,7 +471,7 @@ export default function PoolDetail ({ comprehensive, genesisHash, handleClose, o
                 >
                   <PoolMembers
                     genesisHash={genesisHash}
-                    members={poolDetail.poolMembers ?? []}
+                    members={collapse['Members'] ? poolDetail.poolMembers ?? [] : []}
                     totalStaked={poolDetail.bondedPool?.points.toString() ?? '0'}
                   />
                 </CollapseSection>

--- a/packages/extension-polkagate/src/popup/staking/partial/StakingMenu.tsx
+++ b/packages/extension-polkagate/src/popup/staking/partial/StakingMenu.tsx
@@ -132,14 +132,14 @@ function StakingMenu ({ genesisHash, pool, type }: Props): React.ReactElement {
     }
 
     if (input === '/pool/detail') {
-      pool && togglePoolDetail();
+      togglePoolDetail();
 
       return;
     }
 
     navigate(input) as void;
     setCurrentMenu(input);
-  }, [currentMenu, navigate, pool, togglePoolDetail]);
+  }, [currentMenu, navigate, togglePoolDetail]);
 
   const selectionLineStyle = useMemo(() => ({
     background: 'linear-gradient(90deg, transparent 9.75%, #596AFF 52.71%, transparent 95.13%)',
@@ -180,7 +180,7 @@ function StakingMenu ({ genesisHash, pool, type }: Props): React.ReactElement {
         genesisHash={genesisHash}
         handleClose={togglePoolDetail}
         openMenu={openPopup}
-        poolDetail={openPopup ? pool ?? undefined : undefined}
+        poolDetail={pool ?? undefined}
       />
     </>
   );

--- a/packages/extension-polkagate/src/popup/staking/pool-new/Info.tsx
+++ b/packages/extension-polkagate/src/popup/staking/pool-new/Info.tsx
@@ -117,6 +117,7 @@ export default function Info (): React.ReactElement {
       </Grid>
       <StakingMenu
         genesisHash={genesisHash ?? ''}
+        pool={stakingInfo.pool}
         type='pool'
       />
     </>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Pool detail modal now opens reliably from the staking menu, independent of loading state.
  - Members section no longer renders or processes data when collapsed, preventing flicker and unintended loads.
  - Consistent navigation to pool details across staking views.

- Refactor
  - Simplified menu handling and dialog state for more predictable behavior.
  - Passed pool context directly to the staking menu to streamline interactions and improve popup responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->