### PR TITLE
refactor: add reset button for proxies selected for removal

### DIFF
--- a/packages/extension-polkagate/src/fullscreen/manageProxies/Manage.tsx
+++ b/packages/extension-polkagate/src/fullscreen/manageProxies/Manage.tsx
@@ -15,6 +15,7 @@ import { BN_ZERO } from '@polkadot/util';
 
 import { ChainLogo, GradientButton, ShowBalance, ShowBalance4 } from '../../components';
 import { useTranslation } from '../../hooks';
+import { SelectionStatus } from '../stake/partials/FooterControls';
 import ProxyList from './components/ProxyList';
 import { STEPS } from './consts';
 import { type ProxyFlowStep } from './types';
@@ -91,6 +92,16 @@ export default function Manage ({ api, chain, decimal, depositedValue, isDisable
     setProxyItems(updatedProxyItems);
   }, [proxyItems, setProxyItems]);
 
+  const restoreRemovedItems = useCallback(() => {
+    setProxyItems((prev) =>
+      prev?.map((item) =>
+        item.status === 'remove'
+          ? { ...item, status: 'current' }
+          : item
+      )
+    );
+  }, [setProxyItems]);
+
   const toBeDeletedProxies = useMemo(() => proxyItems?.filter(({ status }) => status === 'remove'), [proxyItems]);
 
   return (
@@ -124,7 +135,7 @@ export default function Manage ({ api, chain, decimal, depositedValue, isDisable
               />}
           </Typography>
           {newDepositValue && depositedValue &&
-            <Stack columnGap= '3px' direction='row' sx={{ bgcolor: '#C6AECC26', borderRadius: '10px', px: '5px' }}>
+            <Stack columnGap='3px' direction='row' sx={{ bgcolor: '#C6AECC26', borderRadius: '10px', px: '5px' }}>
               <Typography color='primary.main' variant='B-1'>
                 {newDepositValue && !newDepositValue.isZero() && (newDepositValue.gt(depositedValue) ? '+' : '-')}
               </Typography>
@@ -148,18 +159,12 @@ export default function Manage ({ api, chain, decimal, depositedValue, isDisable
       {
         !!toBeDeletedProxies?.length &&
         <Stack alignItems='end' direction='row' justifyContent='space-between' sx={{ bottom: '0', position: 'absolute', width: '100%' }}>
-          <Stack alignItems='center' columnGap='10px' direction='row'>
-            <Firstline color='#674394' size='18px' variant='Bold' />
-            <Typography color='#EAEBF1' variant='B-2'>
-              {toBeDeletedProxies?.length}
-            </Typography>
-            <Typography color='#AA83DC' variant='B-4'>
-              {`/ ${proxyItems?.length} selected`}
-            </Typography>
-            <Typography color='#AA83DC' variant='H-4'>
-              X
-            </Typography>
-          </Stack>
+          <SelectionStatus
+            Icon={Firstline}
+            maxSelectable={proxyItems?.length}
+            onReset={restoreRemovedItems}
+            selectedCount={toBeDeletedProxies?.length}
+          />
           <GradientButton
             contentPlacement='center'
             disabled={isDisabledAddProxyButton}

--- a/packages/extension-polkagate/src/fullscreen/manageProxies/Manage.tsx
+++ b/packages/extension-polkagate/src/fullscreen/manageProxies/Manage.tsx
@@ -92,7 +92,7 @@ export default function Manage ({ api, chain, decimal, depositedValue, isDisable
     setProxyItems(updatedProxyItems);
   }, [proxyItems, setProxyItems]);
 
-  const restoreRemovedItems = useCallback(() => {
+  const clearRemoveChecks = useCallback(() => {
     setProxyItems((prev) =>
       prev?.map((item) =>
         item.status === 'remove'
@@ -162,7 +162,7 @@ export default function Manage ({ api, chain, decimal, depositedValue, isDisable
           <SelectionStatus
             Icon={Firstline}
             maxSelectable={proxyItems?.length}
-            onReset={restoreRemovedItems}
+            onReset={clearRemoveChecks}
             selectedCount={toBeDeletedProxies?.length}
           />
           <GradientButton

--- a/packages/extension-polkagate/src/fullscreen/manageProxies/Manage.tsx
+++ b/packages/extension-polkagate/src/fullscreen/manageProxies/Manage.tsx
@@ -71,23 +71,32 @@ export default function Manage ({ api, chain, decimal, depositedValue, isDisable
   }, [setStep]);
 
   const handleDelete = useCallback((proxyItem: ProxyItem) => {
-    const updatedProxyItems = proxyItems?.map((_proxyItem) => {
-      if (proxyItem.proxy.delegate === _proxyItem.proxy.delegate && proxyItem.proxy.proxyType === _proxyItem.proxy.proxyType) {
-        if (_proxyItem.status === 'new') {
-          return undefined;
-        } else if (_proxyItem.status === 'current') {
-          _proxyItem.status = 'remove';
+    if (!proxyItems) {
+      return;
+    }
 
-          return _proxyItem;
-        } else {
-          _proxyItem.status = 'current';
+    const updatedProxyItems = proxyItems
+      .map((_proxyItem) => {
+        const isTarget =
+          proxyItem.proxy.delegate === _proxyItem.proxy.delegate &&
+          proxyItem.proxy.proxyType === _proxyItem.proxy.proxyType;
 
+        if (!isTarget) {
           return _proxyItem;
         }
-      }
 
-      return _proxyItem;
-    }).filter((item) => !!item);
+        switch (_proxyItem.status) {
+          case 'new':
+            return null; // Remove newly added proxy
+          case 'current':
+            return { ..._proxyItem, status: 'remove' };// Mark current proxy for removal
+          case 'remove':
+            return { ..._proxyItem, status: 'current' };// Undo removal
+          default:
+            return _proxyItem;
+        }
+      })
+      .filter(Boolean) as ProxyItem[]; // remove nulls
 
     setProxyItems(updatedProxyItems);
   }, [proxyItems, setProxyItems]);

--- a/packages/extension-polkagate/src/fullscreen/manageProxies/TransactionFlow.tsx
+++ b/packages/extension-polkagate/src/fullscreen/manageProxies/TransactionFlow.tsx
@@ -192,6 +192,7 @@ function TransactionFlow ({ address, api, chain, depositedValue, proxyItems, set
       noDivider
       onClose={handleClose}
       open={true}
+      showBackIconAsClose
       style={{ backgroundColor: '#1B133C', minHeight: step === STEPS.WAIT_SCREEN ? '320px' : `${540 + extraHeight}px`, padding: '20px 15px 10px' }}
       title={
         [STEPS.REVIEW, STEPS.SIGN_QR].includes(step)

--- a/packages/extension-polkagate/src/fullscreen/manageProxies/components/ProxyAccountInfo.tsx
+++ b/packages/extension-polkagate/src/fullscreen/manageProxies/components/ProxyAccountInfo.tsx
@@ -5,7 +5,7 @@ import type { ProxyItem } from '../../../util/types';
 
 import { Grid, Stack, type SxProps, type Theme, Typography } from '@mui/material';
 import { POLKADOT_GENESIS } from '@polkagate/apps-config';
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 
 import useAccountSelectedChain from '@polkadot/extension-polkagate/src/hooks/useAccountSelectedChain';
 import PolkaGateIdenticon from '@polkadot/extension-polkagate/src/style/PolkaGateIdenticon';
@@ -40,6 +40,12 @@ export default function ProxyAccountInfo ({ handleDelete, proxyItem, showCheck =
   const genesisHash = useAccountSelectedChain(proxyItem.proxy.delegate);
 
   const [selected, setSelected] = useState(false);
+
+  useEffect(() => {
+    if (proxyItem.status !== 'remove' && selected) {
+      setSelected(false);
+    }
+  }, [proxyItem.status, selected]);
 
   const handleCheck = useCallback((checked: boolean) => {
     handleDelete(proxyItem);

--- a/packages/extension-polkagate/src/fullscreen/manageProxies/components/ProxyAccountInfo.tsx
+++ b/packages/extension-polkagate/src/fullscreen/manageProxies/components/ProxyAccountInfo.tsx
@@ -39,13 +39,11 @@ export default function ProxyAccountInfo ({ handleDelete, proxyItem, showCheck =
   const { t } = useTranslation();
   const genesisHash = useAccountSelectedChain(proxyItem.proxy.delegate);
 
-  const [selected, setSelected] = useState(false);
+  const [selected, setSelected] = useState(proxyItem.status === 'remove');
 
   useEffect(() => {
-    if (proxyItem.status !== 'remove' && selected) {
-      setSelected(false);
-    }
-  }, [proxyItem.status, selected]);
+      setSelected(proxyItem.status === 'remove');
+  }, [proxyItem.status]);
 
   const handleCheck = useCallback((checked: boolean) => {
     handleDelete(proxyItem);

--- a/packages/extension-polkagate/src/fullscreen/manageProxies/components/ProxyList.tsx
+++ b/packages/extension-polkagate/src/fullscreen/manageProxies/components/ProxyList.tsx
@@ -4,7 +4,7 @@
 import type { ProxyItem } from '../../../util/types';
 
 import { Grid, type SxProps, type Theme } from '@mui/material';
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 
 import { useTranslation } from '../../../components/translate';
 import { EmptyListBox } from '../../components';
@@ -21,11 +21,12 @@ export default function ProxyList ({ handleDelete, proxyItems, style }: Props): 
   const { t } = useTranslation();
   const _handleDelete = useCallback((proxyItem: ProxyItem) => handleDelete && handleDelete(proxyItem), [handleDelete]);
 
-  const isDeleting = proxyItems?.find(({ status }) => status === 'remove');
+  const isDeleting = useMemo(() => proxyItems?.find(({ status }) => status === 'remove'), [proxyItems]);
+  const itemsToShow = useMemo(() => proxyItems?.filter(({ status }) => status !== 'new'), [proxyItems]);
 
   return (
     <Grid alignItems='start' container gap='10px' item sx={{ maxHeight: isDeleting ? '464px' : '600px', mt: '10px', overflow: 'hidden', overflowY: 'auto', width: '100%', ...style }}>
-      {proxyItems?.filter(({ status }) => status !== 'new').map((proxyItem, index) => {
+      {itemsToShow?.map((proxyItem, index) => {
         return (
           <ProxyAccountInfo
             handleDelete={_handleDelete}

--- a/packages/extension-polkagate/src/fullscreen/stake/partials/FooterControls.tsx
+++ b/packages/extension-polkagate/src/fullscreen/stake/partials/FooterControls.tsx
@@ -1,27 +1,45 @@
 // Copyright 2019-2025 @polkadot/extension-polkagate authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { Container, type SxProps, type Theme, Typography, useTheme } from '@mui/material';
+import { Container, Grid, type SxProps, type Theme, Typography, useTheme } from '@mui/material';
 import { Add, ArrowLeft, type Icon } from 'iconsax-react';
 import React, { memo } from 'react';
 
 import { ActionButton, GradientButton, GradientDivider } from '../../../components';
 import { useTranslation } from '../../../hooks';
 
-interface Props {
-  onBack: () => void;
-  onReset: () => void;
-  onNext: () => void;
+interface SelectionStatusProps {
+  Icon: Icon;
   selectedCount: number | undefined;
   maxSelectable: number | undefined;
+  onReset: () => void;
+}
+
+export const SelectionStatus = ({ Icon, maxSelectable, onReset, selectedCount }: SelectionStatusProps) => {
+  const theme = useTheme();
+  const { t } = useTranslation();
+
+  return (
+    <Grid container item sx={{ alignItems: 'center', width: 'fit-content' }}>
+      <Icon color='#674394' size='18' variant='Bold' />
+      <Typography color='#AA83DC' ml='4px' variant='B-2'>
+        <span style={{ color: theme.palette.text.primary }}>{selectedCount || 0}</span>
+        {t(' / {{maxSelectable}} selected', { replace: { maxSelectable } })}
+      </Typography>
+      <Add color='#674394' onClick={onReset} size='28' style={{ cursor: 'pointer', rotate: '45deg' }} />
+    </Grid>
+  );
+};
+
+interface Props extends SelectionStatusProps {
+  onBack: () => void;
+  onNext: () => void;
   isNextDisabled: boolean;
-  Icon: Icon;
   style?: SxProps<Theme>;
 }
 
 function FooterControls ({ Icon, isNextDisabled, maxSelectable, onBack, onNext, onReset, selectedCount, style }: Props) {
   const { t } = useTranslation();
-  const theme = useTheme();
 
   return (
     <Container disableGutters sx={{ alignItems: 'center', display: 'flex', flexDirection: 'row', justifyContent: 'space-between', pt: '26px', width: '100%', zIndex: 1, ...style }}>
@@ -44,12 +62,12 @@ function FooterControls ({ Icon, isNextDisabled, maxSelectable, onBack, onNext, 
           orientation='vertical'
           style={{ height: '40px', mx: '4px' }}
         />
-        <Icon color='#674394' size='18' variant='Bold' />
-        <Typography color='#AA83DC' variant='B-2'>
-          <span style={{ color: theme.palette.text.primary }}>{selectedCount || 0}</span>
-          {t(' / {{maxSelectable}} selected', { replace: { maxSelectable } })}
-        </Typography>
-        <Add color='#674394' onClick={onReset} size='28' style={{ cursor: 'pointer', rotate: '45deg' }} />
+        <SelectionStatus
+          Icon={Icon}
+          maxSelectable={maxSelectable}
+          onReset={onReset}
+          selectedCount={selectedCount}
+        />
       </Container>
       <GradientButton
         disabled={isNextDisabled}


### PR DESCRIPTION
Closes #1872
References  #1873


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a selection-status bar showing count, icon, and reset action for proxy removals.
  - Modal back icon now behaves as a close control in the proxy flow.

- Refactor
  - Extracted status UI into a reusable SelectionStatus component and integrated it.
  - Consolidated deletion toggle logic and synchronized item selection state.

- Style
  - Minor JSX/layout cleanup.

- Performance
  - Reduced re-renders by memoizing deletion state and filtered lists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->