### PR TITLE
chore: add new button in Account settings in extension mode to open manage proxy

### DIFF
--- a/packages/extension-polkagate/src/popup/settings/accountSettings/index.tsx
+++ b/packages/extension-polkagate/src/popup/settings/accountSettings/index.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Container, Stack, Typography } from '@mui/material';
-import { Edit2, ExportCurve, ImportCurve, LogoutCurve, Notification, ShieldSecurity } from 'iconsax-react';
+import { Data, Edit2, ExportCurve, ImportCurve, LogoutCurve, Notification, ShieldSecurity } from 'iconsax-react';
 import React, { useCallback, useEffect } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
 
@@ -12,7 +12,7 @@ import { useExtensionPopups } from '@polkadot/extension-polkagate/src/util/handl
 import { noop } from '@polkadot/util';
 
 import { ActionCard, BackWithLabel, Motion } from '../../../components';
-import { useTranslation } from '../../../hooks';
+import { useAccountSelectedChain, useTranslation } from '../../../hooks';
 import { UserDashboardHeader, WebsitesAccess } from '../../../partials';
 import HomeMenu from '../../../partials/HomeMenu';
 import RemoveAccount from '../../../partials/RemoveAccount';
@@ -26,6 +26,7 @@ function AccountSettings (): React.ReactElement {
   const location = useLocation();
   const navigate = useNavigate();
   const { address } = useParams<{ address: string }>();
+  const selectedChain = useAccountSelectedChain(address);
   const { extensionPopup, extensionPopupCloser, extensionPopupOpener } = useExtensionPopups();
 
   useEffect(() => {
@@ -41,6 +42,7 @@ function AccountSettings (): React.ReactElement {
 
   const onExport = useCallback(() => navigate('/settings-account-export') as void, [navigate]);
   const onImport = useCallback(() => windowOpen('/account/have-wallet') as unknown as void, []);
+  const onManageProxy = useCallback(() => windowOpen(`/proxyManagement/${address}/${selectedChain}`) as unknown as void, [address, selectedChain]);
   const onCloseRemove = useCallback(() => {
     navigate('/') as void;
   }, [navigate]);
@@ -61,10 +63,23 @@ function AccountSettings (): React.ReactElement {
           onClick={noop}
           style={{
             alignItems: 'center',
-            height: '64px',
+            height: '55px',
             mt: '8px'
           }}
           title={t('Notifications')}
+        />
+        <ActionCard
+          Icon={Data}
+          iconColor='#FF4FB9'
+          iconSize={24}
+          iconWithoutTransform
+          onClick={onManageProxy}
+          style={{
+            alignItems: 'center',
+            height: '55px',
+            mt: '8px'
+          }}
+          title={t('Manage Proxies')}
         />
         <ActionCard
           Icon={Edit2}
@@ -74,7 +89,7 @@ function AccountSettings (): React.ReactElement {
           onClick={extensionPopupOpener(ExtensionPopups.RENAME)}
           style={{
             alignItems: 'center',
-            height: '64px',
+            height: '55px',
             mt: '8px'
           }}
           title={t('Rename Account')}
@@ -87,7 +102,7 @@ function AccountSettings (): React.ReactElement {
           onClick={onImport}
           style={{
             alignItems: 'center',
-            height: '64px',
+            height: '55px',
             mt: '8px'
           }}
           title={t('Import Account')}
@@ -100,7 +115,7 @@ function AccountSettings (): React.ReactElement {
           onClick={onExport}
           style={{
             alignItems: 'center',
-            height: '64px',
+            height: '55px',
             mt: '8px'
           }}
           title={t('Export Account')}
@@ -113,7 +128,7 @@ function AccountSettings (): React.ReactElement {
           onClick={extensionPopupOpener(ExtensionPopups.DAPPS)}
           style={{
             alignItems: 'center',
-            height: '64px',
+            height: '55px',
             mt: '8px'
           }}
           title={t('Websites Access')}

--- a/packages/extension-polkagate/src/popup/settings/accountSettings/index.tsx
+++ b/packages/extension-polkagate/src/popup/settings/accountSettings/index.tsx
@@ -47,6 +47,8 @@ function AccountSettings (): React.ReactElement {
     navigate('/') as void;
   }, [navigate]);
 
+  const CARD_STYLE = { alignItems: 'center', height: '55px', mt: '8px' };
+
   return (
     <Container disableGutters sx={{ position: 'relative' }}>
       <UserDashboardHeader fullscreenURL='/settingsfs/account' homeType='default' />
@@ -61,11 +63,7 @@ function AccountSettings (): React.ReactElement {
           iconSize={24}
           iconWithoutTransform
           onClick={noop}
-          style={{
-            alignItems: 'center',
-            height: '55px',
-            mt: '8px'
-          }}
+          style={{ ...CARD_STYLE }}
           title={t('Notifications')}
         />
         <ActionCard
@@ -74,11 +72,7 @@ function AccountSettings (): React.ReactElement {
           iconSize={24}
           iconWithoutTransform
           onClick={onManageProxy}
-          style={{
-            alignItems: 'center',
-            height: '55px',
-            mt: '8px'
-          }}
+          style={{ ...CARD_STYLE }}
           title={t('Manage Proxies')}
         />
         <ActionCard
@@ -87,11 +81,7 @@ function AccountSettings (): React.ReactElement {
           iconSize={24}
           iconWithoutTransform
           onClick={extensionPopupOpener(ExtensionPopups.RENAME)}
-          style={{
-            alignItems: 'center',
-            height: '55px',
-            mt: '8px'
-          }}
+          style={{ ...CARD_STYLE }}
           title={t('Rename Account')}
         />
         <ActionCard
@@ -100,11 +90,7 @@ function AccountSettings (): React.ReactElement {
           iconSize={24}
           iconWithoutTransform
           onClick={onImport}
-          style={{
-            alignItems: 'center',
-            height: '55px',
-            mt: '8px'
-          }}
+          style={{ ...CARD_STYLE }}
           title={t('Import Account')}
         />
         <ActionCard
@@ -113,11 +99,7 @@ function AccountSettings (): React.ReactElement {
           iconSize={24}
           iconWithoutTransform
           onClick={onExport}
-          style={{
-            alignItems: 'center',
-            height: '55px',
-            mt: '8px'
-          }}
+          style={{ ...CARD_STYLE }}
           title={t('Export Account')}
         />
         <ActionCard
@@ -126,11 +108,7 @@ function AccountSettings (): React.ReactElement {
           iconSize={24}
           iconWithoutTransform
           onClick={extensionPopupOpener(ExtensionPopups.DAPPS)}
-          style={{
-            alignItems: 'center',
-            height: '55px',
-            mt: '8px'
-          }}
+          style={{ ...CARD_STYLE }}
           title={t('Websites Access')}
         />
         <Stack alignItems='center' columnGap='5px' direction='row' onClick={extensionPopupOpener(ExtensionPopups.REMOVE)} sx={{ cursor: 'pointer', mt: '25px' }}>

--- a/packages/extension-polkagate/src/popup/settings/accountSettings/index.tsx
+++ b/packages/extension-polkagate/src/popup/settings/accountSettings/index.tsx
@@ -47,7 +47,7 @@ function AccountSettings (): React.ReactElement {
     navigate('/') as void;
   }, [navigate]);
 
-  const CARD_STYLE = { alignItems: 'center', height: '55px', mt: '8px' };
+  const CARD_STYLE = { alignItems: 'center', height: '58px', mt: '5px' };
 
   return (
     <Container disableGutters sx={{ position: 'relative' }}>


### PR DESCRIPTION
Close: #1878

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Manage Proxies” action in Account Settings that opens a Proxy Management screen for the selected chain and account.
  * Introduced a Data icon for the Manage Proxies action.

* **Style**
  * Unified the height of all action cards (Notifications, Rename Account, Import Account, Export Account, Websites Access, Manage Proxies) to 58px for consistent appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->