### PR TITLE
chore: show loading while pool members are fetching in pool detail

### DIFF
--- a/packages/extension-polkagate/src/components/Progress.tsx
+++ b/packages/extension-polkagate/src/components/Progress.tsx
@@ -9,13 +9,8 @@ import { useIsBlueish } from '../hooks';
 
 interface Props {
   direction?: 'column' | 'row'
-  fontSize?: number;
-  titlePaddingTop?: number;
-  titlePaddingLeft?: number;
   title?: string;
-  pt?: number | string;
   size?: number;
-  gridSize?: number;
   type?: 'circle' | 'cubes' | 'grid' | 'wordpress' | 'beatLoader';
   withEllipsis?: boolean;
   style?: React.CSSProperties;

--- a/packages/extension-polkagate/src/fullscreen/nft/components/ItemAvatar.tsx
+++ b/packages/extension-polkagate/src/fullscreen/nft/components/ItemAvatar.tsx
@@ -16,8 +16,6 @@ const WithLoading = ({ children, loaded }: { loaded: boolean, children: React.Re
   <>
     {!loaded &&
       <Progress
-        gridSize={50}
-        pt={0}
         type='grid'
       />
     }

--- a/packages/extension-polkagate/src/popup/staking/partial/PoolDetail.tsx
+++ b/packages/extension-polkagate/src/popup/staking/partial/PoolDetail.tsx
@@ -46,7 +46,7 @@ export const StakingInfoStackWithIcon = ({ Icon, amount, decimal, text, title, t
   return (
     <Container disableGutters sx={{ alignItems: 'center', display: 'flex', flexDirection: 'row', gap: isExtension ? '6px' : '24px', m: 0, width: 'fit-content' }}>
       {Icon}
-      <StakingInfoStack adjustedColorForTitle = {titleColor} amount={amount} decimal={decimal} text={text} title={title} token={token} />
+      <StakingInfoStack adjustedColorForTitle={titleColor} amount={amount} decimal={decimal} text={text} title={title} token={token} />
     </Container>
   );
 };
@@ -184,6 +184,13 @@ export const PoolMembers = ({ genesisHash, maxHeight = '220px', members, totalSt
           </Typography>
         </Container>
         <Stack direction='column' sx={{ gap: '8px', width: '100%' }}>
+          {members.length === 0 &&
+            <Progress
+              size={10}
+              style={{ gap: '20px', marginTop: '10px' }}
+              title={t('Loading pool members')}
+            />
+          }
           {members.map((member, index) => {
             const percentage = (Number(member.member.points.toString()) / Number(totalStaked)) * 100;
             // const percentage = ((isHexToBn(member.member.points.toString()).div(isHexToBn(totalStaked.toString()))).muln(100)).toString();
@@ -196,7 +203,7 @@ export const PoolMembers = ({ genesisHash, maxHeight = '220px', members, totalSt
                     genesisHash={genesisHash ?? ''}
                     identiconSize={18}
                     showShortAddress
-                    style={{ variant: 'B-4', width: '40%' }}
+                    style={{ variant: 'B-4', width: '43%' }}
                   />
                   <FormatBalance2
                     decimals={[decimal ?? 0]}
@@ -205,7 +212,7 @@ export const PoolMembers = ({ genesisHash, maxHeight = '220px', members, totalSt
                     tokens={[token ?? '']}
                     value={isHexToBn(member.member.points.toString())}
                   />
-                  <Typography color='text.primary' textAlign='right' variant='B-4' width='25%'>
+                  <Typography color='text.primary' textAlign='right' variant='B-4' width='22%'>
                     {isNaN(percentage) ? '--' : percentage.toFixed(2)}%
                   </Typography>
                 </Container>
@@ -350,6 +357,8 @@ export default function PoolDetail ({ comprehensive, genesisHash, handleClose, o
   const theme = useTheme();
   const { decimal, token } = useChainInfo(genesisHash, true);
 
+  const membersRef = useRef<{ accountId: string; member: { points: number; poolId: number } }[]>([]);
+
   const { collapse,
     commission,
     handleCollapses,
@@ -357,6 +366,16 @@ export default function PoolDetail ({ comprehensive, genesisHash, handleClose, o
     poolStatus,
     roles,
     totalPoolRewardAsFiat } = usePoolDetail(poolDetail, genesisHash);
+
+  const members = useMemo(() => {
+    if (!collapse['Members'] || !poolDetail) {
+      return membersRef.current;
+    }
+
+    membersRef.current = poolDetail.poolMembers ?? [];
+
+    return poolDetail.poolMembers ?? [];
+  }, [collapse, poolDetail]);
 
   return (
     <Dialog
@@ -471,7 +490,7 @@ export default function PoolDetail ({ comprehensive, genesisHash, handleClose, o
                 >
                   <PoolMembers
                     genesisHash={genesisHash}
-                    members={collapse['Members'] ? poolDetail.poolMembers ?? [] : []}
+                    members={members}
                     totalStaked={poolDetail.bondedPool?.points.toString() ?? '0'}
                   />
                 </CollapseSection>


### PR DESCRIPTION
Closes: #1837 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a loading indicator when pool members are being fetched, providing clearer feedback during data retrieval.
  * Members list now persists when expanding/collapsing the section, delivering a smoother, more consistent browsing experience.

* **Style**
  * Tweaked column widths in the Pool Members view to improve readability and visual balance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->