### PR TITLE
chore: reset transaction flow on sender account switch

### DIFF
--- a/packages/extension-polkagate/src/fullscreen/sendFund/index.tsx
+++ b/packages/extension-polkagate/src/fullscreen/sendFund/index.tsx
@@ -45,6 +45,15 @@ export default function SendFund (): React.ReactElement {
   const canPayFee = useCanPayFeeAndDeposit(address, genesisHash, selectedProxy?.delegate, inputs?.fee ? toBN(inputs?.fee) : undefined);
 
   useEffect(() => {
+  if (!address || !genesisHash) {
+    return;
+  }
+
+  // Reset to the initial step if either address or genesisHash changes
+  setInputStep(INPUT_STEPS.SENDER);
+}, [address, genesisHash]);
+
+  useEffect(() => {
     cryptoWaitReady().then(() => keyring.loadAll({ store: new AccountsStore() })).catch(() => null);
   }, []);
 

--- a/packages/extension-polkagate/src/fullscreen/sendFund/index.tsx
+++ b/packages/extension-polkagate/src/fullscreen/sendFund/index.tsx
@@ -45,14 +45,33 @@ export default function SendFund (): React.ReactElement {
   const canPayFee = useCanPayFeeAndDeposit(address, genesisHash, selectedProxy?.delegate, inputs?.fee ? toBN(inputs?.fee) : undefined);
 
   useEffect(() => {
-  if (!address || !genesisHash) {
-    return;
-  }
+    if (!address || !genesisHash) {
+      return;
+    }
 
-  // Reset to the initial step if either address or genesisHash changes
-  setInputStep(INPUT_STEPS.SENDER);
-}, [address, genesisHash]);
+    const RESET_INPUTS: Partial<Inputs> = {
+      amount: undefined,
+      amountAsBN: undefined,
+      fee: undefined,
+      feeInfo: undefined,
+      paraSpellTransaction: undefined,
+      recipientAddress: undefined,
+      recipientChain: undefined,
+      recipientGenesisHashOrParaId: undefined,
+      transaction: undefined
+    };
 
+    // Reset the entire send flow on sender/network change
+    setInputStep(INPUT_STEPS.SENDER);
+    setInputs((prev) => ({
+      ...(prev || {}),
+      ...RESET_INPUTS
+    }));
+    setSelectedProxy(undefined);
+    setTxInfo(undefined);
+    setFlowStep(TRANSACTION_FLOW_STEPS.REVIEW);
+    setShowProxySelection(false);
+  }, [address, genesisHash]);
   useEffect(() => {
     cryptoWaitReady().then(() => keyring.loadAll({ store: new AccountsStore() })).catch(() => null);
   }, []);

--- a/packages/extension-polkagate/src/fullscreen/sendFund/types.ts
+++ b/packages/extension-polkagate/src/fullscreen/sendFund/types.ts
@@ -9,7 +9,7 @@ import type { BN } from '@polkadot/util';
 
 export interface Inputs {
   amount?: string | undefined;
-  amountAsBN?: BN;
+  amountAsBN?: BN | undefined;
   assetId?: string | number;
   decimal?: number;
   fee?: BN;


### PR DESCRIPTION
closes #1852

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The Send Funds flow now automatically returns to the Sender step when you change the selected account or network. This prevents stale or mismatched form data and avoids getting stuck in later steps after a context change. Previously, switching accounts/networks could leave inputs in an inconsistent state; the form now resets safely, prompting you to re-enter details under the new context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->