### PR TITLE
fix: resolve URL flicker in Manage Proxy when navigated from Home menu

### DIFF
--- a/packages/extension-polkagate/src/fullscreen/components/AccountChainSelect.tsx
+++ b/packages/extension-polkagate/src/fullscreen/components/AccountChainSelect.tsx
@@ -102,14 +102,17 @@ function ChainSwitcher ({ onClick }: { onClick: (toOpen: MODAL_TO_OPEN) => () =>
   );
 }
 
-function AccountSelect ({ noSelection = false, onClick }: { noSelection: boolean, onClick: (toOpen: MODAL_TO_OPEN) => () => void }): React.ReactElement {
+function AccountSelect ({ modalToOpen, noSelection = false, onClick }: { modalToOpen: MODAL_TO_OPEN, noSelection: boolean, onClick: (toOpen: MODAL_TO_OPEN) => () => void }): React.ReactElement {
   const theme = useTheme();
   const isDark = useIsDark();
   const { accounts } = useContext(AccountContext);
   const selectedAccount = useSelectedAccount();
   const { address } = useParams<{ address: string; genesisHash: string }>();
 
-  useUpdateSelectedAccount(selectedAccount?.address, address != selectedAccount?.address);
+  // Update the URL if it contains an address, the address has changed, and the account modal is open
+  const changeUrl = Boolean(address && address !== selectedAccount?.address && modalToOpen === MODAL_TO_OPEN.ACCOUNTS);
+
+  useUpdateSelectedAccount(selectedAccount?.address, changeUrl);
 
   return (
     <Grid container direction='row' item onClick={onClick(MODAL_TO_OPEN.ACCOUNTS)}
@@ -180,7 +183,11 @@ export default function AccountChainSelect ({ noSelection = false }: Props): Rea
           width: '145px'
         }}
       >
-        <AccountSelect noSelection={noSelection} onClick={onClick} />
+        <AccountSelect
+          modalToOpen={modalToOpen}
+          noSelection={noSelection}
+          onClick={onClick}
+        />
         <ChainSwitcher onClick={onClick} />
       </Container>
       <AccountListModal

--- a/packages/extension-polkagate/src/fullscreen/components/AccountListModal.tsx
+++ b/packages/extension-polkagate/src/fullscreen/components/AccountListModal.tsx
@@ -43,7 +43,7 @@ export default function AccountListModal ({ genesisHash, handleClose, isSelected
     handleClose();
   }, [handleClose]);
 
-  useUpdateSelectedAccount(appliedAddress, true, _handleClose);
+  useUpdateSelectedAccount(appliedAddress, open, _handleClose);
 
   useEffect(() => {
     setCategorizedAccounts(initialCategorizedAccounts);


### PR DESCRIPTION
To reproduce the issue on the main branch:
1. Assume the currently selected account is X.
2. From the Home screen, open the account menu for account Y and choose "Manage Proxy" to navigate to the Proxy Management page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account selection reliability: the selected account now syncs with the URL only when relevant, preventing unintended navigation.
  * Account List modal updates selection state only while open, reducing flicker and ensuring smoother close behavior.
  * Ensures consistent behavior across account and chain selection views without altering existing click paths or modal interactions.
  * Minor clarifications to selection logic enhance stability and predictability of account switching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->