### PR TITLE
chore: add next button to top-right corner of request content page

### DIFF
--- a/packages/extension-polkagate/src/components/ExtensionPopup.tsx
+++ b/packages/extension-polkagate/src/components/ExtensionPopup.tsx
@@ -5,7 +5,7 @@ import type { Variant } from '@mui/material/styles/createTypography';
 import type { OverridableStringUnion } from '@mui/types';
 
 import { Box, Container, Dialog, Grid, type SxProps, type Theme, Typography, type TypographyPropsVariantOverrides } from '@mui/material';
-import { ArrowCircleLeft, type Icon } from 'iconsax-react';
+import { ArrowCircleLeft, ArrowCircleRight, type Icon } from 'iconsax-react';
 import React from 'react';
 
 import { useIsBlueish, useTranslation } from '../hooks';
@@ -23,6 +23,7 @@ export interface ExtensionPopupProps {
   iconVariant?: 'Linear' | 'Outline' | 'Broken' | 'Bold' | 'Bulk' | 'TwoTone' | undefined;
   maxHeight?: string;
   onBack?: () => void;
+  onNext?: () => void;
   openMenu: boolean;
   pt?: number;
   px?: number;
@@ -58,7 +59,7 @@ const Gradient = React.memo(function MemoGradient ({ pt, withoutBackground }: { 
   );
 });
 
-function ExtensionPopup ({ RightItem, TitleIcon, children, darkBackground = false, handleClose, iconColor = '#AA83DC', iconSize = 18, iconVariant, maxHeight = '440px', onBack, openMenu, pt, px, style, title, titleAlignment, titleDirection = 'row', titleStyle = {}, titleVariant = 'H-3', withGradientBorder = false, withoutBackground, withoutTopBorder = false }: ExtensionPopupProps): React.ReactElement<ExtensionPopupProps> {
+function ExtensionPopup ({ RightItem, TitleIcon, children, darkBackground = false, handleClose, iconColor = '#AA83DC', iconSize = 18, iconVariant, maxHeight = '440px', onBack, onNext, openMenu, pt, px, style, title, titleAlignment, titleDirection = 'row', titleStyle = {}, titleVariant = 'H-3', withGradientBorder = false, withoutBackground, withoutTopBorder = false }: ExtensionPopupProps): React.ReactElement<ExtensionPopupProps> {
   const { t } = useTranslation();
   const isBlueish = useIsBlueish();
 
@@ -92,7 +93,7 @@ function ExtensionPopup ({ RightItem, TitleIcon, children, darkBackground = fals
         <Grid alignItems='center' container id='container' item justifyContent='center' sx={{ bgcolor: darkBackground ? '#110F2A' : '#1B133C', border: '2px solid', borderColor: '#FFFFFF0D', borderTopLeftRadius: '32px', borderTopRightRadius: '32px', display: 'block', height: `calc(100% - ${60 + (pt ?? 18)}px)`, overflow: 'hidden', overflowY: 'auto', position: 'relative', px: `${px ?? 10}px`, width: '100%' }}>
           {withGradientBorder && <GradientBorder />}
           {!!onBack &&
-            <Grid alignItems='center' container item onClick={onBack} sx={{ cursor: 'pointer', left: '15px', position: 'absolute', pt: '15px', zIndex: 2 }}>
+            <Grid alignItems='center' container item onClick={onBack} sx={{ cursor: 'pointer', left: '15px', position: 'absolute', pt: '15px', width: 'fit-content', zIndex: 2 }}>
               <ArrowCircleLeft
                 color='#FF4FB9'
                 size='24'
@@ -101,6 +102,18 @@ function ExtensionPopup ({ RightItem, TitleIcon, children, darkBackground = fals
               <Typography color='#EAEBF1' ml='4px' variant='B-1'>
                 {t('Back')}
               </Typography>
+            </Grid>
+          }
+          {onNext &&
+            <Grid alignItems='center' container item onClick={onNext} sx={{ cursor: 'pointer', position: 'absolute', right: '15px', pt: '15px', width: 'fit-content', zIndex: 2 }}>
+              <Typography color='#EAEBF1' mr='4px' variant='B-1'>
+                {t('Next')}
+              </Typography>
+              <ArrowCircleRight
+                color='#FF4FB9'
+                size='24'
+                variant='Bulk'
+              />
             </Grid>
           }
           <Grid alignItems='center' columnGap='10px' container direction={titleDirection} item justifyContent={titleAlignment ?? 'center'} p={title || TitleIcon ? '10px' : 0}>

--- a/packages/extension-polkagate/src/popup/signing/ExtrinsicDetail.tsx
+++ b/packages/extension-polkagate/src/popup/signing/ExtrinsicDetail.tsx
@@ -1,7 +1,7 @@
 // Copyright 2019-2025 @polkadot/extension-polkagate authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import type { AccountJson, RequestSign } from '@polkadot/extension-base/background/types';
+import type { RequestSign } from '@polkadot/extension-base/background/types';
 import type { ExtrinsicPayload } from '@polkadot/types/interfaces';
 import type { SignerPayloadJSON } from '@polkadot/types/types';
 import type { ModeData } from './types';
@@ -22,7 +22,6 @@ interface Data {
 }
 
 interface Props {
-  account: AccountJson;
   request: RequestSign;
   mode: ModeData;
 }

--- a/packages/extension-polkagate/src/popup/signing/index.tsx
+++ b/packages/extension-polkagate/src/popup/signing/index.tsx
@@ -104,6 +104,14 @@ export default function Signing (): React.ReactElement {
       });
   }, [navigate, setError, request?.id]);
 
+  const onNext = useCallback(() => {
+    setMode((pre) => ({
+      ...pre,
+      title: t('Your Signature'),
+      type: SIGN_POPUP_MODE.SIGN
+    }));
+  }, [setMode, t]);
+
   return request
     ? <ExtensionPopup
       TitleIcon={mode.Icon}
@@ -111,6 +119,7 @@ export default function Signing (): React.ReactElement {
       iconSize={24}
       maxHeight='calc(100% - 75px)'
       onBack={[SIGN_POPUP_MODE.DETAIL, SIGN_POPUP_MODE.SIGN].includes(mode.type) ? onBack : undefined}
+      onNext={SIGN_POPUP_MODE.DETAIL === mode.type ? onNext : undefined}
       openMenu={true}
       pt={10}
       style={{ '> div#container div#boxContainer': { height: 'calc(100% - 75px)' } }}
@@ -119,7 +128,6 @@ export default function Signing (): React.ReactElement {
       >
       {mode.type === SIGN_POPUP_MODE.DETAIL &&
         <ExtrinsicDetail
-          account={request.account}
           mode={mode}
           request={request.request}
         />


### PR DESCRIPTION
Refs #1942

<img width="360" height="617" alt="Screenshot 2025-10-09 at 19 42 43" src="https://github.com/user-attachments/assets/19c85c81-5dc8-45bf-9c30-5f1d49a3772b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a “Next” button with an arrow icon on the transaction details screen to proceed to the signing step.
- UI/UX Improvements
  - Automatically updates the title to “Your Signature” when entering the signing step.
  - Back and Next controls now size to their content for clearer layout.
  - “Next” only appears when moving forward is applicable, reducing clutter and guiding users through the flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->