### PR TITLE
fix: align Subscan requests with free plan limits

### DIFF
--- a/packages/extension-polkagate/src/class/subscanQueue.ts
+++ b/packages/extension-polkagate/src/class/subscanQueue.ts
@@ -1,7 +1,9 @@
 // Copyright 2019-2026 @polkadot/extension-polkagate authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-const MAX_REQUESTS_PER_SECOND = 3;
+import { SUBSCAN_FREE_REQUESTS_PER_SECOND } from '../util/subscanLimits';
+
+const MAX_REQUESTS_PER_SECOND = SUBSCAN_FREE_REQUESTS_PER_SECOND;
 
 interface QueueTask<T> {
   fn: () => Promise<T>;
@@ -58,5 +60,4 @@ class SubscanRequestQueue {
   }
 }
 
-// Subscan free tier: 5 req/sec
 export const subscanQueue = new SubscanRequestQueue(MAX_REQUESTS_PER_SECOND);

--- a/packages/extension-polkagate/src/popup/history/hookUtils/consts.ts
+++ b/packages/extension-polkagate/src/popup/history/hookUtils/consts.ts
@@ -1,8 +1,10 @@
 // Copyright 2019-2026 @polkadot/extension-polkagate authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-export const TRANSFERS_PAGE_SIZE = 50;
-export const EXTRINSICS_PAGE_SIZE = 60;
+import { SUBSCAN_FREE_PAGE_SIZE } from '../../../util/subscanLimits';
+
+export const TRANSFERS_PAGE_SIZE = SUBSCAN_FREE_PAGE_SIZE;
+export const EXTRINSICS_PAGE_SIZE = SUBSCAN_FREE_PAGE_SIZE;
 export const MAX_LOCAL_HISTORY_ITEMS = 20; // Maximum number of items to store locally
 export const DEBUG = false; // Toggle for enabling/disabling logs
 

--- a/packages/extension-polkagate/src/popup/notification/constant.ts
+++ b/packages/extension-polkagate/src/popup/notification/constant.ts
@@ -4,12 +4,13 @@
 import type { NotificationsType } from './types';
 
 import { KUSAMA_GENESIS_HASH, PASEO_GENESIS_HASH, POLKADOT_GENESIS_HASH, WESTEND_GENESIS_HASH } from '../../util/constants';
+import { SUBSCAN_FREE_PAGE_SIZE } from '../../util/subscanLimits';
 
 export const NOTIFICATION_GOVERNANCE_CHAINS = ['kusama', 'polkadot'];
 
 export const RECEIVED_FUNDS_THRESHOLD = 15;
 export const RECEIVED_REWARDS_THRESHOLD = 10;
-export const REFERENDA_COUNT_TO_TRACK_DOT = 50;
+export const REFERENDA_COUNT_TO_TRACK_DOT = SUBSCAN_FREE_PAGE_SIZE;
 export const REFERENDA_COUNT_TO_TRACK_KSM = 10;
 
 export const NOT_READ_BGCOLOR = '#ECF6FE';

--- a/packages/extension-polkagate/src/util/api/getNominationPoolsClaimedRewards.ts
+++ b/packages/extension-polkagate/src/util/api/getNominationPoolsClaimedRewards.ts
@@ -5,6 +5,7 @@ import type { TransferRequest } from '../types';
 
 import { getLink } from '@polkadot/extension-polkagate/src/popup/history/explorer';
 
+import { SUBSCAN_FREE_PAGE_SIZE } from '../subscanLimits';
 import { fetchFromSubscan } from '..';
 
 export function getNominationPoolsClaimedRewards(chainName: string, address: string, pageSize: number): Promise<TransferRequest> {
@@ -25,6 +26,6 @@ export function getNominationPoolsClaimedRewards(chainName: string, address: str
   return fetchFromSubscan(link,
     {
       address,
-      row: pageSize
+      row: Math.min(pageSize, SUBSCAN_FREE_PAGE_SIZE)
     });
 }

--- a/packages/extension-polkagate/src/util/api/getRewardsSlashes.ts
+++ b/packages/extension-polkagate/src/util/api/getRewardsSlashes.ts
@@ -5,6 +5,7 @@ import type { TransferRequest } from '../types';
 
 import { getLink } from '@polkadot/extension-polkagate/src/popup/history/explorer';
 
+import { SUBSCAN_FREE_PAGE_SIZE } from '../subscanLimits';
 import { fetchFromSubscan } from '..';
 
 export default function getRewardsSlashes(chainName: string, address: string, filter: 'unclaimed' | 'claimed'): Promise<TransferRequest> {
@@ -27,6 +28,6 @@ export default function getRewardsSlashes(chainName: string, address: string, fi
     category: 'Reward',
     claimed_filter: filter,
     is_stash: true,
-    row: 100
+    row: SUBSCAN_FREE_PAGE_SIZE
   });
 }

--- a/packages/extension-polkagate/src/util/api/getTransfers.ts
+++ b/packages/extension-polkagate/src/util/api/getTransfers.ts
@@ -7,6 +7,7 @@ import { getLink } from '@polkadot/extension-polkagate/src/popup/history/explore
 import { keyMaker } from '@polkadot/extension-polkagate/src/popup/history/hookUtils/utils';
 
 import getChainName from '../getChainName';
+import { SUBSCAN_FREE_PAGE_SIZE } from '../subscanLimits';
 import { fetchFromSubscan } from '..';
 
 function nullifier(requested: string) {
@@ -51,7 +52,7 @@ export async function getTxTransfers(address: string, genesisHash: string, pageN
     address,
     direction: 'received',
     page: pageNum,
-    row: pageSize
+    row: Math.min(pageSize, SUBSCAN_FREE_PAGE_SIZE)
   });
 
   if (!transferRequest.data.transfers) {

--- a/packages/extension-polkagate/src/util/subscanLimits.ts
+++ b/packages/extension-polkagate/src/util/subscanLimits.ts
@@ -1,0 +1,5 @@
+// Copyright 2019-2026 @polkadot/extension-polkagate authors & contributors
+// SPDX-License-Identifier: Apache-2.0
+
+export const SUBSCAN_FREE_PAGE_SIZE = 25;
+export const SUBSCAN_FREE_REQUESTS_PER_SECOND = 2;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized Subscan API rate limiting and pagination configuration into a dedicated utility module, replacing hardcoded values throughout the codebase with standardized constants for consistent API behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->