### PR TITLE
fix: force password migration when no legacy password is present

### DIFF
--- a/packages/extension-polkagate/src/popup/passwordManagement/Login.tsx
+++ b/packages/extension-polkagate/src/popup/passwordManagement/Login.tsx
@@ -117,13 +117,17 @@ function Content ({ setStep }: Props): React.ReactElement {
       const canUnlock = canUnlockDirectly(isOldPasswordCorrect, oldPasswordExists);
 
       if (canUnlock) {
-        return handleDirectUnlock(plainPassword, autoLockPeriod);
+        await handleDirectUnlock(plainPassword, autoLockPeriod);
+
+        return;
       }
 
       const needsPasswordMigration = accountsNeedMigration?.length && (isOldPasswordCorrect || !oldPasswordExists);
 
       if (needsPasswordMigration) {
-        return handlePasswordMigration();
+        await handlePasswordMigration();
+
+        return;
       }
 
       // not migrated and old password exist but it is incorrect
@@ -189,7 +193,7 @@ function Content ({ setStep }: Props): React.ReactElement {
       <DecisionButtons
         cancelButton
         direction='vertical'
-        disabled={!hashedPassword}
+        disabled={!hashedPassword || isUnlocking}
         isBusy={isUnlocking}
         onPrimaryClick={onUnlock}
         onSecondaryClick={onForgotPassword}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a direct-unlock path letting eligible users sign in immediately without manual steps.
  * Unlock button now reflects unlocking state (disabled/busy) to prevent duplicate actions.

* **Bug Fixes**
  * Improved password migration flow and fallback handling to reduce failed unlocks and guide users to migration when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->