### PR TITLE
fix: resolve mis displayed unlock date in reserved reasons section

### DIFF
--- a/packages/extension-polkagate/src/popup/tokens/partial/ReservedLockedPopup.tsx
+++ b/packages/extension-polkagate/src/popup/tokens/partial/ReservedLockedPopup.tsx
@@ -128,8 +128,8 @@ function Item ({ amount, decimal, noDivider, price, reason, token, unlockTracks 
         <Grid alignItems='center' container item justifyContent='space-between' xs>
           <Grid alignItems='center' container gap='4px' item width='fit-content'>
             <ReasonAndDescription
-              description={unlockTracks?.lockedTooltip}
-              inColorPart={unlockTracks?.unlockDate}
+              description={isGovernance ? unlockTracks?.lockedTooltip : undefined}
+              inColorPart={isGovernance ? unlockTracks?.unlockDate : undefined}
               reason={reason}
             />
             {isGovernance && unlockTracks &&


### PR DESCRIPTION
<img width="1075" height="530" alt="image" src="https://github.com/user-attachments/assets/bcceffba-3da4-4edd-8fb0-b94312a0e62e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed description and date display in reserved and locked tokens popup to correctly show only for governance-related items, preventing incorrect information from appearing in non-governance cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->