### PR TITLE
fix: replace back button with 'Done' in extension mode on receive page

### DIFF
--- a/packages/extension-polkagate/src/popup/receive/Receive.tsx
+++ b/packages/extension-polkagate/src/popup/receive/Receive.tsx
@@ -222,7 +222,7 @@ function QrCode ({ address, onBackToAccount, selectedChain, setSelectedChain }: 
           height: '44px',
           width: '320px'
         }}
-        text={t('Back')}
+        text={t('Done')}
       />
     </Grid>
   );


### PR DESCRIPTION
Closes: #1860

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the button label in the QR code receive view from “Back” to “Done” for clearer completion cues.
  * Improves UX clarity and aligns wording with similar flows across the app, reducing potential confusion after viewing or sharing an address.
  * No functional changes; existing navigation and handlers remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->