### PR TITLE
fix: update balances correctly when only watch-only accounts are in the extension

### DIFF
--- a/packages/extension-base/src/background/handlers/Extension.ts
+++ b/packages/extension-base/src/background/handlers/Extension.ts
@@ -64,6 +64,12 @@ export default class Extension {
   }
 
   private scheduleExpiryCheck (): void {
+    const accountsLocal = this.localAccounts();
+
+    if (accountsLocal.length === 0) {
+      return;
+    }
+
     if (this.#expiryTimeout) {
       clearTimeout(this.#expiryTimeout);
     }
@@ -511,6 +517,12 @@ export default class Extension {
   }
 
   private areLocksExpired (): boolean {
+    const accountsLocal = this.localAccounts();
+
+    if (accountsLocal.length === 0) {
+      return false; // no lock when has only external accounts
+    }
+
     return this.#unlockExpiry === null || this.#unlockExpiry < Date.now();
   }
 
@@ -764,7 +776,7 @@ export default class Extension {
       case 'pri(accounts.forgetAll)':
         return this.accountsForgetAll();
 
-        case 'pri(accounts.setUnlockExpiry)':
+      case 'pri(accounts.setUnlockExpiry)':
         return this.setUnlockExpiry(request as RequestAccountsSetUnlockExpiry);
       // -------------------------------------
 

--- a/packages/extension-ui/src/Popup/contexts/AccountProvider.tsx
+++ b/packages/extension-ui/src/Popup/contexts/AccountProvider.tsx
@@ -7,6 +7,7 @@ import React, { useEffect, useState } from 'react';
 
 import { canDerive } from '@polkadot/extension-base/utils';
 import { AccountContext } from '@polkadot/extension-polkagate/src/components/contexts';
+import { useExtensionLockContext } from '@polkadot/extension-polkagate/src/context/ExtensionLockContext';
 import useIsForgotten from '@polkadot/extension-polkagate/src/hooks/useIsForgotten';
 import { subscribeAccounts, tieAccount } from '@polkadot/extension-polkagate/src/messaging';
 import { getStorage, setStorage, updateStorage } from '@polkadot/extension-polkagate/src/util';
@@ -28,6 +29,7 @@ export default function AccountProvider ({ children }: { children: React.ReactNo
   const [accounts, setAccounts] = useState<null | AccountJson[]>(null);
   const [accountCtx, setAccountCtx] = useState<AccountsContext>({ accounts: [], hierarchy: [] });
   const isForgotten = useIsForgotten();
+  const { setExtensionLock } = useExtensionLockContext();
 
   useEffect(() => {
     subscribeAccounts(setAccounts).catch(console.log);
@@ -38,6 +40,14 @@ export default function AccountProvider ({ children }: { children: React.ReactNo
       return;
     }
 
+    // unlock extension if all existing accounts are external
+    const hasLocalAccount = accounts.some(({ isExternal }) => !isExternal);
+
+    if (!hasLocalAccount) {
+      setExtensionLock(false);
+    }
+
+    // TODO: this needs to be removed on future releases
     // eslint-disable-next-line no-void
     void (async () => {
       try {


### PR DESCRIPTION
close #1990

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Extension now automatically unlocks when there are no local accounts configured.
  * Lock state updates immediately when account configuration changes.
  * Avoids unnecessary expiry checks when no local accounts exist.
  * Preserves existing behavior for expired-lock messages (triggers the same reload/notification).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->