### PR TITLE
chore: enable applying on double-clicking items

### DIFF
--- a/packages/extension-polkagate/src/fullscreen/components/AccountListModal.tsx
+++ b/packages/extension-polkagate/src/fullscreen/components/AccountListModal.tsx
@@ -133,6 +133,7 @@ export default function AccountListModal ({ genesisHash, handleClose, isSelected
                                 isLast={isLast}
                                 isSelected={account.address === selectedAccount?.address}
                                 maybeSelected={maybeSelected}
+                                onDoubleClick = {_onApply}
                               />
                             </React.Fragment>
                           );

--- a/packages/extension-polkagate/src/fullscreen/components/AccountRowSimple.tsx
+++ b/packages/extension-polkagate/src/fullscreen/components/AccountRowSimple.tsx
@@ -18,10 +18,10 @@ interface Props {
   isFirstProfile?: boolean;
   isLast?: boolean;
   maybeSelected: string | undefined;
-  style?: React.CSSProperties;
+  onDoubleClick: () => void
 }
 
-function AccountRowSimple ({ account, handleSelect, isFirstAccount, isFirstProfile, isLast, isSelected, maybeSelected }: Props): React.ReactElement {
+function AccountRowSimple ({ account, handleSelect, isFirstAccount, isFirstProfile, isLast, isSelected, maybeSelected, onDoubleClick }: Props): React.ReactElement {
   const _onClick = useCallback(() => {
     handleSelect(account?.address);
   }, [account?.address, handleSelect]);
@@ -32,7 +32,7 @@ function AccountRowSimple ({ account, handleSelect, isFirstAccount, isFirstProfi
       initial={{ opacity: 0, y: 10 }}
       transition={{ duration: 0.4 }}
     >
-      <Stack alignItems='center' direction='row' justifyContent='space-between' sx={{ bgcolor: '#05091C', borderRadius: isLast ? '0 0 14px 14px' : '0px', mt: isFirstProfile && isFirstAccount ? 0 : '2px', p: '5px 8px 5px 15px', minHeight: '40px', position: 'relative', width: '100%' }}>
+      <Stack alignItems='center' direction='row' justifyContent='space-between' onDoubleClick={onDoubleClick} sx={{ bgcolor: '#05091C', borderRadius: isLast ? '0 0 14px 14px' : '0px', mt: isFirstProfile && isFirstAccount ? 0 : '2px', p: '5px 8px 5px 15px', minHeight: '40px', position: 'relative', width: '100%' }}>
         {
           isSelected &&
           <Divider orientation='vertical' sx={{ background: '#FF4FB9', borderRadius: '0 9px 9px 0', height: '24px', left: '1px', position: 'absolute', width: '3px' }} />

--- a/packages/extension-polkagate/src/fullscreen/components/ChainListModal.tsx
+++ b/packages/extension-polkagate/src/fullscreen/components/ChainListModal.tsx
@@ -131,8 +131,8 @@ export default function ChainListModal ({ externalOptions, handleClose, open, se
               return (
                 <Grid
                   alignItems='center'
-                  // eslint-disable-next-line react/jsx-no-bind
-                  container item justifyContent='space-between' key={index} onClick={() => onItemClick(text, String(value))} sx={{
+                  container
+                  item justifyContent='space-between' key={index} onClick={() => onItemClick(text, String(value))} onDoubleClick={onApply} sx={{
                     '&:hover': { bgcolor: '#6743944D' },
                     borderRadius: '12px',
                     lineHeight: '55px',

--- a/packages/extension-polkagate/src/fullscreen/components/ChainListModal.tsx
+++ b/packages/extension-polkagate/src/fullscreen/components/ChainListModal.tsx
@@ -1,6 +1,8 @@
 // Copyright 2019-2025 @polkadot/extension-polkagate authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+/* eslint-disable react/jsx-first-prop-new-line */
+
 import type { DropdownOption } from '@polkadot/extension-polkagate/src/util/types';
 
 import { Container, Grid, Stack, Typography } from '@mui/material';
@@ -105,7 +107,7 @@ export default function ChainListModal ({ externalOptions, handleClose, open, se
     return chainsOptions.filter(({ text }) => text.toLowerCase().includes(keyword));
   }, [searchKeyword, chainsOptions]);
 
-  const onItemClick = useCallback((text: string, value: string) => {
+  const onItemClick = useCallback((text: string, value: string) => () => {
     setMayBeSelected({ text, value });
   }, []);
 
@@ -124,20 +126,15 @@ export default function ChainListModal ({ externalOptions, handleClose, open, se
           placeholder={t('🔍 Search networks')}
         />
         <VelvetBox style={{ margin: '5px 0 15px' }}>
-          <Stack ref={refContainer} style={{ maxHeight: '388px', minHeight: '88px', overflow: 'hidden', overflowY: 'auto', position: 'relative' }}>
+          <Stack ref={refContainer} style={{ gap: '4px', maxHeight: '388px', minHeight: '88px', overflow: 'hidden', overflowY: 'auto', position: 'relative' }}>
             {filteredChainsToList.map(({ text, value }, index) => {
               const normalizedChainName = isMigratedHub(String(value)) ? text.replace('Asset Hub', '') : text.replace('Relay Chain', '');
 
               return (
-                <Grid
-                  alignItems='center'
-                  container
-                  item justifyContent='space-between' key={index} onClick={() => onItemClick(text, String(value))} onDoubleClick={onApply} sx={{
-                    '&:hover': { bgcolor: '#6743944D' },
-                    borderRadius: '12px',
-                    lineHeight: '55px',
-                    px: '7px'
-                  }}
+                <Grid alignItems='center' container item justifyContent='space-between' key={index}
+                  onClick={onItemClick(text, String(value))}
+                  onDoubleClick={onApply}
+                  sx={{ '&:hover': { bgcolor: '#6743944D' }, borderRadius: '12px', cursor: 'pointer', p: '10px 7px' }}
                 >
                   <Stack alignItems='center' direction='row'>
                     <ChainLogo chainName={text} genesisHash={value as string} size={24} />

--- a/packages/extension-polkagate/src/partials/SelectLanguage.tsx
+++ b/packages/extension-polkagate/src/partials/SelectLanguage.tsx
@@ -23,9 +23,10 @@ interface Props {
 }
 
 interface LanguageOptionProps {
+  handleLanguageSelect: (lang: string) => () => void;
+  onDoubleClick: () => void;
   options: LanguageOptions[];
   selectedLanguage: string | undefined;
-  handleLanguageSelect: (lang: string) => () => void;
 }
 
 const ListItem = styled(Grid)(() => ({
@@ -46,7 +47,7 @@ const ListItem = styled(Grid)(() => ({
 }));
 
 const LanguageSelect = React.memo(
-  function F ({ handleLanguageSelect, options, selectedLanguage }: LanguageOptionProps): React.ReactElement {
+  function F ({ handleLanguageSelect, onDoubleClick, options, selectedLanguage }: LanguageOptionProps): React.ReactElement {
     const flag = useCallback((value: string) => {
       const option = options.find((item) => item?.flag?.toUpperCase() === value.toUpperCase() || String(item.value).toUpperCase() === value.toUpperCase());
       const key = String(option?.flag ?? option?.value ?? 'EN');
@@ -59,7 +60,7 @@ const LanguageSelect = React.memo(
       <Grid container item justifyContent='center' sx={{ maxHeight: '380px', overflowY: 'auto' }}>
         {options.map(({ text, value }, index) => (
           <React.Fragment key={index}>
-            <ListItem className={selectedLanguage === value ? 'selected' : ''} container item key={value} onClick={handleLanguageSelect(value as string)}>
+            <ListItem className={selectedLanguage === value ? 'selected' : ''} container item key={value} onClick={handleLanguageSelect(value as string)} onDoubleClick={onDoubleClick}>
               <Grid alignItems='center' container item sx={{ columnGap: '10px', width: 'fit-content' }}>
                 <Box
                   component='img'
@@ -102,6 +103,7 @@ function Content ({ onClose }: { onClose: ExtensionPopupCloser }): React.ReactEl
     <Grid container item justifyContent='center' sx={{ position: 'relative', py: '5px', zIndex: 1 }}>
       <LanguageSelect
         handleLanguageSelect={handleLanguageSelect}
+        onDoubleClick={applyLanguageChange}
         options={options}
         selectedLanguage={maybeSelectedLanguage ?? languageTicker}
       />

--- a/packages/extension-polkagate/src/popup/home/partial/SelectCurrency.tsx
+++ b/packages/extension-polkagate/src/popup/home/partial/SelectCurrency.tsx
@@ -24,6 +24,7 @@ interface Props {
 interface CurrencyOptionProps {
   handleCurrencySelect: (currency: CurrencyItemType) => () => void;
   selectedCurrency: CurrencyItemType | undefined;
+  onDoubleClick?: () => void
 }
 
 interface CurrencyListProps extends CurrencyOptionProps {
@@ -67,7 +68,7 @@ const CategoryHeader = ({ type }: { type: 'crypto' | 'fiat' }) => {
   );
 };
 
-const CurrencyList = ({ currencyList, handleCurrencySelect, noLastDivider = false, selectedCurrency, type }: CurrencyListProps) => {
+const CurrencyList = ({ currencyList, handleCurrencySelect, noLastDivider = false, onDoubleClick, selectedCurrency, type }: CurrencyListProps) => {
   const flagSVG = useCallback((currency: CurrencyItemType) => {
     const countryCode = currency.code.slice(0, 2).toUpperCase();
 
@@ -101,7 +102,7 @@ const CurrencyList = ({ currencyList, handleCurrencySelect, noLastDivider = fals
       <CategoryHeader type={type} />
       {currencyList.map((currency, index) => (
         <Fragment key={index}>
-          <ListItem className={selectedCurrency === currency ? 'selected' : ''} container item key={currency.code} onClick={handleCurrencySelect(currency)}>
+          <ListItem className={selectedCurrency === currency ? 'selected' : ''} container item key={currency.code} onClick={handleCurrencySelect(currency)} onDoubleClick={onDoubleClick}>
             <Grid alignItems='center' container item sx={{ columnGap: '10px', width: 'fit-content' }}>
               <Box
                 component='img'
@@ -125,7 +126,7 @@ const CurrencyList = ({ currencyList, handleCurrencySelect, noLastDivider = fals
   );
 };
 
-const CurrencyOptions = memo(function LanguageOptions({ handleCurrencySelect, selectedCurrency }: CurrencyOptionProps): React.ReactElement {
+const CurrencyOptions = memo(function CO ({ handleCurrencySelect, onDoubleClick, selectedCurrency }: CurrencyOptionProps): React.ReactElement {
   const { t } = useTranslation();
 
   const [searchedCurrencies, setSearchedCurrencies] = useState<CurrencyItemType[]>();
@@ -165,6 +166,7 @@ const CurrencyOptions = memo(function LanguageOptions({ handleCurrencySelect, se
         <CurrencyList
           currencyList={cryptos}
           handleCurrencySelect={handleCurrencySelect}
+          onDoubleClick={onDoubleClick}
           selectedCurrency={selectedCurrency}
           type='crypto'
         />
@@ -172,6 +174,7 @@ const CurrencyOptions = memo(function LanguageOptions({ handleCurrencySelect, se
           currencyList={fiats}
           handleCurrencySelect={handleCurrencySelect}
           noLastDivider
+          onDoubleClick={onDoubleClick}
           selectedCurrency={selectedCurrency}
           type='fiat'
         />
@@ -212,6 +215,7 @@ function Content({ setOpenMenu }: { setOpenMenu: React.Dispatch<React.SetStateAc
       <CurrencyOptions
         handleCurrencySelect={handleCurrencySelect}
         selectedCurrency={selectedCurrency}
+        onDoubleClick={applyLanguageChange}
       />
       <GradientButton
         contentPlacement='center'
@@ -237,8 +241,8 @@ function SelectCurrency({ openMenu, setOpenMenu }: Props): React.ReactElement {
 
   return (
     <SharePopup
-      onClose={handleClose}
       modalProps={{ showBackIconAsClose: true }}
+      onClose={handleClose}
       open={openMenu}
       popupProps={{
         TitleIcon: Hashtag,

--- a/packages/extension-polkagate/src/popup/home/partial/SelectCurrency.tsx
+++ b/packages/extension-polkagate/src/popup/home/partial/SelectCurrency.tsx
@@ -68,7 +68,7 @@ const CategoryHeader = ({ type }: { type: 'crypto' | 'fiat' }) => {
   );
 };
 
-const CurrencyList = ({ currencyList, handleCurrencySelect, noLastDivider = false, onDoubleClick, selectedCurrency, type }: CurrencyListProps) => {
+const CurrencyList = memo(function CL ({ currencyList, handleCurrencySelect, noLastDivider = false, onDoubleClick, selectedCurrency, type }: CurrencyListProps) {
   const flagSVG = useCallback((currency: CurrencyItemType) => {
     const countryCode = currency.code.slice(0, 2).toUpperCase();
 
@@ -100,31 +100,35 @@ const CurrencyList = ({ currencyList, handleCurrencySelect, noLastDivider = fals
   return (
     <>
       <CategoryHeader type={type} />
-      {currencyList.map((currency, index) => (
-        <Fragment key={index}>
-          <ListItem className={selectedCurrency === currency ? 'selected' : ''} container item key={currency.code} onClick={handleCurrencySelect(currency)} onDoubleClick={onDoubleClick}>
-            <Grid alignItems='center' container item sx={{ columnGap: '10px', width: 'fit-content' }}>
-              <Box
-                component='img'
-                src={flagSVG(currency)}
-                sx={{ borderRadius: '5px', height: '18px', width: '18px' }}
+      {currencyList.map((currency, index) => {
+        const isSelected = selectedCurrency?.code === currency.code;
+
+        return (
+          <Fragment key={index}>
+            <ListItem className={isSelected ? 'selected' : ''} container item key={currency.code} onClick={handleCurrencySelect(currency)} onDoubleClick={onDoubleClick}>
+              <Grid alignItems='center' container item sx={{ columnGap: '10px', width: 'fit-content' }}>
+                <Box
+                  component='img'
+                  src={flagSVG(currency)}
+                  sx={{ borderRadius: '5px', height: '18px', width: '18px' }}
+                />
+                <Typography color='text.primary' variant='B-2'>
+                  {currency.country} - {currency.sign}
+                </Typography>
+              </Grid>
+              <GlowCheck
+                show={isSelected}
               />
-              <Typography color='text.primary' variant='B-2'>
-                {currency.country} - {currency.sign}
-              </Typography>
-            </Grid>
-            <GlowCheck
-              show={selectedCurrency === currency}
-            />
-          </ListItem>
-          {(!noLastDivider || index !== currencyList.length - 1) &&
-            <GradientDivider style={{ my: '3px' }} />
-          }
-        </Fragment>
-      ))}
+            </ListItem>
+            {(!noLastDivider || index !== currencyList.length - 1) &&
+              <GradientDivider style={{ my: '3px' }} />
+            }
+          </Fragment>
+        );
+      })}
     </>
   );
-};
+});
 
 const CurrencyOptions = memo(function CO ({ handleCurrencySelect, onDoubleClick, selectedCurrency }: CurrencyOptionProps): React.ReactElement {
   const { t } = useTranslation();
@@ -187,7 +191,7 @@ const CurrencyOptions = memo(function CO ({ handleCurrencySelect, onDoubleClick,
   );
 });
 
-function Content({ setOpenMenu }: { setOpenMenu: React.Dispatch<React.SetStateAction<boolean>> }): React.ReactElement {
+function Content ({ setOpenMenu }: { setOpenMenu: React.Dispatch<React.SetStateAction<boolean>> }): React.ReactElement {
   const { t } = useTranslation();
   const { currency, setCurrency } = useContext(CurrencyContext);
 
@@ -197,9 +201,7 @@ function Content({ setOpenMenu }: { setOpenMenu: React.Dispatch<React.SetStateAc
     !selectedCurrency && currency && setSelectedCurrency(currency);
   }, [currency, selectedCurrency]);
 
-  const handleCurrencySelect = useCallback((currency: CurrencyItemType) => () => {
-    setSelectedCurrency(currency);
-  }, []);
+  const handleCurrencySelect = useCallback((currency: CurrencyItemType) => () => setSelectedCurrency(currency), []);
 
   const applyLanguageChange = useCallback(() => {
     if (selectedCurrency) {
@@ -214,8 +216,8 @@ function Content({ setOpenMenu }: { setOpenMenu: React.Dispatch<React.SetStateAc
     <Grid container item justifyContent='center' sx={{ position: 'relative', py: '1px', zIndex: 1 }}>
       <CurrencyOptions
         handleCurrencySelect={handleCurrencySelect}
-        selectedCurrency={selectedCurrency}
         onDoubleClick={applyLanguageChange}
+        selectedCurrency={selectedCurrency}
       />
       <GradientButton
         contentPlacement='center'
@@ -225,7 +227,6 @@ function Content({ setOpenMenu }: { setOpenMenu: React.Dispatch<React.SetStateAc
           bottom: '6px',
           height: '44px',
           position: 'absolute',
-          width: '345px',
           zIndex: 10
         }}
         text={t('Apply')}
@@ -234,7 +235,7 @@ function Content({ setOpenMenu }: { setOpenMenu: React.Dispatch<React.SetStateAc
   );
 }
 
-function SelectCurrency({ openMenu, setOpenMenu }: Props): React.ReactElement {
+function SelectCurrency ({ openMenu, setOpenMenu }: Props): React.ReactElement {
   const { t } = useTranslation();
 
   const handleClose = useCallback(() => setOpenMenu(false), [setOpenMenu]);


### PR DESCRIPTION
closes #1930

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added double-click to apply selections in account, chain, language, and currency lists, mirroring the Apply action for faster workflows.
- UI/UX
  - Improved interaction consistency: double-clicking a row or item now immediately applies the current selection without changing single-click behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->