### PR TITLE
feat: add support for non-native fee assets

### DIFF
--- a/packages/extension-polkagate/src/components/SignWithLedger.tsx
+++ b/packages/extension-polkagate/src/components/SignWithLedger.tsx
@@ -61,6 +61,7 @@ export default function SignWithLedger ({ address, api, from, handleTxResult, on
             account={account}
             error={error}
             onCancel={onSecondaryClick}
+            // eslint-disable-next-line @typescript-eslint/no-misused-promises
             onSignature={onLedgerGenericSignature}
             payload={signerPayload}
             setError={setError}
@@ -72,6 +73,7 @@ export default function SignWithLedger ({ address, api, from, handleTxResult, on
             error={error}
             genesisHash={account?.genesisHash || api?.genesisHash?.toHex()}
             onCancel={onSecondaryClick} // TODO: should be fixed later
+            // eslint-disable-next-line @typescript-eslint/no-misused-promises
             onSignature={onSignature}
             payload={payload}
             setError={setError}

--- a/packages/extension-polkagate/src/fullscreen/manageProxies/Confirmation.tsx
+++ b/packages/extension-polkagate/src/fullscreen/manageProxies/Confirmation.tsx
@@ -30,18 +30,19 @@ const SubScanIcon = ({ size = '13px' }: { size?: string }) => (
 interface AmountProps {
   amount: string | undefined;
   genesisHash: string | undefined;
-  assetDecimal: number | undefined
+  assetDecimal: number | undefined;
   token: string | undefined;
 }
 
 const Amount = ({ amount, assetDecimal, genesisHash, token }: AmountProps) => {
   const { decimal: nativeAssetDecimal, token: nativeToken } = useChainInfo(genesisHash, true);
 
-  const price = useTokenPriceBySymbol(token, genesisHash);
   const currency = useCurrency();
 
   const _decimal = assetDecimal ?? nativeAssetDecimal;
   const _token = token ?? nativeToken;
+  const price = useTokenPriceBySymbol(_token, genesisHash);
+
   const amountInHuman = amountToHuman((amount ?? '0'), _decimal);
 
   const value = ((price.price ?? 0) * parseFloat(amountInHuman)).toFixed(2);

--- a/packages/extension-polkagate/src/fullscreen/sendFund/Step2Recipient.tsx
+++ b/packages/extension-polkagate/src/fullscreen/sendFund/Step2Recipient.tsx
@@ -30,12 +30,7 @@ export default function Step2Recipient ({ assetId, genesisHash, inputs, setInput
   const { t } = useTranslation();
   const { chainName } = useChainInfo(genesisHash, true);
 
-  const [selectedChain, setSelectedChain] = useState<DropdownOption>();
-
-  useEffect(() => {
-    !inputs?.recipientChain?.text && setSelectedChain({ text: chainName ?? '', value: genesisHash ?? '' });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  const [selectedChain, setSelectedChain] = useState<DropdownOption>({ text: inputs?.recipientChain?.text ?? chainName ?? '', value: inputs?.recipientChain?.value ?? genesisHash ?? '' });
 
   const destinationOptions = useMemo((): DropdownOption[] => {
     if (!chainName || !inputs?.token) {

--- a/packages/extension-polkagate/src/fullscreen/sendFund/Step2Recipient.tsx
+++ b/packages/extension-polkagate/src/fullscreen/sendFund/Step2Recipient.tsx
@@ -30,7 +30,12 @@ export default function Step2Recipient ({ assetId, genesisHash, inputs, setInput
   const { t } = useTranslation();
   const { chainName } = useChainInfo(genesisHash, true);
 
-  const [selectedChain, setSelectedChain] = useState<DropdownOption>({ text: chainName ?? '', value: genesisHash ?? '' });
+  const [selectedChain, setSelectedChain] = useState<DropdownOption>();
+
+  useEffect(() => {
+    !inputs?.recipientChain?.text && setSelectedChain({ text: chainName ?? '', value: genesisHash ?? '' });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const destinationOptions = useMemo((): DropdownOption[] => {
     if (!chainName || !inputs?.token) {

--- a/packages/extension-polkagate/src/fullscreen/sendFund/Step3Amount.tsx
+++ b/packages/extension-polkagate/src/fullscreen/sendFund/Step3Amount.tsx
@@ -24,7 +24,7 @@ import NumberedTitle from './partials/NumberedTitle';
 import useLimitedFeeCall from './useLimitedFeeCall';
 import useParaSpellFeeCall from './useParaSpellFeeCall';
 import useWarningMessage from './useWarningMessage';
-import { isOnSameChain, reorderAssetHubLabel } from './utils';
+import { isOnSameChain, normalizeChainName } from './utils';
 
 interface Props {
   inputs: Inputs | undefined;
@@ -152,7 +152,7 @@ export default function Step3Amount ({ inputs, setInputs, teleportState }: Props
       let mayBeEDasBN;
 
       if (senderChainName && inputs?.token && !TEST_NETS.includes(genesisHash ?? '')) {
-        const _senderChainName = reorderAssetHubLabel(senderChainName);
+        const _senderChainName = normalizeChainName(senderChainName);
 
         mayBeEDasBN = getExistentialDeposit(_senderChainName as TNodeWithRelayChains, { symbol: inputs.token });
       } else {

--- a/packages/extension-polkagate/src/fullscreen/sendFund/Step4Summary.tsx
+++ b/packages/extension-polkagate/src/fullscreen/sendFund/Step4Summary.tsx
@@ -10,34 +10,33 @@ import { ArrowCircleRight2 } from 'iconsax-react';
 import React, { useMemo } from 'react';
 import { useParams } from 'react-router';
 
-import { FLOATING_POINT_DIGIT } from '@polkadot/extension-polkagate/src/util/constants';
 import getLogo2 from '@polkadot/extension-polkagate/src/util/getLogo2';
 
 import { AssetLogo, Motion, ShowBalance4 } from '../../components';
 import { useAccountAssets, useChainInfo, useTranslation } from '../../hooks';
-import { UnableToPayFee } from '../../partials';
+import FeeRow from './partials/FeeRow';
 import FromToBox from './partials/FromToBox';
 
 interface Props {
   canPayFee: CanPayFee;
   inputs: Inputs;
+  setInputs: React.Dispatch<React.SetStateAction<Inputs | undefined>>;
   teleportState: Teleport;
 }
 
-export default function Step4Summary ({ canPayFee, inputs }: Props): React.ReactElement {
+export default function Step4Summary ({ canPayFee, inputs, setInputs }: Props): React.ReactElement {
   const { t } = useTranslation();
   const theme = useTheme();
 
   const { address, assetId, genesisHash } = useParams<{ address: string, genesisHash: string, assetId: string }>();
   const accountAssets = useAccountAssets(address);
-  const { chainName, token: sourceChainNativeToken } = useChainInfo(genesisHash);
+  const { chainName } = useChainInfo(genesisHash);
 
   const assetToTransfer = useMemo(() =>
     accountAssets?.find((asset) => asset.genesisHash === genesisHash && String(asset.assetId) === assetId),
-  [accountAssets, assetId, genesisHash]);
+    [accountAssets, assetId, genesisHash]);
 
   const logoInfo = useMemo(() => getLogo2(genesisHash, assetToTransfer?.token), [assetToTransfer?.token, genesisHash]);
-  const feeLogoInfo = useMemo(() => getLogo2(genesisHash, sourceChainNativeToken), [genesisHash, sourceChainNativeToken]);
 
   return (
     <Motion variant='fade'>
@@ -78,24 +77,13 @@ export default function Step4Summary ({ canPayFee, inputs }: Props): React.React
         />
       </Stack>
       <Stack direction='column' sx={{ m: '25px 10px 20px', width: '766px' }}>
-        <Stack direction='row' justifyContent='space-between' sx={{ px: '15px' }}>
-          <Typography color='primary.main' sx={{ textAlign: 'left' }} variant='B-1'>
-            {t('Estimated fee')}
-          </Typography>
-          <Stack alignItems='center' columnGap='5px' direction='row' justifyContent='end'>
-            {canPayFee.isAbleToPay === false && canPayFee.warning &&
-              <UnableToPayFee warningText={canPayFee.warning} />
-            }
-            <Typography color='text.primary' sx={{ ml: '5px', textAlign: 'left' }} variant='B-1'>
-              <ShowBalance4
-                balance={inputs.paraSpellFee ?? inputs.fee}
-                decimalPoint={FLOATING_POINT_DIGIT}
-                genesisHash={genesisHash}
-              />
-            </Typography>
-            <AssetLogo assetSize='18px' genesisHash={genesisHash} logo={feeLogoInfo?.logo} />
-          </Stack>
-        </Stack>
+        <FeeRow
+          address={address}
+          canPayFee={canPayFee}
+          genesisHash={genesisHash}
+          inputs={inputs}
+          setInputs={setInputs}
+        />
         <Box sx={{ background: 'linear-gradient(90deg, rgba(210, 185, 241, 0.03) 0%, rgba(210, 185, 241, 0.15) 50.06%, rgba(210, 185, 241, 0.03) 100%)', height: '1px', my: '10px', width: '766px' }} />
       </Stack>
     </Motion>

--- a/packages/extension-polkagate/src/fullscreen/sendFund/index.tsx
+++ b/packages/extension-polkagate/src/fullscreen/sendFund/index.tsx
@@ -28,8 +28,8 @@ import { type Inputs } from './types';
 
 export default function SendFund (): React.ReactElement {
   const { t } = useTranslation();
-
   const { address, assetId, genesisHash } = useParams<{ address: string, genesisHash: string, assetId: string }>();
+
   const ref = useRef<HTMLDivElement | null>(null);
   const teleportState = useTeleport(genesisHash);
   const navigate = useNavigate();
@@ -62,10 +62,7 @@ export default function SendFund (): React.ReactElement {
 
   const inputTransaction = inputs?.paraSpellTransaction ?? inputs?.transaction;
 
-  const isLoading = useMemo(() =>
-    (inputStep === INPUT_STEPS.AMOUNT && !(inputs?.amount && inputTransaction && inputs?.fee))
-    ,
-    [inputStep, inputs, inputTransaction]);
+  const isLoading = useMemo(() => (inputStep === INPUT_STEPS.AMOUNT && !(inputs?.amount && inputTransaction && inputs?.fee)), [inputStep, inputs, inputTransaction]);
 
   const buttonDisable = useMemo(() =>
     (inputStep === INPUT_STEPS.SENDER && !inputs?.token) ||
@@ -78,6 +75,7 @@ export default function SendFund (): React.ReactElement {
   const transactionDetail = useMemo(() => {
     return {
       amount: inputs?.amountAsBN,
+      assetDecimal: inputs?.decimal,
       description: t('Amount'),
       extra: {
         from: formatted,
@@ -85,11 +83,11 @@ export default function SendFund (): React.ReactElement {
         // eslint-disable-next-line sort-keys
         recipientNetwork: inputs?.recipientChain?.text
       },
-      fee: inputs?.fee,
       ...txInfo,
-      token: inputs?.token // since an asset may be transferring other than native hence we overwrite native token
+      fee: inputs?.feeInfo,
+      token: inputs?.token // since a token other than native token might be transferred, hence we overwrite native token
     } as TransactionDetail;
-  }, [formatted, inputs?.amountAsBN, inputs?.fee, inputs?.recipientAddress, inputs?.recipientChain?.text, inputs?.token, t, txInfo]);
+  }, [formatted, inputs?.amountAsBN, inputs?.decimal, inputs?.feeInfo, inputs?.recipientAddress, inputs?.recipientChain?.text, inputs?.token, t, txInfo]);
 
   return (
     <HomeLayout
@@ -133,6 +131,7 @@ export default function SendFund (): React.ReactElement {
           <Step4Summary
             canPayFee={canPayFee}
             inputs={inputs}
+            setInputs={setInputs}
             teleportState={teleportState}
           />
         }
@@ -189,6 +188,7 @@ export default function SendFund (): React.ReactElement {
                   }
                 }
               }}
+              signerOption={inputs?.feeInfo?.assetId ? { assetId: inputs.feeInfo.assetId } : undefined}
               style={{ position: 'unset', width: '73%' }}
               transaction={inputTransaction}
               withCancel

--- a/packages/extension-polkagate/src/fullscreen/sendFund/partials/FeeRow.tsx
+++ b/packages/extension-polkagate/src/fullscreen/sendFund/partials/FeeRow.tsx
@@ -27,7 +27,7 @@ interface Props {
   setInputs: React.Dispatch<React.SetStateAction<Inputs | undefined>>
 }
 
-export default function FeeRow({ address, canPayFee, genesisHash, inputs, setInputs }: Props): React.ReactElement {
+export default function FeeRow ({ address, canPayFee, genesisHash, inputs, setInputs }: Props): React.ReactElement {
   const { t } = useTranslation();
   const containerRef = useRef<HTMLDivElement>(null);
 

--- a/packages/extension-polkagate/src/fullscreen/sendFund/partials/FeeRow.tsx
+++ b/packages/extension-polkagate/src/fullscreen/sendFund/partials/FeeRow.tsx
@@ -12,7 +12,7 @@ import getLogo2 from '@polkadot/extension-polkagate/src/util/getLogo2';
 import { isOnAssetHub } from '@polkadot/extension-polkagate/src/util/utils';
 
 import { AssetLogo, ShowBalance4 } from '../../../components';
-import { useChainInfo, useFormatted, useTranslation } from '../../../hooks';
+import { useAccount, useChainInfo, useFormatted, useTranslation } from '../../../hooks';
 import { UnableToPayFee } from '../../../partials';
 import usePartialFee from '../usePartialFee';
 import usePayWithAsset from '../usePayWithAsset';
@@ -34,6 +34,7 @@ export default function FeeRow ({ address, canPayFee, genesisHash, inputs, setIn
   const { api, decimal, token } = useChainInfo(genesisHash);
   const feeAssets = usePayWithAsset(genesisHash);
   const formatted = useFormatted(address, genesisHash);
+  const account = useAccount(address);
 
   const [openTokenList, setOpenTokenList] = useState<boolean>(false);
   const [selectedAssetId, setSelectedAssetId] = useState<string>();
@@ -94,13 +95,15 @@ export default function FeeRow ({ address, canPayFee, genesisHash, inputs, setIn
     setOpenTokenList(false);
   }, []);
 
+  const showFeeSelector = !!feeAssets?.length && !account?.isExternal;
+
   return (
     <Stack alignItems='center' direction='row' justifyContent='space-between' sx={{ height: '22px', px: '15px' }}>
       <Typography color='primary.main' sx={{ textAlign: 'left' }} variant='B-1'>
         {t('Estimated fee')}
       </Typography>
       <ClickAwayListener onClickAway={handleClickAway}>
-        <Stack alignItems='center' columnGap='5px' direction='row' justifyContent='end' ref={containerRef} sx={{ transform: feeAssets?.length ? 'translateX(0)' : 'translateX(10px)', transition: 'all 400ms ease-out' }}>
+        <Stack alignItems='center' columnGap='5px' direction='row' justifyContent='end' ref={containerRef} sx={{ transform: showFeeSelector ? 'translateX(0)' : 'translateX(10px)', transition: 'all 400ms ease-out' }}>
           {canPayFee.isAbleToPay === false && canPayFee.warning &&
             <UnableToPayFee warningText={canPayFee.warning} />
           }
@@ -113,7 +116,7 @@ export default function FeeRow ({ address, canPayFee, genesisHash, inputs, setIn
             />
           </Typography>
           <AssetLogo assetSize='18px' genesisHash={genesisHash} logo={feeLogoInfo?.logo} />
-          {!!feeAssets?.length &&
+          {showFeeSelector &&
             <OpenerButton
               flip
               onClick={onToggleTokenSelection}

--- a/packages/extension-polkagate/src/fullscreen/sendFund/partials/FeeRow.tsx
+++ b/packages/extension-polkagate/src/fullscreen/sendFund/partials/FeeRow.tsx
@@ -1,0 +1,133 @@
+// Copyright 2019-2025 @polkadot/extension-polkagate authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { CanPayFee, FetchedBalance } from '../../../util/types';
+import type { FeeInfo, Inputs } from '../types';
+
+import { ClickAwayListener, Stack, Typography } from '@mui/material';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { FLOATING_POINT_DIGIT, NATIVE_TOKEN_ASSET_ID, NATIVE_TOKEN_ASSET_ID_ON_ASSETHUB } from '@polkadot/extension-polkagate/src/util/constants';
+import getLogo2 from '@polkadot/extension-polkagate/src/util/getLogo2';
+import { isOnAssetHub } from '@polkadot/extension-polkagate/src/util/utils';
+
+import { AssetLogo, ShowBalance4 } from '../../../components';
+import { useChainInfo, useFormatted, useTranslation } from '../../../hooks';
+import { UnableToPayFee } from '../../../partials';
+import usePartialFee from '../usePartialFee';
+import usePayWithAsset from '../usePayWithAsset';
+import CustomizedDropDown from './CustomizedDropDown';
+import OpenerButton from './OpenerButton';
+
+interface Props {
+  address: string | undefined;
+  canPayFee: CanPayFee;
+  inputs: Inputs;
+  genesisHash: string | undefined;
+  setInputs: React.Dispatch<React.SetStateAction<Inputs | undefined>>
+}
+
+export default function FeeRow({ address, canPayFee, genesisHash, inputs, setInputs }: Props): React.ReactElement {
+  const { t } = useTranslation();
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const { api, decimal, token } = useChainInfo(genesisHash);
+  const feeAssets = usePayWithAsset(genesisHash);
+  const formatted = useFormatted(address, genesisHash);
+
+  const [openTokenList, setOpenTokenList] = useState<boolean>(false);
+  const [selectedAssetId, setSelectedAssetId] = useState<string>();
+
+  const maybeSelectedNonNativeFeeAsset = useMemo(() => feeAssets?.find(({ id }) => id.toString() === selectedAssetId), [feeAssets, selectedAssetId]);
+  const maybePartialFee = usePartialFee(api, inputs, formatted, maybeSelectedNonNativeFeeAsset?.multiLocation);
+
+  const feeAssetsToShow = useMemo(() => {
+    const nativeAsset = {
+      assetId: isOnAssetHub(genesisHash) ? NATIVE_TOKEN_ASSET_ID_ON_ASSETHUB : NATIVE_TOKEN_ASSET_ID,
+      genesisHash,
+      token
+    };
+
+    const nonNativeAssets = feeAssets?.map(({ id, symbol }) => ({ assetId: id, genesisHash, token: symbol }));
+
+    if (!maybeSelectedNonNativeFeeAsset) {
+      return nonNativeAssets as unknown as Partial<FetchedBalance>[];
+    }
+
+    const filteredNonNativeAssets = nonNativeAssets?.filter(({ assetId }) => !assetId.eq(maybeSelectedNonNativeFeeAsset.id)) as unknown as Partial<FetchedBalance>[];
+
+    return [...filteredNonNativeAssets, nativeAsset] as Partial<FetchedBalance>[];
+  }, [feeAssets, genesisHash, maybeSelectedNonNativeFeeAsset, token]);
+
+  const feeInfo: FeeInfo = useMemo(() => {
+    if (maybeSelectedNonNativeFeeAsset) {
+      return {
+        assetId: maybeSelectedNonNativeFeeAsset?.multiLocation,
+        decimal: Number(maybeSelectedNonNativeFeeAsset.decimals),
+        fee: maybePartialFee,
+        token: maybeSelectedNonNativeFeeAsset.symbol.toString()
+      };
+    }
+
+    return {
+      decimal,
+      fee: inputs.fee,
+      token
+    };
+  }, [decimal, inputs.fee, maybeSelectedNonNativeFeeAsset, maybePartialFee, token]);
+
+  useEffect(() => {
+    setInputs((prevInputs) => ({
+      ...(prevInputs || {}),
+      feeInfo
+    }));
+  }, [feeInfo, setInputs]);
+
+  const feeLogoInfo = useMemo(() => getLogo2(genesisHash, feeInfo.token), [feeInfo.token, genesisHash]);
+  const onToggleTokenSelection = useCallback(() => {
+    setOpenTokenList(!openTokenList);
+  }, [openTokenList]);
+
+  const handleClickAway = useCallback(() => {
+    setOpenTokenList(false);
+  }, []);
+
+  return (
+    <Stack alignItems='center' direction='row' justifyContent='space-between' sx={{ height: '22px', px: '15px' }}>
+      <Typography color='primary.main' sx={{ textAlign: 'left' }} variant='B-1'>
+        {t('Estimated fee')}
+      </Typography>
+      <ClickAwayListener onClickAway={handleClickAway}>
+        <Stack alignItems='center' columnGap='5px' direction='row' justifyContent='end' ref={containerRef} sx={{ transform: feeAssets?.length ? 'translateX(0)' : 'translateX(10px)', transition: 'all 400ms ease-out' }}>
+          {canPayFee.isAbleToPay === false && canPayFee.warning &&
+            <UnableToPayFee warningText={canPayFee.warning} />
+          }
+          <Typography color='text.primary' sx={{ ml: '5px', textAlign: 'left' }} variant='B-1'>
+            <ShowBalance4
+              balance={feeInfo.fee}
+              decimal={feeInfo.decimal}
+              decimalPoint={FLOATING_POINT_DIGIT}
+              token={feeInfo.token}
+            />
+          </Typography>
+          <AssetLogo assetSize='18px' genesisHash={genesisHash} logo={feeLogoInfo?.logo} />
+          {!!feeAssets?.length &&
+            <OpenerButton
+              flip
+              onClick={onToggleTokenSelection}
+            />
+          }
+        </Stack>
+      </ClickAwayListener>
+      {!!feeAssets?.length && openTokenList &&
+        <CustomizedDropDown
+          assets={feeAssetsToShow}
+          containerRef={containerRef}
+          open={openTokenList}
+          setSelectedAsset={setSelectedAssetId}
+          style={{ marginLeft: '6px' }}
+        />
+      }
+    </Stack>
+  );
+}

--- a/packages/extension-polkagate/src/fullscreen/sendFund/partials/FeeRow.tsx
+++ b/packages/extension-polkagate/src/fullscreen/sendFund/partials/FeeRow.tsx
@@ -54,7 +54,9 @@ export default function FeeRow({ address, canPayFee, genesisHash, inputs, setInp
       return nonNativeAssets as unknown as Partial<FetchedBalance>[];
     }
 
-    const filteredNonNativeAssets = nonNativeAssets?.filter(({ assetId }) => !assetId.eq(maybeSelectedNonNativeFeeAsset.id)) as unknown as Partial<FetchedBalance>[];
+    const filteredNonNativeAssets = nonNativeAssets?.filter(({ assetId }) => {
+      return assetId?.toString() !== maybeSelectedNonNativeFeeAsset.id.toString();
+    }) as unknown as Partial<FetchedBalance>[];
 
     return [...filteredNonNativeAssets, nativeAsset] as Partial<FetchedBalance>[];
   }, [feeAssets, genesisHash, maybeSelectedNonNativeFeeAsset, token]);

--- a/packages/extension-polkagate/src/fullscreen/sendFund/partials/FromToBox.tsx
+++ b/packages/extension-polkagate/src/fullscreen/sendFund/partials/FromToBox.tsx
@@ -4,6 +4,8 @@
 import { Stack, Typography } from '@mui/material';
 import React from 'react';
 
+import { toTitleCase } from '@polkadot/extension-polkagate/src/util';
+
 import { ChainLogo, Identity2 } from '../../../components';
 
 interface Props {
@@ -23,7 +25,7 @@ export default function FromToBox ({ address, chainName, genesisHash, label }: P
         <Stack alignItems='center' columnGap='3px' direction='row' justifyContent='start' sx={{ bgcolor: '#1B133C', border: '1px solid #2D1E4A', borderRadius: '6px', height: 'fit-content', px: '7px', textAlign: 'left' }}>
           <ChainLogo chainName={chainName} size={14} />
           <Typography color='primary.main' variant='B-1'>
-            {chainName}
+            {toTitleCase(chainName)}
           </Typography>
         </Stack>
       </Stack>

--- a/packages/extension-polkagate/src/fullscreen/sendFund/partials/SelectYourChain.tsx
+++ b/packages/extension-polkagate/src/fullscreen/sendFund/partials/SelectYourChain.tsx
@@ -17,7 +17,7 @@ interface Props {
   destinationOptions?: DropdownOption[];
   chainName: string | undefined;
   withTitle?: boolean;
-  setSelectedChain?: React.Dispatch<React.SetStateAction<DropdownOption | undefined>>;
+  setSelectedChain?: React.Dispatch<React.SetStateAction<DropdownOption>>;
   style?: React.CSSProperties;
 }
 

--- a/packages/extension-polkagate/src/fullscreen/sendFund/partials/SelectYourChain.tsx
+++ b/packages/extension-polkagate/src/fullscreen/sendFund/partials/SelectYourChain.tsx
@@ -17,7 +17,7 @@ interface Props {
   destinationOptions?: DropdownOption[];
   chainName: string | undefined;
   withTitle?: boolean;
-  setSelectedChain?: React.Dispatch<React.SetStateAction<DropdownOption>>;
+  setSelectedChain?: React.Dispatch<React.SetStateAction<DropdownOption | undefined>>;
   style?: React.CSSProperties;
 }
 

--- a/packages/extension-polkagate/src/fullscreen/sendFund/types.ts
+++ b/packages/extension-polkagate/src/fullscreen/sendFund/types.ts
@@ -3,7 +3,10 @@
 
 import type { SubmittableExtrinsic } from '@polkadot/api-base/types';
 import type { DropdownOption } from '@polkadot/extension-polkagate/util/types';
-import type { ISubmittableResult } from '@polkadot/types/types';
+//@ts-ignore
+import type { PalletAssetsAssetDetails, PalletAssetsAssetMetadata } from '@polkadot/types/lookup';
+import type { AnyNumber, ISubmittableResult } from '@polkadot/types/types';
+import type { Bytes } from '@polkadot/types-codec';
 import type { BN } from '@polkadot/util';
 
 export interface Inputs {
@@ -11,11 +14,28 @@ export interface Inputs {
   amountAsBN?: BN;
   decimal?: number;
   fee?: BN;
-  paraSpellFee?: BN;
   paraSpellTransaction?: SubmittableExtrinsic<'promise', ISubmittableResult>;
   transaction?: SubmittableExtrinsic<'promise', ISubmittableResult>;
   recipientAddress?: string | undefined;
   recipientChain?: DropdownOption | undefined; // NOTE: value cold be genesis hash or para id!
   recipientGenesisHashOrParaId?: string | undefined;
   token?: string;
+  feeInfo?: FeeInfo | undefined;
+}
+
+export interface FeeAssetInfo {
+  deposit: BN;
+  name: Bytes;
+  symbol: Bytes;
+  decimals: BN;
+  isFrozen: boolean;
+  id: BN;
+  multiLocation: AnyNumber | object;
+}
+
+export interface FeeInfo {
+  assetId?: object | AnyNumber;
+  decimal: number | undefined;
+  fee: BN | null | undefined;
+  token: string | undefined;
 }

--- a/packages/extension-polkagate/src/fullscreen/sendFund/types.ts
+++ b/packages/extension-polkagate/src/fullscreen/sendFund/types.ts
@@ -3,8 +3,6 @@
 
 import type { SubmittableExtrinsic } from '@polkadot/api-base/types';
 import type { DropdownOption } from '@polkadot/extension-polkagate/util/types';
-//@ts-ignore
-import type { PalletAssetsAssetDetails, PalletAssetsAssetMetadata } from '@polkadot/types/lookup';
 import type { AnyNumber, ISubmittableResult } from '@polkadot/types/types';
 import type { Bytes } from '@polkadot/types-codec';
 import type { BN } from '@polkadot/util';

--- a/packages/extension-polkagate/src/fullscreen/sendFund/useParaSpellFeeCall.ts
+++ b/packages/extension-polkagate/src/fullscreen/sendFund/useParaSpellFeeCall.ts
@@ -67,7 +67,7 @@ export default function useParaSpellFeeCall (address: string | undefined, amount
         setError('Something went wrong while calculating estimated fee!');
         console.error('Something went wrong while getting fee', err);
       });
-  }, [address, senderChainName, amountAsBN, genesisHash, setError, inputs?.assetId, inputs?.token, inputs?.recipientChain?.text, inputs?.recipientAddress, inputs?.amount, inputs?.recipientChain?.value]);
+  }, [api, address, senderChainName, amountAsBN, genesisHash, setError, inputs?.assetId, inputs?.token, inputs?.recipientChain?.text, inputs?.recipientAddress, inputs?.amount, inputs?.recipientChain?.value]);
 
   return {
     paraSpellFee,

--- a/packages/extension-polkagate/src/fullscreen/sendFund/useParaSpellFeeCall.ts
+++ b/packages/extension-polkagate/src/fullscreen/sendFund/useParaSpellFeeCall.ts
@@ -12,7 +12,7 @@ import { useEffect, useState } from 'react';
 import { TEST_NETS } from '@polkadot/extension-polkagate/src/util/constants';
 import { BN } from '@polkadot/util';
 
-import { isOnSameChain, reorderAssetHubLabel } from './utils';
+import { isOnSameChain, normalizeChainName } from './utils';
 
 export default function useParaSpellFeeCall (address: string | undefined, amountAsBN: BN | undefined, genesisHash: string | undefined, inputs: Inputs | undefined, senderChainName: string | undefined, setError: React.Dispatch<React.SetStateAction<string | undefined>>) {
   const [paraSpellFee, setParaSpellFee] = useState<BN>();
@@ -25,7 +25,7 @@ export default function useParaSpellFeeCall (address: string | undefined, amount
       return;
     }
 
-    const _senderChainName = reorderAssetHubLabel(senderChainName);
+    const _senderChainName = normalizeChainName(senderChainName);
 
     if (isOnSameChain(senderChainName, _recipientChainName)) {
       console.info('No need to PS, only use it for xcm ...');

--- a/packages/extension-polkagate/src/fullscreen/sendFund/usePartialFee.ts
+++ b/packages/extension-polkagate/src/fullscreen/sendFund/usePartialFee.ts
@@ -1,0 +1,54 @@
+// Copyright 2019-2025 @polkadot/extension-polkagate authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ApiPromise } from '@polkadot/api';
+import type { AnyNumber } from '@polkadot/types-codec/types';
+import type { Inputs } from './types';
+
+import { useEffect, useState } from 'react';
+
+import { BN, nextTick } from '@polkadot/util';
+
+export default function usePartialFee (
+  api: ApiPromise | undefined,
+  inputs: Inputs | undefined,
+  formatted: string | undefined,
+  assetId: object | AnyNumber | undefined
+): BN | undefined | null {
+  const [partialFee, setPartialFee] = useState<BN | null>();
+
+  const inputTransaction = inputs?.paraSpellTransaction ?? inputs?.transaction;
+
+  useEffect((): void => {
+    assetId && api && formatted && inputTransaction && inputTransaction.hasPaymentInfo &&
+      nextTick(async (): Promise<void> => {
+        setPartialFee(undefined);
+
+        const signerOptions = { assetId };
+
+        try {
+          const info = await inputTransaction.paymentInfo(formatted, signerOptions);
+
+          if (signerOptions?.assetId) {
+            const convertedFee = new BN((await api.call['assetConversionApi']['quotePriceTokensForExactTokens'](
+              signerOptions?.assetId as string,
+              {
+                interior: 'Here',
+                parents: 1
+              } as unknown as string,
+              info.partialFee,
+              true
+            )).toString());
+
+            setPartialFee(convertedFee);
+          } else {
+            setPartialFee(info.partialFee);
+          }
+        } catch (error) {
+          console.error(error);
+        }
+      });
+  }, [api, assetId, formatted, inputTransaction]);
+
+  return partialFee;
+}

--- a/packages/extension-polkagate/src/fullscreen/sendFund/usePartialFee.ts
+++ b/packages/extension-polkagate/src/fullscreen/sendFund/usePartialFee.ts
@@ -30,7 +30,7 @@ export default function usePartialFee (
           const info = await inputTransaction.paymentInfo(formatted, signerOptions);
 
           if (signerOptions?.assetId) {
-         try {
+            try {
               if (!api.call['assetConversionApi']?.['quotePriceTokensForExactTokens']) {
                 console.warn('Asset conversion API not available');
                 setPartialFee(info.partialFee);

--- a/packages/extension-polkagate/src/fullscreen/sendFund/usePayWithAsset.ts
+++ b/packages/extension-polkagate/src/fullscreen/sendFund/usePayWithAsset.ts
@@ -27,7 +27,7 @@ const getFeeAssetLocation = (api: ApiPromise, id: BN): AnyNumber | object => {
   };
 };
 
-export default function usePayWithAsset(genesisHash: string | undefined): FeeAssetInfo[] | undefined {
+export default function usePayWithAsset (genesisHash: string | undefined): FeeAssetInfo[] | undefined {
   const { api } = useChainInfo(genesisHash);
   const [feeAssetsInfo, setFeeAssetsInfo] = useState<FeeAssetInfo[]>();
   const [sufficientAssetIds, setSufficientAssetIds] = useState<BN[]>();

--- a/packages/extension-polkagate/src/fullscreen/sendFund/usePayWithAsset.ts
+++ b/packages/extension-polkagate/src/fullscreen/sendFund/usePayWithAsset.ts
@@ -1,0 +1,79 @@
+// Copyright 2019-2025 @polkadot/extension-polkagate authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ApiPromise } from '@polkadot/api';
+//@ts-ignore
+import type { PalletAssetsAssetMetadata } from '@polkadot/types/lookup';
+import type { AnyNumber } from '@polkadot/types-codec/types';
+import type { FeeAssetInfo } from './types';
+
+import { useEffect, useState } from 'react';
+
+import { BN } from '@polkadot/util';
+
+import { useChainInfo } from '../../hooks';
+
+const getFeeAssetLocation = (api: ApiPromise, id: BN): AnyNumber | object => {
+  const metadata = api.registry.metadata;
+  const palletIndex = metadata.pallets.filter((a) => a.name.toString() === 'Assets')[0].index.toString();
+
+  // FIX ME: it may not be applicable for all chains
+  const palletInstance = { PalletInstance: palletIndex };
+  const generalIndex = { GeneralIndex: id };
+
+  return {
+    interior: { X2: [palletInstance, generalIndex] },
+    parents: 0
+  };
+};
+
+export default function usePayWithAsset (genesisHash: string | undefined): FeeAssetInfo[] | undefined {
+  const { api } = useChainInfo(genesisHash);
+  const [feeAssetsInfo, setFeeAssetsInfo] = useState<FeeAssetInfo[]>();
+  const [sufficientAssetIds, setSufficientAssetIds] = useState<BN[]>();
+
+  useEffect(() => {
+    if (!api) {
+      return;
+    }
+
+    setFeeAssetsInfo(undefined);
+
+    api.query['assets']?.['asset'].entries().then((res) => {
+      const isSufficientAssets = res.filter(([, asset]) => {
+        //@ts-ignore
+        return asset.toPrimitive()?.isSufficient;
+      });
+
+      const ids = isSufficientAssets.map(([id, _]) => {
+        const assetIdInHuman = id.toHuman() as string[];
+
+        return new BN(assetIdInHuman[0].replaceAll(',', ''));
+      });
+
+      setSufficientAssetIds(ids);
+    }).catch(console.error);
+  }, [api, genesisHash]);
+
+  useEffect(() => {
+    if (!api || !sufficientAssetIds?.length) {
+      return;
+    }
+
+    api.query['assets']?.['metadata'].multi(sufficientAssetIds).then((res) => {
+      const info = res.map((r, index) => {
+        const id = sufficientAssetIds[index];
+
+        return {
+          id,
+          multiLocation: getFeeAssetLocation(api, id),
+          ...(r.toPrimitive() as unknown as PalletAssetsAssetMetadata)
+        } as unknown as FeeAssetInfo;
+      });
+
+      setFeeAssetsInfo(info);
+    }).catch(console.error);
+  }, [api, sufficientAssetIds]);
+
+  return feeAssetsInfo;
+}

--- a/packages/extension-polkagate/src/fullscreen/sendFund/utils.tsx
+++ b/packages/extension-polkagate/src/fullscreen/sendFund/utils.tsx
@@ -69,7 +69,7 @@ export function getSupportedDestinations (sourceChain: TNodeWithRelayChains | st
 export function isNativeAsset (api: ApiPromise, token: string, assetId: number | string) {
   const isAssetHub = isOnAssetHub(api.genesisHash.toHex());
 
-  if (isAssetHub && assetId === NATIVE_TOKEN_ASSET_ID_ON_ASSETHUB) {
+  if (isAssetHub && Number(assetId) === NATIVE_TOKEN_ASSET_ID_ON_ASSETHUB) {
     return true;
   }
 

--- a/packages/extension-polkagate/src/fullscreen/sendFund/utils.tsx
+++ b/packages/extension-polkagate/src/fullscreen/sendFund/utils.tsx
@@ -1,9 +1,13 @@
 // Copyright 2019-2025 @polkadot/extension-polkagate authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import type { ApiPromise } from '@polkadot/api';
 import type { DropdownOption } from '@polkadot/extension-polkagate/src/util/types';
 
 import { getParaId, getRelayChainSymbol, hasSupportForAsset, NODES_WITH_RELAY_CHAINS_DOT_KSM, type TNodeWithRelayChains } from '@paraspell/sdk-pjs';
+
+import { NATIVE_TOKEN_ASSET_ID_ON_ASSETHUB } from '@polkadot/extension-polkagate/src/util/constants';
+import { isOnAssetHub } from '@polkadot/extension-polkagate/src/util/utils';
 
 export const XCM_LOC = ['xcm', 'xcmPallet', 'polkadotXcm'];
 export const INVALID_PARA_ID = Number.MAX_SAFE_INTEGER;
@@ -60,4 +64,16 @@ export function getSupportedDestinations (sourceChain: TNodeWithRelayChains | st
   }
 
   return destinationChains;
+}
+
+export function isNativeAsset (api: ApiPromise, token: string, assetId: number | string) {
+  const isAssetHub = isOnAssetHub(api.genesisHash.toHex());
+
+  if (isAssetHub && assetId === NATIVE_TOKEN_ASSET_ID_ON_ASSETHUB) {
+    return true;
+  }
+
+  const nativeTokens = api.registry.chainTokens; // e.g., ['KSM']
+
+  return nativeTokens.includes(token);
 }

--- a/packages/extension-polkagate/src/fullscreen/sendFund/utils.tsx
+++ b/packages/extension-polkagate/src/fullscreen/sendFund/utils.tsx
@@ -8,7 +8,7 @@ import { getParaId, getRelayChainSymbol, hasSupportForAsset, NODES_WITH_RELAY_CH
 export const XCM_LOC = ['xcm', 'xcmPallet', 'polkadotXcm'];
 export const INVALID_PARA_ID = Number.MAX_SAFE_INTEGER;
 
-export function reorderAssetHubLabel (label: string): string {
+export function normalizeChainName (label: string): string {
   if (label.endsWith('AssetHub')) {
     return 'AssetHub' + label.replace('AssetHub', '');
   }
@@ -29,8 +29,8 @@ export const isOnSameChain = (senderChainName: string | undefined, recipientChai
     return;
   }
 
-  const _senderChainName = reorderAssetHubLabel(senderChainName);
-  const _recipientChainName = reorderAssetHubLabel(recipientChainName);
+  const _senderChainName = normalizeChainName(senderChainName);
+  const _recipientChainName = normalizeChainName(recipientChainName);
 
   return _senderChainName === _recipientChainName;
 };
@@ -40,7 +40,7 @@ export function getSupportedDestinations (sourceChain: TNodeWithRelayChains | st
     return [];
   }
 
-  const _sourceChainName = reorderAssetHubLabel(sourceChain) as TNodeWithRelayChains;
+  const _sourceChainName = normalizeChainName(sourceChain) as TNodeWithRelayChains;
   const destinationChains = [{ text: _sourceChainName, value: getParaId(_sourceChainName) }];
   const sourceRelayChainSymbol = getRelayChainSymbol(_sourceChainName);
 

--- a/packages/extension-polkagate/src/partials/Confirmation2.tsx
+++ b/packages/extension-polkagate/src/partials/Confirmation2.tsx
@@ -1,6 +1,7 @@
 // Copyright 2019-2025 @polkadot/extension-polkagate authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import type { FeeInfo } from '../fullscreen/sendFund/types';
 import type { TransactionDetail } from '../util/types';
 
 import { Container, Grid, Stack, Typography, useTheme } from '@mui/material';
@@ -69,15 +70,12 @@ const ConfirmationHeader = ({ genesisHash, transactionDetail }: SubProps) => {
             {token}
           </Typography>
         </Stack>
-        {/* <Typography color='text.highlight' variant='B-2'>
-          {transactionDetail}
-        </Typography> */}
       </Stack>
     </GlowBox>
   );
 };
 
-interface ListItemType { content: string | number | undefined; title: string; }
+interface ListItemType { content: FeeInfo | string | number | undefined; title: string; }
 
 const ConfirmationDetail = ({ genesisHash, transactionDetail }: SubProps) => {
   const { t } = useTranslation();
@@ -113,7 +111,7 @@ const ConfirmationDetail = ({ genesisHash, transactionDetail }: SubProps) => {
                   {content === undefined
                     ? '--'
                     : isHash
-                      ? toShortAddress(content.toString(), 6)
+                      ? toShortAddress(String(content), 6)
                       : (isFee || isAmount)
                         ? (
                           <FormatBalance2
@@ -129,7 +127,7 @@ const ConfirmationDetail = ({ genesisHash, transactionDetail }: SubProps) => {
                             tokens={[token ?? '']}
                             value={content as string}
                           />)
-                        : content
+                        : content as string
                   }
                 </Typography>
               </Container>

--- a/packages/extension-polkagate/src/popup/history/modal/HistoryDetailModal.tsx
+++ b/packages/extension-polkagate/src/popup/history/modal/HistoryDetailModal.tsx
@@ -25,7 +25,7 @@ interface Props {
   setShowDetail: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-export default function HistoryDetailModal({ chainName, decimal, info, setShowDetail, token }: Props): React.ReactElement {
+export default function HistoryDetailModal ({ chainName, decimal, info, setShowDetail, token }: Props): React.ReactElement {
   const { t } = useTranslation();
   const { accounts } = useContext(AccountContext);
   const options = { day: 'numeric', hour: 'numeric', minute: 'numeric', month: 'short', second: 'numeric', weekday: 'short', year: 'numeric' } as Intl.DateTimeFormatOptions;
@@ -92,7 +92,7 @@ export default function HistoryDetailModal({ chainName, decimal, info, setShowDe
           <Item item={`${t('Track Id')}: #${info.class}`} noDivider />
         }
         {info?.fee &&
-          <Amount amount={info?.fee} decimal={decimal} label={t('Fee')} token={token} />
+          <Amount amount={info?.fee as string} decimal={decimal} label={t('Fee')} token={token} />
         }
         <Divider
           sx={{

--- a/packages/extension-polkagate/src/util/types.ts
+++ b/packages/extension-polkagate/src/util/types.ts
@@ -23,6 +23,7 @@ import type { KeypairType } from '@polkadot/util-crypto/types';
 import type { LatestReferenda } from '../fullscreen/governance/types';
 import type { CurrencyItemType } from '../fullscreen/home/partials/type';
 import type { ItemInformation } from '../fullscreen/nft/utils/types';
+import type { FeeInfo } from '../fullscreen/sendFund/types';
 
 import { type SxProps, type Theme } from '@mui/material';
 
@@ -148,7 +149,7 @@ interface stashAccountDisplay {
 export interface TxResult {
   block?: number;
   txHash?: string;
-  fee?: string;
+  fee?: string | FeeInfo;
   success: boolean;
   failureText?: string;
 }
@@ -157,24 +158,25 @@ export interface TransactionDetail extends TxResult {
   action: string; // send, solo staking, pool staking, convictionvoting, ...
   amount?: string;
   chain?: Chain | null;
-  description?: string; // a short description which can be replace with 'Completed' text on success
   calls?: string[];
   class?: number;
   conviction?: string;
+  description?: string; // a short description which can be replace with 'Completed' text on success
   date: number;
   decimal?: number;
   delegatee?: string;
   deposit?: string;
+  extra?: Record<string, string>;
   from: NameAddress;
   nominators?: string[];
   poolId?: string;
   refId?: number;
+  assetDecimal?: number;
   subAction?: string; // bond_extra, unbound, nominate, vote, unvote, unlock, ...
   to?: NameAddress;
   token?: string;
   throughProxy?: NameAddress; // not available in subscan (can be removed)
   voteType?: number;
-  extra?: Record<string, string>
 }
 
 export type ExtraDetailConfirmationPage = Partial<TransactionDetail>;

--- a/packages/extension-polkagate/src/util/types.ts
+++ b/packages/extension-polkagate/src/util/types.ts
@@ -161,8 +161,8 @@ export interface TransactionDetail extends TxResult {
   calls?: string[];
   class?: number;
   conviction?: string;
-  description?: string; // a short description which can be replace with 'Completed' text on success
   date: number;
+  description?: string; // a short description which can be replace with 'Completed' text on success
   decimal?: number;
   delegatee?: string;
   deposit?: string;


### PR DESCRIPTION
closes ##1847

this just supports sign with password,
needs to be enabled for ledger and QR attached devices as well

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Pay network fees with selectable assets in the send flow; estimated fees update dynamically.
  - Per-asset decimals and tokens now display across summaries, confirmations, and history.

- Improvements
  - More accurate fee estimation with cross-asset conversion where supported.
  - Send summary uses a dedicated fee row for clearer presentation.
  - Recipient chain pre-fills from prior input; chain names display in Title Case.
  - Enhanced consistency of fee display and formatting across the app.
  - Added safeguards to prevent zero-amount transactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->