### PR TITLE
fix: resolve back button issue in full-screen mode on Receive page

### DIFF
--- a/packages/extension-polkagate/src/fullscreen/accountDetails/rightColumn/Receive.tsx
+++ b/packages/extension-polkagate/src/fullscreen/accountDetails/rightColumn/Receive.tsx
@@ -22,6 +22,7 @@ interface Props {
   address: string | undefined;
   onClose?: () => void;
   closePopup: ExtensionPopupCloser;
+  setAddress?: React.Dispatch<React.SetStateAction<string | null | undefined>>;
 }
 
 interface AddressComponentProp {
@@ -126,7 +127,7 @@ function AddressComponent ({ address, chainName, onCopy }: AddressComponentProp)
   );
 }
 
-function Receive ({ address, closePopup, onClose }: Props): React.ReactElement {
+function Receive ({ address, closePopup, onClose, setAddress }: Props): React.ReactElement {
   const { t } = useTranslation();
   const account = useSelectedAccount();
 
@@ -159,11 +160,15 @@ function Receive ({ address, closePopup, onClose }: Props): React.ReactElement {
     }
 
     if (selectedChain) {
-      setSelectedChain(undefined);
-    } else {
-      closePopup();
+      return setSelectedChain(undefined);
     }
-  }, [onClose, selectedChain, closePopup]);
+
+    if (!selectedChain && setAddress) {
+      return setAddress(undefined);
+    }
+
+    closePopup();
+  }, [onClose, selectedChain, setAddress, closePopup]);
 
   const onDone = useCallback(() => {
     onClose && onClose();

--- a/packages/extension-polkagate/src/fullscreen/components/layout/ReceiveGeneral.tsx
+++ b/packages/extension-polkagate/src/fullscreen/components/layout/ReceiveGeneral.tsx
@@ -43,7 +43,7 @@ function ReceiveGeneral ({ closePopup, openPopup }: Props): React.ReactElement {
         <Receive
           address={address}
           closePopup={closePopup}
-          onClose={onClose}
+          setAddress={setAddress}
         />
       }
     </Grid>


### PR DESCRIPTION
Closes: #1862

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improved Receive screen behavior: selecting a network no longer closes the popup; clearing a selection resets the address without exiting; the popup only closes when explicitly dismissed.
  - More reliable, responsive address updates during the Receive flow.

- Refactor
  - Simplified interaction between the Receive view and its parent to allow direct address updates, resulting in a smoother, more predictable Receive experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->