### PR TITLE
fix: lock extension after password change

### DIFF
--- a/packages/extension-polkagate/src/popup/settings/extensionSettings/ManagePassword.tsx
+++ b/packages/extension-polkagate/src/popup/settings/extensionSettings/ManagePassword.tsx
@@ -6,7 +6,7 @@ import React, { useCallback, useState } from 'react';
 
 import useIsExtensionPopup from '@polkadot/extension-polkagate/src/hooks/useIsExtensionPopup';
 import useIsPasswordCorrect from '@polkadot/extension-polkagate/src/hooks/useIsPasswordCorrect';
-import { accountsChangePasswordAll } from '@polkadot/extension-polkagate/src/messaging';
+import { accountsChangePasswordAll, lockExtension } from '@polkadot/extension-polkagate/src/messaging';
 import { getStorage, setStorage } from '@polkadot/extension-polkagate/src/util';
 import { STORAGE_KEY } from '@polkadot/extension-polkagate/src/util/constants';
 import { blake2AsHex } from '@polkadot/util-crypto';
@@ -18,7 +18,7 @@ import { type LoginInfo } from '../../passwordManagement/types';
 import WarningBox from '../partials/WarningBox';
 
 // DEPRECATED, and will be removed int he future versions
-export const isPasswordCorrect = async (password: string, isHashed?: boolean) => {
+export const isPasswordCorrect = async(password: string, isHashed?: boolean) => {
   const hashedPassword = isHashed ? password : blake2AsHex(password, 256);
   const info = await getStorage(STORAGE_KEY.LOGIN_INFO) as LoginInfo;
 
@@ -43,6 +43,7 @@ export default function ManagePassword({ onBack }: { onBack?: () => void }): Rea
     setShowSnackbar(false);
 
     if (missionSucceeded) {
+      lockExtension().catch(console.error);
       window.location.hash = '/';
     }
 
@@ -56,7 +57,7 @@ export default function ManagePassword({ onBack }: { onBack?: () => void }): Rea
     setCurrentPassword(pass || '');
   }, []);
 
-  const onSetPassword = useCallback(async () => {
+  const onSetPassword = useCallback(async() => {
     if (!oldPass || !newPass) {
       return;
     }


### PR DESCRIPTION
closes #2092

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * The extension now automatically locks after a successful password change is completed, adding an extra security checkpoint to the password update process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->