### PR TITLE
fix: prevent home layout from appearing during accounts import

### DIFF
--- a/packages/extension-polkagate/src/fullscreen/components/layout/AdaptiveLayout.tsx
+++ b/packages/extension-polkagate/src/fullscreen/components/layout/AdaptiveLayout.tsx
@@ -18,7 +18,7 @@ function AdaptiveLayout ({ children, style = {} }: Props): React.ReactElement {
   const ChosenLayout = isOnboarding.current ? OnboardingLayout : HomeLayout;
 
   return (
-    <ChosenLayout childrenStyle={{ margin: isOnboarding ? undefined : '30px 0 0 25px', maxWidth: '550px', ...style }}>
+    <ChosenLayout childrenStyle={{ margin: isOnboarding.current ? undefined : '30px 0 0 25px', maxWidth: '550px', ...style }}>
       {children}
     </ChosenLayout>
   );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal state handling in the fullscreen layout was reorganized to use a stable reference, improving reliability and preventing layout jitter during initial onboarding or account-less states. No visible API or UI changes expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->