### PR TITLE
fix: fix history amount normalization for governance votes and transfers

### DIFF
--- a/packages/extension-polkagate/src/popup/history/hooks/useTransactionProcessing.ts
+++ b/packages/extension-polkagate/src/popup/history/hooks/useTransactionProcessing.ts
@@ -228,19 +228,21 @@ function parseAmount(amount: string | undefined, decimal: number, amountInHuman?
     return undefined;
   }
 
+  const sanitizedAmount = amount.replace(/,/g, '');
+
   if (amountInHuman) {
-    return amount;
+    return sanitizedAmount;
   }
 
   // Subscan balance params are generally returned in machine units.
   // Small raw balances can still have fewer digits than the chain decimals
   // (e.g. 0.01 DOT => 100000000 Planck on a 10-decimal chain), so digit
   // length is not a reliable signal that the value is already human-readable.
-  const isAlreadyInHuman = typeof amount === 'string' && /[.,]/.test(amount);
+  const isAlreadyInHuman = sanitizedAmount.includes('.');
 
   if (isAlreadyInHuman) {
-    return amount;
+    return sanitizedAmount;
   }
 
-  return amountToHuman(amount, decimal);
+  return amountToHuman(sanitizedAmount, decimal);
 }

--- a/packages/extension-polkagate/src/popup/history/hooks/useTransactionProcessing.ts
+++ b/packages/extension-polkagate/src/popup/history/hooks/useTransactionProcessing.ts
@@ -152,7 +152,7 @@ export function useTransactionProcessing({ chain, decimal, extrinsicsTx, receive
     log(`Processing ${extrinsicsTx.transactions.length} extrinsics`);
 
     const processed: TransactionDetail[] = extrinsicsTx.transactions.map((extrinsic: Extrinsics): TransactionDetail => {
-      const { account_display, amount, block_num, block_timestamp, call_module, call_module_function, calls, conviction, delegatee, extrinsic_hash, fee, forAccount, nominators, poolId, refId, success, to, to_account_display, voteType } = extrinsic;
+      const { account_display, amount, amountInHuman, block_num, block_timestamp, call_module, call_module_function, calls, conviction, delegatee, extrinsic_hash, fee, forAccount, nominators, poolId, refId, success, to, to_account_display, voteType } = extrinsic;
       // Determine action type
       const action = getActionType(call_module);
       const subAction = action === 'balances'
@@ -163,7 +163,7 @@ export function useTransactionProcessing({ chain, decimal, extrinsicsTx, receive
 
       return {
         action,
-        amount: parseAmount(amount, decimal),
+        amount: parseAmount(amount, decimal, amountInHuman),
         block: block_num,
         calls,
         chain,
@@ -223,12 +223,20 @@ function getActionType(callModule: string): string {
 }
 
 // Helper: Parse amount considering decimal places
-function parseAmount(amount: string | undefined, decimal: number): string | undefined {
+function parseAmount(amount: string | undefined, decimal: number, amountInHuman?: boolean): string | undefined {
   if (amount === undefined) {
     return undefined;
   }
 
-  const isAlreadyInHuman = typeof amount === 'string' && (amount.includes('.') || amount.length < decimal);
+  if (amountInHuman) {
+    return amount;
+  }
+
+  // Subscan balance params are generally returned in machine units.
+  // Small raw balances can still have fewer digits than the chain decimals
+  // (e.g. 0.01 DOT => 100000000 Planck on a 10-decimal chain), so digit
+  // length is not a reliable signal that the value is already human-readable.
+  const isAlreadyInHuman = typeof amount === 'string' && /[.,]/.test(amount);
 
   if (isAlreadyInHuman) {
     return amount;

--- a/packages/extension-polkagate/src/popup/history/newDesign/HistoryDetail.tsx
+++ b/packages/extension-polkagate/src/popup/history/newDesign/HistoryDetail.tsx
@@ -85,10 +85,11 @@ function HistoryStatus({ action, success }: { action: string, success: boolean }
 
 function HistoryAmount({ amount, decimal, genesisHash, sign, token }: { amount: string, decimal: number, sign?: string, token?: string, genesisHash: string }) {
   const price = useTokenPriceBySymbol(token, genesisHash);
+  const sanitizedAmount = useMemo(() => amount.replace(/,/g, ''), [amount]);
 
-  const totalBalancePrice = useMemo(() => calcPrice(price.price, amountToMachine(amount, decimal) ?? BN_ZERO, decimal ?? 0), [amount, decimal, price.price]);
+  const totalBalancePrice = useMemo(() => calcPrice(price.price, amountToMachine(sanitizedAmount, decimal) ?? BN_ZERO, decimal ?? 0), [decimal, price.price, sanitizedAmount]);
 
-  const [integerPart, decimalPart] = amount.split('.');
+  const [integerPart, decimalPart] = sanitizedAmount.split('.');
 
   const decimalToShow = useMemo(() => {
     if (decimalPart) {

--- a/packages/extension-polkagate/src/util/amount.ts
+++ b/packages/extension-polkagate/src/util/amount.ts
@@ -202,8 +202,8 @@ export function amountToHuman(_amount: string | number | BN | bigint | Compact<u
  * amountToMachine("500", 2) // BN instance representing 50000
  * amountToMachine("0.005", 6) // BN instance representing 5000
  */
-export function amountToMachine(amount: string | undefined, decimal: number | undefined): BN {
-  if (!amount || !decimal) {
+export function amountToMachine(amount: string | undefined, decimal: number | null | undefined): BN {
+  if (!amount || decimal === undefined || decimal === null) {
     return BN_ZERO;
   }
 

--- a/packages/extension-polkagate/src/util/amount.ts
+++ b/packages/extension-polkagate/src/util/amount.ts
@@ -203,12 +203,18 @@ export function amountToHuman(_amount: string | number | BN | bigint | Compact<u
  * amountToMachine("0.005", 6) // BN instance representing 5000
  */
 export function amountToMachine(amount: string | undefined, decimal: number | undefined): BN {
-  if (!amount || !Number(amount) || !decimal) {
+  if (!amount || !decimal) {
     return BN_ZERO;
   }
 
   try {
-    const _amount = sciToDecimal(amount);
+    const normalizedAmount = amount.replace(/,/g, '');
+
+    if (!Number(normalizedAmount)) {
+      return BN_ZERO;
+    }
+
+    const _amount = sciToDecimal(normalizedAmount);
     const dotIndex = _amount.indexOf('.');
     let newAmount = _amount;
 

--- a/packages/extension-polkagate/src/util/api/getTXsHistory.ts
+++ b/packages/extension-polkagate/src/util/api/getTXsHistory.ts
@@ -315,6 +315,7 @@ function getAdditionalInfo(functionName: keyof ParamTypesMapping, txDetail: { da
 
           return {
             amount,
+            amountInHuman: Boolean(transfer?.amount),
             from,
             to
           };

--- a/packages/extension-polkagate/src/util/types.ts
+++ b/packages/extension-polkagate/src/util/types.ts
@@ -265,6 +265,7 @@ export interface Extrinsics {
   },
   refId?: number;
   amount?: string;
+  amountInHuman?: boolean;
   voteType?: number;
   class?: number;
   conviction?: string;

--- a/packages/extension/manifest.json
+++ b/packages/extension/manifest.json
@@ -33,11 +33,11 @@
     }
   ],
   "icons": {
-    "16": "images/icon-16.png",
-    "32": "images/icon-32.png",
-    "48": "images/icon-48.png",
-    "64": "images/icon-64.png",
-    "128": "images/icon-128.png"
+    "16": "images/16b.png",
+    "32": "images/32b.png",
+    "48": "images/48b.png",
+    "64": "images/64b.png",
+    "128": "images/128b.png"
   },
   "web_accessible_resources": [{
     "resources":  ["page.js"],

--- a/packages/extension/manifest.json
+++ b/packages/extension/manifest.json
@@ -33,11 +33,11 @@
     }
   ],
   "icons": {
-    "16": "images/16b.png",
-    "32": "images/32b.png",
-    "48": "images/48b.png",
-    "64": "images/64b.png",
-    "128": "images/128b.png"
+    "16": "images/icon-16.png",
+    "32": "images/icon-32.png",
+    "48": "images/icon-48.png",
+    "64": "images/icon-64.png",
+    "128": "images/icon-128.png"
   },
   "web_accessible_resources": [{
     "resources":  ["page.js"],


### PR DESCRIPTION
closes #2133

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing and display of transaction amounts in history so values render correctly.
  * Better detection of already human-readable amounts to avoid incorrect decimal conversions.
  * Proper handling of comma-separated (thousands-separated) amounts to ensure accurate calculations and price display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->