### PR TITLE
fix: fullscreen 'Derive New Account' menu opens correct modal

### DIFF
--- a/packages/extension-polkagate/src/components/HomeAccountDropDown.tsx
+++ b/packages/extension-polkagate/src/components/HomeAccountDropDown.tsx
@@ -5,11 +5,12 @@ import { ClickAwayListener, Grid, styled, type SxProps, type Theme } from '@mui/
 import { AddCircle, ArrowDown2, Broom, ExportCurve, ImportCurve, Setting, User } from 'iconsax-react';
 import React, { useCallback, useMemo, useRef, useState } from 'react';
 
+import DeriveAccount from '../fullscreen/home/DeriveAccount';
 import ExportAllAccounts from '../fullscreen/home/ExportAllAccounts';
 import { useTranslation } from '../hooks';
-import DropMenuContent from './DropMenuContent';
-import { useExtensionPopups } from '../util/handleExtensionPopup';
 import { ExtensionPopups } from '../util/constants';
+import { useExtensionPopups } from '../util/handleExtensionPopup';
+import DropMenuContent from './DropMenuContent';
 
 const DropSelectContainer = styled(Grid, {
   shouldForwardProp: (prop) => prop !== 'focused'
@@ -55,7 +56,7 @@ function HomeAccountDropDown ({ style }: Props) {
       {
         Icon: Broom,
         text: t('Derive New Account'),
-        value: '/account/create'
+        value: extensionPopupOpener(ExtensionPopups.DERIVE)
       },
       {
         Icon: ExportCurve,
@@ -65,7 +66,7 @@ function HomeAccountDropDown ({ style }: Props) {
     ];
 
     return OPTIONS;
-  }, [t]);
+  }, [extensionPopupOpener, t]);
 
   const [open, setOpen] = useState<boolean>(false);
 
@@ -89,6 +90,11 @@ function HomeAccountDropDown ({ style }: Props) {
       {extensionPopup === ExtensionPopups.EXPORT &&
         <ExportAllAccounts
           onClose={extensionPopupCloser}
+        />
+      }
+      {extensionPopup === ExtensionPopups.DERIVE &&
+        <DeriveAccount
+          closePopup={extensionPopupCloser}
         />
       }
     </>

--- a/packages/extension-polkagate/src/fullscreen/home/DeriveAccount/index.tsx
+++ b/packages/extension-polkagate/src/fullscreen/home/DeriveAccount/index.tsx
@@ -1,6 +1,8 @@
 // Copyright 2019-2025 @polkadot/extension-polkagate authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import type { ExtensionPopupCloser } from '@polkadot/extension-polkagate/util/handleExtensionPopup';
+
 import React, { useCallback, useEffect, useState } from 'react';
 
 import useAccountSelectedChain from '@polkadot/extension-polkagate/src/hooks/useAccountSelectedChain';
@@ -11,7 +13,6 @@ import ChildInfo from './ChildInfo';
 import ParentInfo from './ParentInfo';
 import StepsRow from './StepsRow';
 import { DERIVATION_STEPS, type PathState } from './types';
-import type { ExtensionPopupCloser } from '@polkadot/extension-polkagate/util/handleExtensionPopup';
 
 interface Props {
   closePopup: ExtensionPopupCloser;
@@ -23,7 +24,7 @@ interface Props {
  *
  * Only has been used in full-screen mode!
  */
-function DeriveAccount({ closePopup }: Props): React.ReactElement {
+function DeriveAccount ({ closePopup }: Props): React.ReactElement {
   const { t } = useTranslation();
   const selectedAccount = useSelectedAccount();
   const selectedGenesis = useAccountSelectedChain(selectedAccount?.address);
@@ -71,16 +72,16 @@ function DeriveAccount({ closePopup }: Props): React.ReactElement {
             setNewParentAddress={setNewParentAddress}
             setParentPassword={setParentPassword}
             setStep={setStep}
-          />
+            />
           : <ChildInfo
             genesisHash={selectedGenesis}
             maybeChidAccount={maybeChidAccount}
+            onClose={closePopup}
             parentAddress={parentAccount?.address}
             parentPassword={parentPassword}
-            onClose={closePopup}
             setMaybeChidAccount={setMaybeChidAccount}
             setStep={setStep}
-          />
+            />
         }
       </>
     </DraggableModal>

--- a/packages/extension-polkagate/src/fullscreen/settings/AccountSettings.tsx
+++ b/packages/extension-polkagate/src/fullscreen/settings/AccountSettings.tsx
@@ -14,7 +14,7 @@ import { Motion } from '../../components';
 import { useSelectedAccount, useTranslation } from '../../hooks';
 import { WebsitesAccess } from '../../partials';
 import { VelvetBox } from '../../style';
-import DeriveAccount from '../home/DeriveAccount/DeriveAccount';
+import DeriveAccount from '../home/DeriveAccount';
 import ExportAllAccounts from '../home/ExportAllAccounts';
 import RenameAccount from '../home/RenameAccount';
 


### PR DESCRIPTION
closes #1891

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Derive New Account now opens in an in-app overlay within the extension popup, providing a smoother, guided flow with easy close controls.

- Refactor
  - Internal component and import adjustments to support the new overlay flow; no impact on functionality outside the derive experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->