### PR TITLE
fix: migrate accounts for compatibility with strict apps (e.g., Polkadot.js)

### DIFF
--- a/packages/extension-polkagate/src/util/constants.ts
+++ b/packages/extension-polkagate/src/util/constants.ts
@@ -316,6 +316,7 @@ export const TIME_TO_REMOVE_ALERT = 5 * 1000; // 5 secs
 export const STORAGE_KEY = {
   ASSETS: 'migrated-assets',
   DISABLE_DIAGNOSTIC_REPORTS: 'diagnosticReports',
+  IS_ACCOUNT_MIGRATED_TO_ANY_CHAIN: 'accountsMigratedToAnyChain',
   LOGIN_IFO: 'loginInfo',
   MY_POOL: 'MyPool',
   SELECTED_ACCOUNT: 'selectedAccount',

--- a/packages/extension-ui/src/Popup/contexts/AccountProvider.tsx
+++ b/packages/extension-ui/src/Popup/contexts/AccountProvider.tsx
@@ -41,7 +41,7 @@ export default function AccountProvider ({ children }: { children: React.ReactNo
     // eslint-disable-next-line no-void
     void (async () => {
       try {
-        // migrate accounts to any chain if not done yet
+        // Migrate accounts to any chain if not already migrated
         const migrated = await getStorage(STORAGE_KEY.IS_ACCOUNT_MIGRATED_TO_ANY_CHAIN);
 
         if (!migrated) {

--- a/packages/extension-ui/src/Popup/contexts/AccountProvider.tsx
+++ b/packages/extension-ui/src/Popup/contexts/AccountProvider.tsx
@@ -7,9 +7,9 @@ import React, { useEffect, useState } from 'react';
 
 import { canDerive } from '@polkadot/extension-base/utils';
 import { AccountContext } from '@polkadot/extension-polkagate/src/components/contexts';
-import { subscribeAccounts } from '@polkadot/extension-polkagate/src/messaging';
+import { subscribeAccounts, tieAccount } from '@polkadot/extension-polkagate/src/messaging';
 import { LOGIN_STATUS, type LoginInfo } from '@polkadot/extension-polkagate/src/popup/passwordManagement/types';
-import { getStorage, updateStorage } from '@polkadot/extension-polkagate/src/util';
+import { getStorage, setStorage, updateStorage } from '@polkadot/extension-polkagate/src/util';
 import { buildHierarchy } from '@polkadot/extension-polkagate/src/util/buildHierarchy';
 import { STORAGE_KEY } from '@polkadot/extension-polkagate/src/util/constants';
 
@@ -32,6 +32,29 @@ export default function AccountProvider ({ children }: { children: React.ReactNo
   useEffect(() => {
     subscribeAccounts(setAccounts).catch(console.log);
   }, []);
+
+  useEffect(() => {
+    if (!accounts?.length) {
+      return;
+    }
+
+    // eslint-disable-next-line no-void
+    void (async () => {
+      try {
+        // migrate accounts to any chain if not done yet
+        const migrated = await getStorage(STORAGE_KEY.IS_ACCOUNT_MIGRATED_TO_ANY_CHAIN);
+
+        if (!migrated) {
+          await Promise.all(accounts.map(({ address }) => tieAccount(address, null)));
+          await setStorage(STORAGE_KEY.IS_ACCOUNT_MIGRATED_TO_ANY_CHAIN, true);
+        }
+      } catch (error) {
+        console.error(error);
+      }
+    })();
+    // The hook updates accounts data, so we track only the accounts array length as the dependency
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [accounts?.length]);
 
   useEffect(() => {
     const fetchLoginInfo = async () => {


### PR DESCRIPTION
closes #1893

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Automatic one-time account migration runs after accounts load to enable multi-chain compatibility; no user action required.

- Chores
  - Added a persistent flag to track migration completion for smoother future launches and to avoid repeated migrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->