### PR TITLE
chore: replace “wallet” with “account” in onboarding and UI text

### DIFF
--- a/packages/extension-polkagate/src/fullscreen/haveWallet/index.tsx
+++ b/packages/extension-polkagate/src/fullscreen/haveWallet/index.tsx
@@ -18,12 +18,12 @@ function HaveWallet (): React.ReactElement {
     <AdaptiveLayout style={{ maxWidth: '622px', width: '622px' }}>
       <Stack alignItems='start' direction='column' justifyContent='flex-start' sx={{ zIndex: 1 }}>
         <OnboardTitle
-          label={t('Already have a wallet')}
-          labelPartInColor={t('have a wallet')}
+          label={t('Already have accounts')}
+          labelPartInColor={t('have accounts')}
           url='/onboarding'
         />
         <Typography color={theme.palette.text.secondary} py='15px' textAlign='left' variant='B-1' width='480px'>
-          {t('If you already have an account, you can import it using your preferred method. For batch imports, you can restore multiple accounts from a file.')}
+          {t('If you already have accounts, you can import them using your preferred method. For batch imports, you can restore multiple accounts from a file.')}
         </Typography>
         <Grid columnGap='10px' container item rowGap='10px' sx={{ mb: '20px', mt: '10px' }}>
           <CreationButton

--- a/packages/extension-polkagate/src/fullscreen/onboarding/Bread.tsx
+++ b/packages/extension-polkagate/src/fullscreen/onboarding/Bread.tsx
@@ -77,7 +77,7 @@ function Bread (): React.ReactElement {
       </Stack>
       {[STATUS.ALREADY_HAVE_A_WALLET, STATUS.CREATE_A_NEW_WALLET, STATUS.OTHERS].includes(status) &&
         <Typography color={status === STATUS.ALREADY_HAVE_A_WALLET ? DISABLED_LINK_COLOR : ENABLED_LINK_COLOR} fontSize='14px' onClick={onHaveWalletClick} sx={{ cursor: status === STATUS.ALREADY_HAVE_A_WALLET ? 'default' : 'pointer' }} variant='B-1'>
-          {t('Already have a wallet')}
+          {t('Already have accounts')}
         </Typography>
       }
       {[STATUS.ALREADY_HAVE_A_WALLET, STATUS.CREATE_A_NEW_WALLET].includes(status) &&

--- a/packages/extension-polkagate/src/fullscreen/onboarding/index.tsx
+++ b/packages/extension-polkagate/src/fullscreen/onboarding/index.tsx
@@ -93,8 +93,8 @@ function Onboarding (): React.ReactElement {
             width: '100%'
           }}
           text={{
-            text: t('Already have an account'),
-            textPartInColor: t('have an account')
+            text: t('Already have accounts'),
+            textPartInColor: t('have accounts')
           }}
           variant='contained'
         />

--- a/packages/extension-polkagate/src/popup/newAccount/createAccountFullScreen/index.tsx
+++ b/packages/extension-polkagate/src/popup/newAccount/createAccountFullScreen/index.tsx
@@ -133,7 +133,7 @@ function CreateAccount (): React.ReactElement {
         {step === STEP.SEED &&
           <>
             <Typography color={theme.palette.text.secondary} py='15px' textAlign='left' variant='B-1' width='480px'>
-              {t('In order to create a new account you are given a 12-word recovery phrase which needs to be recorded and saved in a safe place. The recovery phrase can be used to restore your wallet. Keep it carefully to not lose your assets.')}
+              {t('In order to create a new account you are given a 12-word recovery phrase which needs to be recorded and saved in a safe place. The recovery phrase can be used to restore your account. Keep it carefully to not lose your assets.')}
             </Typography>
             <MnemonicSeedDisplay seed={seed} style={{ marginBlock: '20px' }} />
             <Stack alignItems='center' columnGap='20px' direction='row' sx={{ marginTop: '25px' }}>

--- a/packages/extension-polkagate/src/popup/welcome/AddAccount.tsx
+++ b/packages/extension-polkagate/src/popup/welcome/AddAccount.tsx
@@ -87,7 +87,7 @@ function AddAccount ({ openMenu, setPopup }: Props): React.ReactElement {
           <GradientBorder />
           <Grid alignItems='center' columnGap='10px' container item justifyContent='center' p='10px'>
             <Typography color='#fff' textTransform='uppercase' variant='H-2'>
-              {t('Already have a wallet')}
+              {t('Already have accounts')}
             </Typography>
           </Grid>
           <RedGradient style={{ top: '-130px' }} />


### PR DESCRIPTION
closes #1828


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Updated terminology from “wallet” to “accounts” across onboarding screens and prompts (Have Accounts, breadcrumb labels, Add Account modal).
  - Revised action button texts to “Already have accounts” and “have accounts” for consistency.
  - Adjusted onboarding headings and descriptive paragraphs to reflect “accounts” language.
  - Updated recovery phrase message to state it restores your account, improving clarity without changing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->