### PR TITLE
style: add ability to close non-essential fullscreen modals by clicking outside

### DIFF
--- a/packages/extension-polkagate/src/fullscreen/accountDetails/rightColumn/Receive.tsx
+++ b/packages/extension-polkagate/src/fullscreen/accountDetails/rightColumn/Receive.tsx
@@ -109,7 +109,7 @@ function SelectChain ({ setSelectedChain }: SelectChainProp) {
 }
 
 function AddressComponent ({ address, chainName, onCopy }: AddressComponentProp) {
-    const { isHovered, ref } = useIsHovered();
+  const { isHovered, ref } = useIsHovered();
 
   return (
     <Grid alignItems='center' container item justifyContent='space-between' sx={{ bgcolor: '#1B133C', border: '1px solid', borderColor: '#BEAAD833', borderRadius: '12px', p: '3px' }}>
@@ -167,6 +167,7 @@ function Receive ({ address, closePopup, onClose, setAddress }: Props): React.Re
 
   return (
     <DraggableModal
+      closeOnAnyWhereClick
       onClose={_onClose}
       open
       showBackIconAsClose

--- a/packages/extension-polkagate/src/fullscreen/components/AccountListModal.tsx
+++ b/packages/extension-polkagate/src/fullscreen/components/AccountListModal.tsx
@@ -91,6 +91,7 @@ export default function AccountListModal ({ genesisHash, handleClose, isSelected
 
   return (
     <DraggableModal
+      closeOnAnyWhereClick
       onClose={_handleClose}
       open={open}
       showBackIconAsClose

--- a/packages/extension-polkagate/src/fullscreen/components/ChainListModal.tsx
+++ b/packages/extension-polkagate/src/fullscreen/components/ChainListModal.tsx
@@ -113,6 +113,7 @@ export default function ChainListModal ({ externalOptions, handleClose, open, se
 
   return (
     <DraggableModal
+      closeOnAnyWhereClick
       onClose={_handleClose}
       open={open}
       showBackIconAsClose

--- a/packages/extension-polkagate/src/fullscreen/components/DraggableModal.tsx
+++ b/packages/extension-polkagate/src/fullscreen/components/DraggableModal.tsx
@@ -25,9 +25,10 @@ export interface DraggableModalProps {
   RightItem?: React.ReactNode;
   rightItemStyle?: React.CSSProperties;
   noCloseButton?: boolean;
+  closeOnAnyWhereClick?: boolean;
 }
 
-export function DraggableModal ({ RightItem, TitleLogo, blurBackdrop = true, children, dividerStyle, draggable = false, maxHeight = 740, minHeight = 615, noCloseButton, noDivider, onClose, open, rightItemStyle, showBackIconAsClose, style = {}, title, width = 415 }: DraggableModalProps): React.ReactElement<DraggableModalProps> {
+export function DraggableModal ({ RightItem, TitleLogo, blurBackdrop = true, children, closeOnAnyWhereClick = false, dividerStyle, draggable = false, maxHeight = 740, minHeight = 615, noCloseButton, noDivider, onClose, open, rightItemStyle, showBackIconAsClose, style = {}, title, width = 415 }: DraggableModalProps): React.ReactElement<DraggableModalProps> {
   const theme = useTheme();
 
   const isDarkMode = useMemo(() => theme.palette.mode === 'dark', [theme.palette.mode]);
@@ -45,12 +46,12 @@ export function DraggableModal ({ RightItem, TitleLogo, blurBackdrop = true, chi
   }, []);
 
   const _onClose = useCallback((_event: unknown, reason: string) => {
-    if (reason && reason === 'backdropClick') {
+    if (reason && reason === 'backdropClick' && closeOnAnyWhereClick === false) {
       return;
     }
 
     onClose();
-  }, [onClose]);
+  }, [closeOnAnyWhereClick, onClose]);
 
   const handleMouseMove = useCallback((e: { clientX: number; clientY: number; }) => {
     if (isDragging && draggable) {

--- a/packages/extension-polkagate/src/fullscreen/components/LineChart.tsx
+++ b/packages/extension-polkagate/src/fullscreen/components/LineChart.tsx
@@ -261,6 +261,7 @@ const TokenChart: React.FC<TokenChartProps> = ({ coinId,
 
   return (
     <DraggableModal
+      closeOnAnyWhereClick
       onClose={_onClose}
       open={true}
       showBackIconAsClose

--- a/packages/extension-polkagate/src/fullscreen/stake/ToBeReleased.tsx
+++ b/packages/extension-polkagate/src/fullscreen/stake/ToBeReleased.tsx
@@ -24,6 +24,7 @@ export default function ToBeReleased ({ genesisHash, onClose, onRestake, toBeRel
 
   return (
     <DraggableModal
+      closeOnAnyWhereClick
       maxHeight={475}
       minHeight={475}
       onClose={onClose}

--- a/packages/extension-polkagate/src/fullscreen/stake/new-pool/Info.tsx
+++ b/packages/extension-polkagate/src/fullscreen/stake/new-pool/Info.tsx
@@ -45,6 +45,7 @@ export default function Info ({ genesisHash, onClose, stakingInfo }: Props): Rea
 
   return (
     <DraggableModal
+      closeOnAnyWhereClick
       minHeight='auto'
       onClose={onClose}
       open

--- a/packages/extension-polkagate/src/fullscreen/stake/new-solo/Info.tsx
+++ b/packages/extension-polkagate/src/fullscreen/stake/new-solo/Info.tsx
@@ -34,6 +34,7 @@ export default function Info ({ genesisHash, onClose, stakingInfo }: Props): Rea
 
   return (
     <DraggableModal
+      closeOnAnyWhereClick
       minHeight='auto'
       onClose={onClose}
       open

--- a/packages/extension-polkagate/src/popup/history/newDesign/HistoryDetail.tsx
+++ b/packages/extension-polkagate/src/popup/history/newDesign/HistoryDetail.tsx
@@ -312,6 +312,7 @@ function HistoryDetail ({ historyItem, setOpenMenu }: HistoryDetailProps): React
             </Container>
           </Dialog>
           : <DraggableModal
+            closeOnAnyWhereClick
             noDivider
             onClose={handleClose}
             open={!!historyItem}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Modal windows throughout the application now close when clicking outside them, providing a more intuitive user experience. This enhancement applies to account management, chain selection, staking operations, transaction history, and other modal dialogs across the extension.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->