### PR TITLE
style: add click-to-copy address feature in Polkasoul

### DIFF
--- a/packages/extension-polkagate/src/fullscreen/settings/partials/AccountIcon.tsx
+++ b/packages/extension-polkagate/src/fullscreen/settings/partials/AccountIcon.tsx
@@ -61,6 +61,7 @@ function Item ({ address, iconTheme, label, selectedTheme }: ItemProps): React.R
           iconTheme={iconTheme}
           size={18}
           style={{ display: 'flex' }}
+          withNotify={false}
         />
         <Typography color='text.primary' sx={{ textAlign: 'left' }} variant='B-4'>
           {label}

--- a/packages/extension-polkagate/src/style/PolkaGateIdenticon.tsx
+++ b/packages/extension-polkagate/src/style/PolkaGateIdenticon.tsx
@@ -3,11 +3,12 @@
 
 import type { IconTheme as BaseIconTheme } from '@polkadot/react-identicon/types';
 
-import React, { useContext } from 'react';
+import React, { useCallback, useContext } from 'react';
 
 import Icon from '@polkadot/react-identicon';
 
 import { AccountIconThemeContext } from '../components';
+import { useAlerts, useTranslation } from '../hooks';
 import PolkaSoul from './PolkaSoul';
 
 type IconTheme = BaseIconTheme | 'polkasoul';
@@ -21,15 +22,22 @@ interface Props {
   prefix?: number;
   size: number;
   style?: React.CSSProperties;
+  withNotify?: boolean;
 }
 
-function PolkaGateIdenticon ({ address, iconTheme, onCopy, prefix, size, style = {} }: Props) {
+function PolkaGateIdenticon ({ address, iconTheme, onCopy, prefix, size, style = {}, withNotify = true }: Props) {
   const { accountIconTheme } = useContext(AccountIconThemeContext);
+  const { t } = useTranslation();
+  const { notify } = useAlerts();
 
   const _theme = (iconTheme ?? accountIconTheme) as IconTheme | undefined;
 
+  const onClick = useCallback(() => {
+    withNotify && notify(t('Address copied!'), 'info');
+  }, [notify, t, withNotify]);
+
   return (
-    <span style={{ height: `${size}px`, width: `${size}px`, ...style }}>
+    <span onClick={onClick} style={{ cursor: withNotify ? 'copy' : 'default', height: `${size}px`, width: `${size}px`, ...style }}>
       {!_theme || _theme === 'polkasoul'
         ? (
           <PolkaSoul
@@ -42,6 +50,7 @@ function PolkaGateIdenticon ({ address, iconTheme, onCopy, prefix, size, style =
             onCopy={onCopy}
             prefix={prefix}
             size={size}
+            style={{ cursor: withNotify ? 'copy' : 'default'}}
             theme={_theme}
             value={address}
           />)

--- a/packages/extension-polkagate/src/style/PolkaSoul.tsx
+++ b/packages/extension-polkagate/src/style/PolkaSoul.tsx
@@ -148,7 +148,7 @@ const PolkaSoul = ({ address, size = 32, style = {} }: Props) => {
   }, [size, params]);
 
   return (
-    <div style={{ alignItems: 'center', cursor: 'copy', display: 'flex', height: `${size}px`, justifyContent: 'center', width: `${size}px`, ...style }}>
+    <div style={{ alignItems: 'center', display: 'flex', height: `${size}px`, justifyContent: 'center', width: `${size}px`, ...style }}>
       <CopyToClipboard text={String(address)}>
         <svg className='rounded-full' height={size} viewBox={`0 0 ${size} ${size}`} width={size}>
           <defs>


### PR DESCRIPTION
Closes #2012

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Click-to-copy addresses with an optional notification when an address is copied.
  * Interactive cursor hints indicate copyable elements.

* **Style**
  * Improved visual rendering with reorganized gradients, filters and enhanced shadow/blur effects for more consistent icons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->