### PR TITLE
chore: filter chains with no endpoints

### DIFF
--- a/packages/extension-polkagate/src/hooks/useChainSelectionSettings.ts
+++ b/packages/extension-polkagate/src/hooks/useChainSelectionSettings.ts
@@ -7,6 +7,7 @@ import type { DropdownOption } from '../util/types';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import EndpointManager from '../class/endpointManager';
+import { getBuiltInEndpointOptions } from '../hooks/useEndpoints';
 import { getStorage, setStorage } from '../util';
 import { AUTO_MODE_DEFAULT_ENDPOINT, STORAGE_KEY } from '../util/constants';
 import { DEFAULT_SELECTED_CHAINS } from '../util/defaultSelectedChains';
@@ -23,6 +24,10 @@ const endpointManager = new EndpointManager();
 
 export default function useChainSelectionSettings(): UseChainSelectionSettings {
   const allChains = useGenesisHashOptions({});
+  const chainsWithEndpoints = useMemo(
+    () => allChains.filter(({ value }) => getBuiltInEndpointOptions(value as string).length > 0),
+    [allChains]
+  );
 
   const [searchedChain, setSearchedChain] = useState<DropdownOption[]>();
   const [selectedChains, setSelectedChains] = useState<Set<string>>(new Set());
@@ -34,7 +39,7 @@ export default function useChainSelectionSettings(): UseChainSelectionSettings {
     selectedChainsRef.current = selectedChains;
   }, [selectedChains]);
 
-  const sortedChainsToShow = useMemo(() => [...allChains].sort((a, b) => {
+  const sortedChainsToShow = useMemo(() => [...chainsWithEndpoints].sort((a, b) => {
     const aInSet = initialChains.has(a.value as string);
     const bInSet = initialChains.has(b.value as string);
 
@@ -47,7 +52,7 @@ export default function useChainSelectionSettings(): UseChainSelectionSettings {
     }
 
     return 0;
-  }), [allChains, initialChains]);
+  }), [chainsWithEndpoints, initialChains]);
 
   useEffect(() => {
     const defaultSelectedGenesisHashes = DEFAULT_SELECTED_CHAINS.map(({ value }) => value as string);
@@ -138,10 +143,10 @@ export default function useChainSelectionSettings(): UseChainSelectionSettings {
     }
 
     const normalizedKeyword = keyword.trim().toLowerCase();
-    const filtered = allChains.filter(({ text }) => text.toLowerCase().includes(normalizedKeyword));
+    const filtered = chainsWithEndpoints.filter(({ text }) => text.toLowerCase().includes(normalizedKeyword));
 
     setSearchedChain([...filtered]);
-  }, [allChains]);
+  }, [chainsWithEndpoints]);
 
   const chainsToList = useMemo(() => searchedChain ?? sortedChainsToShow, [searchedChain, sortedChainsToShow]);
 

--- a/packages/extension-polkagate/src/hooks/useEndpoints.ts
+++ b/packages/extension-polkagate/src/hooks/useEndpoints.ts
@@ -71,9 +71,10 @@ export function getBuiltInEndpointOptions(genesisHash: string | null | undefined
 export function useEndpoints(genesisHash: string | null | undefined): DropdownOption[] {
   const userAddedEndpoint = useUserAddedEndpoint(genesisHash);
 
-  const endpoints: DropdownOption[] | undefined = useMemo(() => {
-    return getBuiltInEndpointOptions(genesisHash);
-  }, [genesisHash]);
+  const endpoints = useMemo(
+    () => getBuiltInEndpointOptions(genesisHash),
+    [genesisHash]
+  );
 
-  return endpoints ?? userAddedEndpoint ?? [];
+  return endpoints.length ? endpoints : (userAddedEndpoint ?? []);
 }

--- a/packages/extension-polkagate/src/hooks/useEndpoints.ts
+++ b/packages/extension-polkagate/src/hooks/useEndpoints.ts
@@ -15,6 +15,55 @@ import { shouldSkipEndpointOption } from '../util/endpoint';
 const supportedLC = ['polkadot', 'kusama', 'westend']; // chains with supported light client
 const allEndpoints = createWsEndpoints();
 
+export function getBuiltInEndpointOptions(genesisHash: string | null | undefined): DropdownOption[] {
+  if (!genesisHash) {
+    return [];
+  }
+
+  const chainName = chains?.find((o) => o.genesisHash === genesisHash)?.name;
+  const lsChainName = sanitizeChainName(chainName)?.toLowerCase();
+
+  if (!lsChainName) {
+    return [];
+  }
+
+  let endpoints = allEndpoints?.filter(({ info, text, value }) => {
+    if (shouldSkipEndpointOption(value)) {
+      return false;
+    }
+
+    const matchesName =
+      String(info)?.toLowerCase() === lsChainName ||
+      String(text)?.toLowerCase()?.includes(lsChainName);
+
+    return matchesName;
+  });
+
+  if (!endpoints.length) {
+    return [];
+  }
+
+  const { genesisHashRelay, paraId } = endpoints[0];
+  const areAllSame = endpoints.every((e) => e.paraId === paraId && e.genesisHashRelay === genesisHashRelay);
+
+  if (!areAllSame) {
+    endpoints = endpoints.filter(({ info }) => String(info)?.toLowerCase() === lsChainName);
+  }
+
+  let endpointOptions = endpoints.map((endpoint) => ({ text: endpoint.textBy, value: endpoint.value }));
+  const hasLightClientSupport = supportedLC.includes(lsChainName);
+
+  if (!hasLightClientSupport) {
+    endpointOptions = endpointOptions.filter((o) => String(o.value).startsWith('wss'));
+  }
+
+  if (endpointOptions.length > 1) {
+    endpointOptions.unshift(AUTO_MODE);
+  }
+
+  return endpointOptions;
+}
+
 /**
  * @description
  * find endpoints based on chainName and also omit light client which my be add later
@@ -23,58 +72,7 @@ export function useEndpoints(genesisHash: string | null | undefined): DropdownOp
   const userAddedEndpoint = useUserAddedEndpoint(genesisHash);
 
   const endpoints: DropdownOption[] | undefined = useMemo(() => {
-    if (!genesisHash) {
-      return [];
-    }
-
-    const chainName = chains?.find((o) => o.genesisHash === genesisHash)?.name;
-    const lsChainName = sanitizeChainName(chainName)?.toLowerCase();
-
-    if (!lsChainName) {
-      return undefined;
-    }
-
-    let endpoints = allEndpoints?.filter(({ info, text, value }) => {
-      if (shouldSkipEndpointOption(value)) {
-        return false;
-      }
-
-      const matchesName =
-        String(info)?.toLowerCase() === lsChainName ||
-        String(text)?.toLowerCase()?.includes(lsChainName);
-
-      return matchesName;
-    }
-    );
-
-    if (!endpoints.length) {
-      return [];
-    }
-
-    // check if all endpoints belong to same chain
-    const { genesisHashRelay, paraId } = endpoints[0];
-
-    const areAllSame = endpoints.every((e) => e.paraId === paraId && e.genesisHashRelay === genesisHashRelay);
-
-    if (!areAllSame) {
-      // Fallback: just filter the exact comparison
-      endpoints = endpoints?.filter(({ info }) => String(info)?.toLowerCase() === lsChainName);
-    }
-
-    // map to DropdownOption
-    let endpointOptions = endpoints.map((endpoint) => ({ text: endpoint.textBy, value: endpoint.value }));
-
-    const hasLightClientSupport = supportedLC.includes(lsChainName);
-
-    if (!hasLightClientSupport) {
-      endpointOptions = endpointOptions.filter((o) => String(o.value).startsWith('wss'));
-    }
-
-    if (endpointOptions.length > 1) {
-      endpointOptions?.unshift(AUTO_MODE);
-    }
-
-    return endpointOptions;
+    return getBuiltInEndpointOptions(genesisHash);
   }, [genesisHash]);
 
   return endpoints ?? userAddedEndpoint ?? [];

--- a/packages/extension-polkagate/src/hooks/useEndpoints.ts
+++ b/packages/extension-polkagate/src/hooks/useEndpoints.ts
@@ -43,8 +43,14 @@ export function getBuiltInEndpointOptions(genesisHash: string | null | undefined
     return [];
   }
 
-  const { genesisHashRelay, paraId } = endpoints[0];
-  const areAllSame = endpoints.every((e) => e.paraId === paraId && e.genesisHashRelay === genesisHashRelay);
+  const referenceEndpoint =
+    endpoints.find(({ info }) => String(info)?.toLowerCase() === lsChainName) ??
+    endpoints[0];
+  const { genesisHashRelay, paraId } = referenceEndpoint;
+  const areAllSame = endpoints.every((endpoint) =>
+    endpoint.paraId === paraId &&
+    endpoint.genesisHashRelay === genesisHashRelay
+  );
 
   if (!areAllSame) {
     endpoints = endpoints.filter(({ info }) => String(info)?.toLowerCase() === lsChainName);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Chain selection now only shows chains that have available endpoint options, fixing empty/unsupported choices in the UI.

* **Refactor**
  * Endpoint selection behavior improved: built-in endpoint choices are prioritized and auto-mode appears when multiple options exist; user-added endpoints are used only when no built-in options are available.
  * Search and list views now operate on the filtered set of chains with endpoints for more accurate results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->