### PR TITLE
fix: enforce full screen lock when reset wallet is dismissed

### DIFF
--- a/packages/extension-polkagate/src/popup/passwordManagement/Reset.tsx
+++ b/packages/extension-polkagate/src/popup/passwordManagement/Reset.tsx
@@ -14,7 +14,7 @@ import { Lock } from '../../assets/gif';
 import { ActionButton, ActionCard, ActionContext, BackWithLabel } from '../../components';
 import { updateStorage } from '../../components/Loading';
 import { useBackground, useIsExtensionPopup, useTranslation } from '../../hooks';
-import { windowOpen } from '../../messaging';
+import { lockExtension, windowOpen } from '../../messaging';
 import { Version } from '../../partials';
 import Header from './Header';
 import { LOGIN_STATUS } from './types';
@@ -114,6 +114,7 @@ function Reset (): React.ReactElement {
       .finally(() => {
         setExtensionLock(true);
         onAction('/');
+        lockExtension().catch(console.error);
       })
       .catch(console.error);
   }, [onAction, setExtensionLock]);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - After completing the password reset flow, the extension now automatically locks to enhance account security.
  - The auto-lock runs even if the reset encounters an issue, ensuring the session is secured.
  - Any issues during auto-lock are handled silently and do not interrupt the user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->