### PR TITLE
style: add blurred overlay for recovery phrase reveal

### DIFF
--- a/packages/extension-polkagate/src/popup/newAccount/createAccountFullScreen/components/IllustrateSeed.tsx
+++ b/packages/extension-polkagate/src/popup/newAccount/createAccountFullScreen/components/IllustrateSeed.tsx
@@ -14,7 +14,7 @@ const IllustrateSeed = ({ seed, style }: { style?: SxProps<Theme>, seed: null | 
 
   return (
     <Box position='relative' sx={style}>
-      <Grid container item>
+      <Grid aria-hidden={!revealed} container id='seed-words' item>
         {wordsArray?.map((word, index) => (
           <Stack
             alignItems='center'
@@ -61,7 +61,17 @@ const IllustrateSeed = ({ seed, style }: { style?: SxProps<Theme>, seed: null | 
       </Grid>
       {!revealed && (
         <Box
+          role='button'
+          tabIndex={0}
+          aria-controls='seed-words'
+          aria-label={t('Reveal recovery phrase') as string}
           onClick={() => setRevealed(true)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              setRevealed(true);
+            }
+          }}
           sx={{
             alignItems: 'center',
             animation: 'fadeIn 0.5s',

--- a/packages/extension-polkagate/src/popup/newAccount/createAccountFullScreen/components/IllustrateSeed.tsx
+++ b/packages/extension-polkagate/src/popup/newAccount/createAccountFullScreen/components/IllustrateSeed.tsx
@@ -4,53 +4,89 @@
 import { Box, Grid, Stack, type SxProps, type Theme, Typography } from '@mui/material';
 import React, { useState } from 'react';
 
+import { useTranslation } from '@polkadot/extension-polkagate/src/hooks';
+
 const IllustrateSeed = ({ seed, style }: { style?: SxProps<Theme>, seed: null | string }) => {
+  const { t } = useTranslation();
   const wordsArray = seed?.split(' ');
   const [isHovered, setIsHovered] = useState<number | undefined>();
+  const [revealed, setRevealed] = useState<boolean>(false);
 
   return (
-    <Grid container item sx={style}>
-      {wordsArray?.map((word, index) => (
-        <Stack
-          alignItems='center'
-          direction='row'
-          key={word} onMouseEnter={() => setIsHovered(index)} onMouseLeave={() => setIsHovered(undefined)}
-          sx={{
-            '@keyframes fadeIn': {
-              from: { opacity: 0, transform: 'translateY(-10px)' },
-              to: { opacity: 1, transform: 'translateY(0)' }
-            },
-            animation: `fadeIn 0.5s ease-in-out ${index * 0.4}s forwards`,
-            background: isHovered === index ? '#2D1E4A' : '#2D1E4A8C',
-            borderRadius: '18px',
-            margin: '5px',
-            minWidth: '100px',
-            opacity: 0,
-            padding: '1px',
-            transform: 'translateY(-10px)',
-            width: 'fit-content'
-          }}
-        >
-          <Box
-            alignContent='center' justifyItems='center' sx={{
-              bgcolor: isHovered === index ? '#674394' : '#2D1E4A',
-              borderRadius: '14px',
-              height: '36px',
-              m: '2px',
-              width: '31px'
+    <Box position='relative' sx={style}>
+      <Grid container item>
+        {wordsArray?.map((word, index) => (
+          <Stack
+            alignItems='center'
+            direction='row'
+            key={word}
+            onMouseEnter={() => setIsHovered(index)}
+            onMouseLeave={() => setIsHovered(undefined)}
+            sx={{
+              '@keyframes fadeIn': {
+                from: { opacity: 0, transform: 'translateY(-10px)' },
+                to: { opacity: 1, transform: 'translateY(0)' }
+              },
+              animation: `fadeIn 0.5s ease-in-out ${index * 0.4}s forwards`,
+              background: isHovered === index ? '#2D1E4A' : '#2D1E4A8C',
+              borderRadius: '18px',
+              margin: '5px',
+              minWidth: '100px',
+              opacity: 0,
+              padding: '1px',
+              transform: 'translateY(-10px)',
+              width: 'fit-content'
             }}
           >
-            <Typography alignSelf='center' color='#BEAAD8'>
-              {index + 1}
+            <Box
+              alignContent='center'
+              justifyItems='center'
+              sx={{
+                bgcolor: isHovered === index ? 'label.primary' : '#2D1E4A',
+                borderRadius: '14px',
+                height: '36px',
+                m: '2px',
+                width: '31px'
+              }}
+            >
+              <Typography alignSelf='center' color='text.secondary'>
+                {index + 1}
+              </Typography>
+            </Box>
+            <Typography color='text.secondary' sx={{ px: '10px' }} variant='B-2'>
+              {word}
             </Typography>
-          </Box>
-          <Typography color='#BEAAD8' sx={{ px: '10px' }} variant='B-2'>
-            {word}
+          </Stack>
+        ))}
+      </Grid>
+      {!revealed && (
+        <Box
+          onClick={() => setRevealed(true)}
+          sx={{
+            alignItems: 'center',
+            animation: 'fadeIn 0.5s',
+            backdropFilter: 'blur(6px)',
+            bgcolor: 'rgba(20, 15, 30, 0.4)',
+            borderRadius: '14px',
+            boxShadow: 'inset 0 0 0 1000px rgba(255,255,255,0.03), 0 8px 24px rgba(0,0,0,0.08)',
+            cursor: 'pointer',
+            display: 'flex',
+            flexDirection: 'column',
+            height: '100%',
+            justifyContent: 'center',
+            left: 0,
+            position: 'absolute',
+            top: 0,
+            width: '100%',
+            zIndex: 10
+          }}
+        >
+          <Typography color='primary.main' sx={{ mb: 2 }} variant='B-2'>
+            {t('Click to reveal — make sure no one is watching!')}
           </Typography>
-        </Stack>
-      ))
-      }
-    </Grid>
+        </Box>
+      )}
+    </Box>
   );
 };
 

--- a/packages/extension-polkagate/src/popup/newAccount/createAccountFullScreen/components/IllustrateSeed.tsx
+++ b/packages/extension-polkagate/src/popup/newAccount/createAccountFullScreen/components/IllustrateSeed.tsx
@@ -2,100 +2,136 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Box, Grid, Stack, type SxProps, type Theme, Typography } from '@mui/material';
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 
-import { useTranslation } from '@polkadot/extension-polkagate/src/hooks';
+import { useAnimateOnce, useTranslation } from '@polkadot/extension-polkagate/src/hooks';
+import useIsHovered from '@polkadot/extension-polkagate/src/hooks/useIsHovered2';
+
+interface WordProps {
+  word: string;
+  index: number;
+}
+
+const Word = ({ index, word }: WordProps) => {
+  const { isHovered, ref } = useIsHovered();
+
+  return (
+    <Stack
+      alignItems='center'
+      direction='row'
+      key={word}
+      ref={ref}
+      sx={{
+        '@keyframes fadeIn': {
+          from: { opacity: 0, transform: 'translateY(-10px)' },
+          to: { opacity: 1, transform: 'translateY(0)' }
+        },
+        animation: `fadeIn 0.5s ease-in-out ${index * 0.2}s forwards`,
+        background: isHovered ? '#2D1E4A' : '#2D1E4A8C',
+        borderRadius: '18px',
+        margin: '5px',
+        minWidth: '100px',
+        opacity: 0,
+        padding: '1px',
+        transform: 'translateY(-10px)',
+        width: 'fit-content'
+      }}
+    >
+      <Box
+        alignContent='center'
+        justifyItems='center'
+        sx={{
+          bgcolor: isHovered ? 'label.primary' : '#2D1E4A',
+          borderRadius: '14px',
+          height: '36px',
+          m: '2px',
+          width: '31px'
+        }}
+      >
+        <Typography alignSelf='center' color='text.secondary'>
+          {index + 1}
+        </Typography>
+      </Box>
+      <Typography color='text.secondary' sx={{ px: '10px' }} variant='B-2'>
+        {word}
+      </Typography>
+    </Stack>
+  );
+};
+
+const TIME_OUT = 300;
+
+const SecretPhraseGuard = ({ revealed, setRevealed }: { revealed: boolean; setRevealed: React.Dispatch<React.SetStateAction<boolean>> }) => {
+  const { t } = useTranslation();
+
+  const [removeGlass, setRemoveGlass] = useState<boolean>(false);
+
+  const invisible = useCallback(() => setRemoveGlass(true), []);
+
+  useAnimateOnce(revealed, { delay: TIME_OUT, onStart: invisible });
+
+  const reveal = useCallback(() => setRevealed(true), [setRevealed]);
+  const onKeyDown = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      setRevealed(true);
+    }
+  }, [setRevealed]);
+
+  return (
+    <Box
+      onClick={reveal}
+      onKeyDown={onKeyDown}
+      role='button'
+      sx={{
+        alignItems: 'center',
+        animation: 'fadeIn 0.5s',
+        backdropFilter: 'blur(6px)',
+        bgcolor: 'rgba(20, 15, 30, 0.4)',
+        borderRadius: '14px',
+        boxShadow: 'inset 0 0 0 1000px rgba(255, 255, 255, 0.03), 0 0 14px rgba(255, 255, 255, 0.08)',
+        cursor: 'pointer',
+        display: removeGlass ? 'none' : 'flex',
+        flexDirection: 'column',
+        height: '100%',
+        justifyContent: 'center',
+        left: 0,
+        opacity: revealed ? 0 : 1,
+        position: 'absolute',
+        top: 0,
+        transition: `opacity ${TIME_OUT}ms ease-in-out`,
+        width: '100%',
+        zIndex: 10
+      }}
+      tabIndex={0}
+    >
+      <Typography color='primary.main' sx={{ mb: 2 }} variant='B-2'>
+        {t('Click to reveal — make sure no one is watching!')}
+      </Typography>
+    </Box>
+  );
+};
 
 const IllustrateSeed = ({ seed, style }: { style?: SxProps<Theme>, seed: null | string }) => {
-  const { t } = useTranslation();
   const wordsArray = seed?.split(' ');
-  const [isHovered, setIsHovered] = useState<number | undefined>();
+
   const [revealed, setRevealed] = useState<boolean>(false);
 
   return (
     <Box position='relative' sx={style}>
       <Grid aria-hidden={!revealed} container id='seed-words' item>
         {wordsArray?.map((word, index) => (
-          <Stack
-            alignItems='center'
-            direction='row'
-            key={word}
-            onMouseEnter={() => setIsHovered(index)}
-            onMouseLeave={() => setIsHovered(undefined)}
-            sx={{
-              '@keyframes fadeIn': {
-                from: { opacity: 0, transform: 'translateY(-10px)' },
-                to: { opacity: 1, transform: 'translateY(0)' }
-              },
-              animation: `fadeIn 0.5s ease-in-out ${index * 0.4}s forwards`,
-              background: isHovered === index ? '#2D1E4A' : '#2D1E4A8C',
-              borderRadius: '18px',
-              margin: '5px',
-              minWidth: '100px',
-              opacity: 0,
-              padding: '1px',
-              transform: 'translateY(-10px)',
-              width: 'fit-content'
-            }}
-          >
-            <Box
-              alignContent='center'
-              justifyItems='center'
-              sx={{
-                bgcolor: isHovered === index ? 'label.primary' : '#2D1E4A',
-                borderRadius: '14px',
-                height: '36px',
-                m: '2px',
-                width: '31px'
-              }}
-            >
-              <Typography alignSelf='center' color='text.secondary'>
-                {index + 1}
-              </Typography>
-            </Box>
-            <Typography color='text.secondary' sx={{ px: '10px' }} variant='B-2'>
-              {word}
-            </Typography>
-          </Stack>
+          <Word
+            index={index}
+            key={`${index} + ${word}`}
+            word={word}
+          />
         ))}
       </Grid>
-      {!revealed && (
-        <Box
-          role='button'
-          tabIndex={0}
-          aria-controls='seed-words'
-          aria-label={t('Reveal recovery phrase') as string}
-          onClick={() => setRevealed(true)}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter' || e.key === ' ') {
-              e.preventDefault();
-              setRevealed(true);
-            }
-          }}
-          sx={{
-            alignItems: 'center',
-            animation: 'fadeIn 0.5s',
-            backdropFilter: 'blur(6px)',
-            bgcolor: 'rgba(20, 15, 30, 0.4)',
-            borderRadius: '14px',
-            boxShadow: 'inset 0 0 0 1000px rgba(255,255,255,0.03), 0 8px 24px rgba(0,0,0,0.08)',
-            cursor: 'pointer',
-            display: 'flex',
-            flexDirection: 'column',
-            height: '100%',
-            justifyContent: 'center',
-            left: 0,
-            position: 'absolute',
-            top: 0,
-            width: '100%',
-            zIndex: 10
-          }}
-        >
-          <Typography color='primary.main' sx={{ mb: 2 }} variant='B-2'>
-            {t('Click to reveal — make sure no one is watching!')}
-          </Typography>
-        </Box>
-      )}
+      <SecretPhraseGuard
+        revealed={revealed}
+        setRevealed={setRevealed}
+      />
     </Box>
   );
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Click‑to‑reveal overlay protecting the seed phrase until explicitly revealed.
  * Keyboard reveal (Enter/Space) for improved usability.
  * Localized prompt text supporting translation.

* **Style**
  * Refreshed seed phrase layout and index badges for readability.
  * Enhanced per-word hover styling and staggered fade‑in animation for clearer visual feedback.
  * Subtle initial reveal animation when the overlay is removed.

* **Accessibility**
  * Added ARIA attributes, roles, and keyboard focus handling for screen readers and keyboard users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->