### PR TITLE
fix: wrong full-screen URL path in NominationsSetting.tsx

### DIFF
--- a/packages/extension-polkagate/src/popup/staking/partial/NominationsBackButton.tsx
+++ b/packages/extension-polkagate/src/popup/staking/partial/NominationsBackButton.tsx
@@ -4,7 +4,7 @@
 import { Container, Grid, type SxProps, type Theme, Typography, useTheme } from '@mui/material';
 import { ArrowCircleLeft, Repeat } from 'iconsax-react';
 import React, { useCallback, useRef } from 'react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 import { useIsHovered, useTranslation } from '../../../hooks';
 import { windowOpen } from '../../../messaging';
@@ -36,20 +36,21 @@ const SettingButton = ({ Icon, disabled = false, onClick, text }: SettingButtonP
 };
 
 interface Props {
+  address: string | undefined;
+  genesisHash: string | undefined;
   style?: SxProps<Theme>;
 }
 
-export default function NominationsBackButton ({ style }: Props) {
+export default function NominationsBackButton ({ address, genesisHash, style }: Props) {
   const { t } = useTranslation();
   const theme = useTheme();
 
   const containerRef = useRef(null);
   const hovered = useIsHovered(containerRef);
   const navigate = useNavigate();
-  const { genesisHash } = useParams<{ genesisHash: string }>();
 
   const onBack = useCallback(() => navigate('/solo/' + genesisHash) as void, [genesisHash, navigate]);
-  const onChange = useCallback(() => windowOpen('/fullscreen-stake/solo/manage-validator/' + genesisHash) as unknown as void, [genesisHash]);
+  const onChange = useCallback(() => windowOpen('/fullscreen-stake/solo/manage-validator/' + address + '/' + genesisHash) as unknown as void, [address, genesisHash]);
 
   return (
     <Container disableGutters sx={{ alignItems: 'center', display: 'flex', flexDirection: 'row', justifyContent: 'space-between', px: '15px', width: '100%', ...style }}>

--- a/packages/extension-polkagate/src/popup/staking/solo-new/nominations/NominationsSetting.tsx
+++ b/packages/extension-polkagate/src/popup/staking/solo-new/nominations/NominationsSetting.tsx
@@ -84,7 +84,11 @@ export default function NominationsSetting (): React.ReactElement {
     <Grid alignContent='flex-start' container sx={{ position: 'relative' }}>
       <UserDashboardHeader fullscreenURL={'/fullscreen-stake/solo/' + address + '/' + genesisHash} homeType='default' />
       <Motion variant='slide'>
-        <NominationsBackButton style={{ mt: '8px' }} />
+        <NominationsBackButton
+          address={address}
+          genesisHash={genesisHash}
+          style={{ mt: '8px' }}
+        />
         <Stack direction='row' ref={refContainer} sx={{ maxHeight: '500px', mt: '12px', overflowY: 'auto', px: '15px', width: '100%' }}>
           {isLoading &&
             <Progress


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Back button now reliably returns to the correct solo staking screen for the selected network.
  - “Manage Validators” opens with the correct account and network, preventing misnavigation.

- Refactor
  - Streamlined navigation to use the currently selected account and network from the parent context for greater consistency and reliability across staking flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->