### PR TITLE
fix: resolve issue where “hide balance” did not apply to token balance

### DIFF
--- a/packages/extension-polkagate/src/components/DisplayBalance.tsx
+++ b/packages/extension-polkagate/src/components/DisplayBalance.tsx
@@ -5,15 +5,16 @@ import type { ApiPromise } from '@polkadot/api';
 import type { Compact, u64, u128 } from '@polkadot/types';
 import type { Balance } from '@polkadot/types/interfaces';
 import type { INumber } from '@polkadot/types-codec/types';
+import type { DotsVariant } from './Dots';
 
 import { Fade, type SxProps, type Theme, Typography, useTheme } from '@mui/material';
 import React, { memo, useMemo } from 'react';
 
 import { type BN, formatBalance } from '@polkadot/util';
 
-import { useChainInfo, useIsDark } from '../hooks';
+import { useChainInfo, useIsDark, useIsHideNumbers } from '../hooks';
 import { FLOATING_POINT_DIGIT } from '../util/constants';
-import { MySkeleton } from '.';
+import { Dots, MySkeleton } from '.';
 
 const THOUSAND_LENGTH = 4;
 const DEFAULT_DECIMAL_PRECISION = 2;
@@ -68,7 +69,9 @@ interface DisplayBalanceProps {
   api?: ApiPromise;
   balance: Balance | Compact<u128 | u64 | INumber> | string | BN | null | undefined;
   decimal?: number;
+  decimalColor?: string;
   decimalPoint?: number;
+  dotStyle?: DotsVariant;
   genesisHash?: string | undefined;
   isShort?: boolean;
   skeletonStyle?: SxProps<Theme>;
@@ -80,9 +83,11 @@ interface DisplayBalanceProps {
   withSi?: boolean;
 }
 
-function DisplayBalance({ api, balance, decimal, decimalPoint, genesisHash, isShort, skeletonStyle, style, token, tokenColor, useAdaptiveDecimalPoint, withCurrency, withSi }: DisplayBalanceProps) {
+function DisplayBalance({ api, balance, decimal, decimalColor, decimalPoint, dotStyle, genesisHash, isShort, skeletonStyle, style, token, tokenColor, useAdaptiveDecimalPoint, withCurrency, withSi }: DisplayBalanceProps) {
   const isDark = useIsDark();
   const theme = useTheme();
+  const { isHideNumbers } = useIsHideNumbers();
+
   const { decimal: nativeDecimal, token: nativeToken } = useChainInfo(genesisHash, true);
 
   const { apiDecimal, apiToken } = useMemo(() => {
@@ -134,9 +139,23 @@ function DisplayBalance({ api, balance, decimal, decimalPoint, genesisHash, isSh
 
   return (
     <Fade in={true} timeout={1000}>
-      <Typography sx={{ ...theme.typography['B-1'], width: 'fit-content', ...style }}>
-        {applyFormat(resolvedDecimalPoint, balance, resolvedDecimal, resolvedToken, withCurrency, withSi, isShort, tokenColor)}
-      </Typography>
+      <div>
+        {isHideNumbers
+          ? (
+            <Dots
+              //@ts-ignore
+              color={style?.color as string || tokenColor}
+              decimalColor={decimalColor}
+              variant={dotStyle}
+            />
+          )
+          : (
+            <Typography sx={{ ...theme.typography['B-1'], width: 'fit-content', ...style }}>
+              {applyFormat(resolvedDecimalPoint, balance, resolvedDecimal, resolvedToken, withCurrency, withSi, isShort, tokenColor)}
+            </Typography>
+          )
+        }
+      </div>
     </Fade>
   );
 }


### PR DESCRIPTION
closes #2105 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added capability to hide numeric balance displays and show an animated indicator instead, providing alternative presentation modes
  * Introduced customization options including multiple animation style variants and configurable color schemes for personalized visual appearance of balance information

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->